### PR TITLE
added a 'where' clase to FeatureLayer's options

### DIFF
--- a/src/Layers/FeatureLayer.js
+++ b/src/Layers/FeatureLayer.js
@@ -42,6 +42,10 @@
         requestOptions.token = this.options.token;
       }
 
+      if(this.options.where){
+        requestOptions.where = this.options.where;
+      }
+
       L.esri.get(this.url, requestOptions, function(response){
         this.fire("metadata", { metadata: response });
       }, this);

--- a/src/esri-leaflet.js
+++ b/src/esri-leaflet.js
@@ -212,6 +212,10 @@ L.esri.Mixins.featureGrid = {
       requestOptions.token = this.options.token;
     }
 
+    if(this.options.where){
+      requestOptions.where = this.options.where;
+    }    
+
     L.esri.get(this.url+"query", requestOptions, function(response){
       //deincriment the request counter
       this._activeRequests--;


### PR DESCRIPTION
The FeatureLayer class doesn't provide a way to pass options to the JSON request, other than the ArcGIS Server token. I've added a "where" clause, as it's the only other option that makes sense in the context of a persistent layer.
