### PR TITLE
Fix layerDefs doc snippet with numeric keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Option | Type | Default | Description
 `bboxSR` | `Integer` | `4326` | Spatial reference of the bounding box to generate the image with. If you don't know what this is don't change it.
 `imageSR` | | `3857` | Spatial reference of the output image. If you don't know what this is don't change it.
 `layers` | `String` or `Array` | `''` | An array of Layer IDs like `[3,4,5]` to show from the service or a string in the format like `[show | hide | include | exclude]:layerId1,layerId2` like `exclude:3,5`.
-`layerDefs` | `String` `Object` | `''` | A string representing a query to run against the service before the image is rendered. This can be a string like `"STATE_NAME='Kansas' and POP2007>25000"` or an object mapping different queries to specific layers `{5:"STATE_NAME='Kansas'", 4:"STATE_NAME='Kansas'}`.
+`layerDefs` | `String` `Object` | `''` | A string representing a query to run against the service before the image is rendered. This can be a string like `"STATE_NAME='Kansas' and POP2007>25000"` or an object mapping different queries to specific layers `{'5':"STATE_NAME='Kansas'", '4':"STATE_NAME='Kansas'}`.
 `opacity` | `Integer` | `1` | Opacity of the layer. Should be a value between 0 and 1.
 `position` | `String` | '"front"` | position of the layer relative to other overlays
 `token` | `String` | `null` | If you pass a token in your options it will included in all requests to the service. See [working with authenticated services](#working-with-authenticated-services) for more information.


### PR DESCRIPTION
Fix the documentation for layerDefs.  Can't use numeric keys for javascript 
objects, string representation of layerId works fine.
