### PR TITLE
bump version to 0.0.1-rc.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "esri-leaflet",
-  "version": "0.0.1-rc.1",
+  "version": "0.0.1-rc.2",
   "main": "dist/esri-leaflet.js",
   "ignore": [
     "**/.*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Esri-Leaflet",
-  "version": "0.0.1",
+  "version": "0.0.1-rc.2",
   "description": "ArcGIS Plugins for Leaflet",
   "main": "src/esri-leaflet.js",
   "devDependencies": {


### PR DESCRIPTION
Files in [latest release](https://github.com/Esri/esri-leaflet/releases/tag/v0.0.1-rc.2) are distributed with the wrong version in the banner.

I was unable to build the dist as `grunt build` is failing.

```
Running "karma:coverage" (karma) task
INFO [karma]: Karma v0.10.4 server started at http://localhost:9876/
INFO [launcher]: Starting browser PhantomJS
WARN [watcher]: Pattern "/Users/nate/dev/esri-leaflet/vendor/Leaflet/dist/leaflet-src.js" does not match any file.
INFO [PhantomJS 1.9.2 (Mac OS X)]: Connected on socket Lw2V2K9NpEKqROqMGsP8
PhantomJS 1.9.2 (Mac OS X) ERROR
  ReferenceError: Can't find variable: L
  at /Users/nate/dev/esri-leaflet/src/esri-leaflet.js:6
PhantomJS 1.9.2 (Mac OS X) ERROR
  ReferenceError: Can't find variable: L
  at /Users/nate/dev/esri-leaflet/src/Layers/BasemapLayer.js:6
PhantomJS 1.9.2 (Mac OS X) ERROR
  ReferenceError: Can't find variable: L
  at /Users/nate/dev/esri-leaflet/src/Layers/ClusteredFeatureLayer.js:6
PhantomJS 1.9.2 (Mac OS X) ERROR
  ReferenceError: Can't find variable: L
  at /Users/nate/dev/esri-leaflet/src/Layers/DynamicMapLayer.js:6
PhantomJS 1.9.2 (Mac OS X) ERROR
  ReferenceError: Can't find variable: L
  at /Users/nate/dev/esri-leaflet/src/Layers/FeatureLayer.js:6
PhantomJS 1.9.2 (Mac OS X) ERROR
  ReferenceError: Can't find variable: L
  at /Users/nate/dev/esri-leaflet/src/Layers/TiledMapLayer.js:6
PhantomJS 1.9.2 (Mac OS X): Executed 0 of 0 ERROR (0.049 secs / 0 secs)
Warning: Task "karma:coverage" failed. Use --force to continue.
```
