### PR TITLE
Added delayMetadataLoad option to DynamicMapLayer.  

### DIFF
--- a/src/EsriLeaflet.js
+++ b/src/EsriLeaflet.js
@@ -277,6 +277,7 @@ L.esri.Mixins.identifiableLayer = {
 };
 
 L.esri.Mixins.metadata = {
+  _metadataLoaded: false,
   _getMetadata: function(){
    var requestOptions = {};
 
@@ -322,6 +323,7 @@ L.esri.Mixins.metadata = {
           }
         }
 
+        this._metadataLoaded = true;
         this.fire("metadata", payload);
       }
 

--- a/src/Layers/DynamicMapLayer.js
+++ b/src/Layers/DynamicMapLayer.js
@@ -29,7 +29,8 @@ L.esri.DynamicMapLayer = L.Class.extend({
 
   options: {
     opacity: 1,
-    position: 'front'
+    position: 'front',
+    delayMetadataLoad: false
   },
 
   _defaultLayerParams: {
@@ -57,7 +58,7 @@ L.esri.DynamicMapLayer = L.Class.extend({
 
     L.Util.setOptions(this, options);
 
-    this._getMetadata();
+    if (!this.options.delayMetadataLoad) { this._getMetadata(); }
 
     if(!this._layerParams.transparent) {
       this.options.opacity = 1;
@@ -65,6 +66,8 @@ L.esri.DynamicMapLayer = L.Class.extend({
   },
 
   onAdd: function (map) {
+    if (!this._metadataLoaded) { this._getMetadata(); }
+
     this._map = map;
     this._moveHandler = L.esri.Util.debounce(this._update, 150, this);
 


### PR DESCRIPTION
This causes the layer to load it's metadata on layer add rather than initialization.  When you have a layer that is controlled by a layer control, it's not added to the map on page load.  Delaying the metadata load reduces traffic for unused layers until they are added to the map.

I'm using some third party services and I don't want to bombard them with metadata requests.  Our initial map has a lot of traffic, but the third party layers are rarely used.  Examples using a DynamicMapLayer seem unaffected by the change.
