### PR TITLE
Fix default 'layers' param values for REST API Identify request

### DIFF
--- a/src/EsriLeaflet.js
+++ b/src/EsriLeaflet.js
@@ -244,7 +244,7 @@ L.esri.Mixins.identifiableLayer = {
     };
 
     if(this.options.layers) {
-      defaults.layers = this.options.layers;
+      defaults.layers = "visible:" + this.options.layers;
     }
 
     var params;


### PR DESCRIPTION
There may be a better way to implement this, but per the REST API spec here: http://help.arcgis.com/en/arcgisserver/10.0/apis/rest/identify.html, when you pass a comma separated list of layers to operate on for the Identify function, it needs to be pre-pended with 'visible:' in order to only operate on those layers.  Otherwise it will default to 'top' for keyword.  According to the spec, that should mean that it returns features from the 'top' layer as well as whichever layers are specified in the list, in practice it seems to only return features from 'top' layer.

Since the purpose of using the Leaflet Layer's 'options.layers' value is to filter only by those layers for Identify, it makes sense to pass the 'visible' keyword to get the expected result.
