### PR TITLE
added dynamicreprojected sample

### DIFF
--- a/dynamicreprojected.html
+++ b/dynamicreprojected.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Reprojected Dynamic Map Services</title>
+      <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <link rel="stylesheet" href="leaflet/leaflet.css" />
+    <link rel="stylesheet" href="demo.css" />
+    <!--[if lte IE 8]><link rel="stylesheet" href="leaflet/leaflet.ie.css" /><![endif]-->
+    <script src="leaflet/leaflet-src.js"></script>
+    <script src="esri-leaflet.min.js"></script>
+    <script src="demo.js"></script>
+  </head>
+  <body>
+    <div id="map"> </div>
+    <div class="demo-controls">
+      <h1 class="title contract" id="title" onclick="showControls();">Reprojected Dynamic Map Service</h1>
+      <div class="control-container" id="controlContainer">
+        <p>Dynamic map services published in projections other than Web Mercator, like <a href="http://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer">this one</a>, are reprojected on the fly.</p>
+      </div>
+    </div>
+    <a href="https://github.com/esri/esri-leaflet"><img style="z-index: 1000; position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" alt="Fork me on GitHub"></a>
+    <script>	  
+      //Initialize the map to ceneter on Western Europe
+      var map = L.map('map').setView([49.39609, 5.76991], 4);
+	  
+      //Add Gray Basemap
+      L.esri.basemapLayer("Gray").addTo(map);
+	  
+	  dynLayer = L.esri.dynamicMapLayer("http://sampleserver6.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer");
+	  
+      map.addLayer(dynLayer);	  
+     </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
       <ul>
         <li><a href="dynamicmapservice.html">Map Service Identify</a></li>
         <li><a href="dynamicmapserviceidentify.html">Map Service Filter</a></li>
+		<li><a href="dynamicreprojected.html">Dynamic Map Service Reprojected on the Fly</a></li>
       </ul>
       </ul>
       <h3>ArcGIS Demographic Map Services</h3>


### PR DESCRIPTION
added sample showing that Dynamic Map Services will be reprojected on
the fly if they were published in a projection other than Web Mercator.
