### PR TITLE
When removing a DynamicMapLayer that is outside the min/max zoom levels,...

### DIFF
--- a/src/Layers/DynamicMapLayer.js
+++ b/src/Layers/DynamicMapLayer.js
@@ -119,7 +119,7 @@ L.esri.DynamicMapLayer = L.Class.extend({
   },
 
   onRemove: function (map) {
-    this._map.removeLayer(this._currentImage);
+    if (this._currentImage) { this._map.removeLayer(this._currentImage); }
     map.off("moveend", this._moveHandler, this);
   },
 


### PR DESCRIPTION
A simple fix for a DynamicMapLayer that hasn't drawn an image due to the map zoom level.  When using a layer control and you uncheck the layer, it will throw an error because _currentImage is null.
