### PR TITLE
Added z-index to map element and demo controls

### DIFF
--- a/examples/demo.css
+++ b/examples/demo.css
@@ -5,6 +5,9 @@ html, body, #map {
   font-family: "Helvetica Neue", Arial, Helvetica, sans-serif;
   font-size: 16px;
 }
+#map {
+  z-index: 1;
+}
 .leaflet-popup-content-wrapper {
   -webkit-border-radius: 4px;
   border-radius: 4px;
@@ -124,4 +127,5 @@ input[type=checkbox]{
   border-radius: 4px;
   background: white;
   box-shadow: 0 3px 14px rgba(0,0,0,0.4);
+  z-index: 2;
 }


### PR DESCRIPTION
Adding z-index values in demo.css for the map element and demo controls seems to fix an issue in IE 9 where the demo controls disappear after the map tiles load. Tested in IE 9 and Chrome.
