### PR TITLE
Updated samples to use esri-leaflet.min.js script reference.

### DIFF
--- a/demo/arcgisbasemap.html
+++ b/demo/arcgisbasemap.html
@@ -7,16 +7,8 @@
     <!--[if lte IE 8]>
         <link rel="stylesheet" href="leaflet.ie.css" />
     <![endif]-->
-
     <script src="../vendor/leaflet/dist/leaflet-src.js"></script>
-    <script src="../vendor/terraformer/dist/browser/terraformer.js"></script>
-    <script src="../vendor/terraformer/dist/browser/rtree.js"></script>
-    <script src="../vendor/terraformer/dist/browser/arcgis.js"></script>
-    <script src="../vendor/arcgis-node/browser/arcgis.js"></script>
-
-    <script src="../src/Layers/TileLayer.js"></script>
-    <script src="../src/Layers/FeatureLayer.js"></script>
-
+    <script src="../dist/esri-leaflet.min.js"></script>
     <style>
       html, body, #map {
         width: 100%;

--- a/demo/arcgisbasemaps.html
+++ b/demo/arcgisbasemaps.html
@@ -7,16 +7,8 @@
     <!--[if lte IE 8]>
         <link rel="stylesheet" href="leaflet.ie.css" />
     <![endif]-->
-
     <script src="../vendor/leaflet/dist/leaflet-src.js"></script>
-    <script src="../vendor/terraformer/dist/browser/terraformer.js"></script>
-    <script src="../vendor/terraformer/dist/browser/rtree.js"></script>
-    <script src="../vendor/terraformer/dist/browser/arcgis.js"></script>
-    <script src="../vendor/arcgis-node/browser/arcgis.js"></script>
-
-    <script src="../src/Layers/TileLayer.js"></script>
-    <script src="../src/Layers/FeatureLayer.js"></script>
-
+    <script src="../dist/esri-leaflet.min.js"></script>
     <style>
       html, body, #map {
         width: 100%;

--- a/demo/arcgisfeatureservice.html
+++ b/demo/arcgisfeatureservice.html
@@ -7,7 +7,6 @@
     <!--[if lte IE 8]>
         <link rel="stylesheet" href="leaflet.ie.css" />
     <![endif]-->
-
     <script src="../vendor/leaflet/dist/leaflet-src.js"></script>
     <script src="../dist/esri-leaflet.min.js"></script>
     <style>

--- a/demo/findplaces.html
+++ b/demo/findplaces.html
@@ -7,16 +7,8 @@
     <!--[if lte IE 8]>
         <link rel="stylesheet" href="leaflet.ie.css" />
     <![endif]-->
-
     <script src="../vendor/leaflet/dist/leaflet-src.js"></script>
-    <script src="../vendor/terraformer/dist/browser/terraformer.js"></script>
-    <script src="../vendor/terraformer/dist/browser/rtree.js"></script>
-    <!--script src="../vendor/terraformer/dist/browser/arcgis.js"></script-->
-    <script src="../vendor/arcgis-node/browser/arcgis.js"></script>
-
-    <script src="../src/Layers/TileLayer.js"></script>
-    <script src="../src/Layers/FeatureLayer.js"></script>
-
+    <script src="../dist/esri-leaflet.min.js"></script>
     <style>
       html, body, #map {
         width: 100%;

--- a/demo/mobile.html
+++ b/demo/mobile.html
@@ -8,16 +8,8 @@
     <!--[if lte IE 8]>
         <link rel="stylesheet" href="leaflet.ie.css" />
     <![endif]-->
-
     <script src="../vendor/leaflet/dist/leaflet-src.js"></script>
-    <script src="../vendor/terraformer/dist/browser/terraformer.js"></script>
-    <script src="../vendor/terraformer/dist/browser/rtree.js"></script>
-    <script src="../vendor/terraformer/dist/browser/arcgis.js"></script>
-    <script src="../vendor/arcgis-node/browser/arcgis.js"></script>
-
-    <script src="../src/Layers/TileLayer.js"></script>
-    <script src="../src/Layers/FeatureLayer.js"></script>
-
+    <script src="../dist/esri-leaflet.min.js"></script>
     <style>
       html, body, #map {
         width: 100%;

--- a/demo/reversegeocode.html
+++ b/demo/reversegeocode.html
@@ -7,16 +7,8 @@
     <!--[if lte IE 8]>
         <link rel="stylesheet" href="leaflet.ie.css" />
     <![endif]-->
-
     <script src="../vendor/leaflet/dist/leaflet-src.js"></script>
-    <script src="../vendor/terraformer/dist/browser/terraformer.js"></script>
-    <script src="../vendor/terraformer/dist/browser/rtree.js"></script>
-    <!--script src="../vendor/terraformer/dist/browser/arcgis.js"></script-->
-    <script src="../vendor/arcgis-node/browser/arcgis.js"></script>
-
-    <script src="../src/Layers/TileLayer.js"></script>
-    <script src="../src/Layers/FeatureLayer.js"></script>
-
+    <script src="../dist/esri-leaflet.min.js"></script>
     <style>
       html, body, #map {
         width: 100%;


### PR DESCRIPTION
- reversegeocoding won't work until export function is fixed in arcgis-node

`````` arcgis.js

function ArcGIS (options) {
  this.options = options;

  this.geocode = geocode;
  this.reverse = reverse;  // the fix 
  this.FeatureService = FeatureService;
  this.authenticate   = authenticate;
  this.requestHandler = { get: get, post: post };

  var self = this;

  this.geocode.Batch = function (optionalToken) {
    optionalToken = optionalToken || self.token;

    var batch = new geocode.Batch(optionalToken);
    batch.requestHandler = request;

    return batch;
  };
}```
``````
