### PR TITLE
grab the appropriate url before calling identify

### DIFF
--- a/src/EsriLeaflet.js
+++ b/src/EsriLeaflet.js
@@ -260,7 +260,7 @@ L.esri.Mixins.identifiableLayer = {
       params = L.Util.extend(defaults, options);
     }
 
-    L.esri.get(this.serviceUrl + '/identify', params, callback);
+    L.esri.get(this.url + '/identify', params, callback);
   },
   parseLayerDefs: function (layerDefs) {
     if (layerDefs instanceof Array) {


### PR DESCRIPTION
update the way we dig out the service url when constructing our identify
request.
