### PR TITLE
Fixed misspelling of `moveend` map event.

### DIFF
--- a/src/Layers/FeatureLayer.js
+++ b/src/Layers/FeatureLayer.js
@@ -44,11 +44,11 @@
     },
     onAdd: function(map){
       L.LayerGroup.prototype.onAdd.call(this, map);
-      map.on("zoomend resize moveEnd", this._update, this);
+      map.on("zoomend resize moveend", this._update, this);
       this._initializeFeatureGrid(map);
     },
     onRemove: function(map){
-      map.off("zoomend resize moveEnd", this._update, this);
+      map.off("zoomend resize moveend", this._update, this);
       L.LayerGroup.prototype.onRemove.call(this, map);
       this._destroyFeatureGrid(map);
     },


### PR DESCRIPTION
This was preventing hidden features from reappearing when you panned to make them visible in my map.
