### PR TITLE
Include newer karma-requirejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "karma-firefox-launcher": "~0.1.0",
     "karma-html2js-preprocessor": "~0.1.0",
     "karma-jasmine": "~0.1.0",
-    "karma-requirejs": "~0.1.0",
+    "karma-requirejs": "~0.2.1",
     "karma-coffee-preprocessor": "~0.1.0",
     "karma-phantomjs-launcher": "~0.1.0",
     "karma": "~0.10.1",


### PR DESCRIPTION
On my machine, running `npm install` resulted in this dependency not being satisfied:
`npm ERR! peerinvalid The package karma-requirejs does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer karma@0.10.10 wants karma-requirejs@~0.2.0`

Bumping the `karma-requirejs` version was sufficient to fix things.
