### PR TITLE
fix errors in IE 8

### DIFF
--- a/src/Layers/BasemapLayer.js
+++ b/src/Layers/BasemapLayer.js
@@ -168,20 +168,20 @@ L.esri.BasemapLayer = L.TileLayer.extend({
     }
   },
   getAttributionSpan:function(){
-    return this._map._container.getElementsByClassName("esri-attributions")[0];
+    return this._map._container.querySelectorAll('.esri-attributions')[0];
   },
   updateMapAttribution: function(){
-    var newAttributions = [];
+    var newAttributions = '';
     for (var i = 0; i < this.attributionBoundingBoxes.length; i++) {
       var attr = this.attributionBoundingBoxes[i];
       if(this.bounds.intersects(attr.bounds) && this.zoom >= attr.minZoom && this.zoom <= attr.maxZoom) {
         var attribution = this.attributionBoundingBoxes[i].attribution;
         if(newAttributions.indexOf(attribution) === -1){
-          newAttributions.push(attribution);
+          newAttributions += ', ' + attribution;
         }
       }
     }
-    this.getAttributionSpan().innerHTML = newAttributions.join(", ");
+    this.getAttributionSpan().innerHTML = newAttributions;
     this.resizeAttribution();
   }
 });


### PR DESCRIPTION
This pull request fixes the following issues in IE 8:

-> IE 8 does not have .getElementsByClassName(). This has been replaced with .querySelectorAll(), which is available in IE 8+. This will not work in IE 7, but IE 7 has a whole other host of problems.

-> IE 8 does not have Array#indexOf. It does, however have String#indexOf. Instead of Array and Array#join, this changes it to a String and uses the += String concatenation operator. As a side benefit, this is faster in tests posted on the web.

http://www.sitepoint.com/javascript-fast-string-concatenation/
http://jsperf.com/string-concatenation/28
http://jsperf.com/concat-vs-plus-vs-join
