### PR TITLE
Docs for beta 6

### DIFF
--- a/site/source/pages/api-reference/events.md
+++ b/site/source/pages/api-reference/events.md
@@ -31,6 +31,31 @@ layer.on('load', function(e){
 layer.addTo(map);
 ```
 
+### Feature Create
+
+`createfeature` is fired when a feature from the Feature Layer is loaded for the first time.
+
+| Data | Value | Description |
+| --- | --- | --- |
+| `feature` | [`GeoJSON Feature`](http://geojson.org/geojson-spec.html#feature-objects) | GeoJSON respresentation of the feature that was created. |
+
+### Feature Remove
+
+`removefeature` is fired when a feature is removed from the map, either as the result of a filter operation or because it was deleted from the service.
+
+| Data | Value | Description |
+| --- | --- | --- |
+| `feature` | [`GeoJSON Feature`](http://geojson.org/geojson-spec.html#feature-objects) | GeoJSON respresentation of the feature that was created. |
+| `permanent` | `Boolean` | `true` if the feature was permanently deleted from the service or `false` if the feature was removed as the result of a filter operation.
+
+### Feature Add
+
+`addfeature` is fired when a feature that has already been created is added to the map again, usually the result of a filtering operation.
+
+| Data | Value | Description |
+| --- | --- | --- |
+| `feature` | [`GeoJSON Feature`](http://geojson.org/geojson-spec.html#feature-objects) | GeoJSON respresentation of the feature that was added. |
+
 ### Request Event
 
 | Data | Value | Description |

--- a/site/source/pages/api-reference/layers/clustered-feature-layer.md
+++ b/site/source/pages/api-reference/layers/clustered-feature-layer.md
@@ -118,6 +118,9 @@ More information about Feature Layers can be found in the [`L.esri.Layers.Featur
 | --- | --- | --- |
 | `loading` | [<`LoadingEvent`>]({{assets}}api-reference/events.html#loading-event) | Fires when new features start loading. |
 | `load` | [<`LoadEvent`>]({{assets}}api-reference/events.html#load-event) | Fires when all features in the current bounds of the map have loaded. |
+| `createfeature` | [<`CreateFeatureEvent`>]({{assets}}api-reference/events.html#feature-create) | Fired when a feature from the Feature Layer is loaded for the first time. |
+| `removefeature` | [<`RemoveFeatureEvent`>]({{assets}}api-reference/events.html#feature-remove) | Fired when a feature on the layer is removed from the map. |
+| `addfeature` | [<`AddFeatureEvent`>]({{assets}}api-reference/events.html#feature-add) | Fired when a previously removed feature is added back to the map. |
 
 `L.esri.Layer.FeatureLayer` also fires all  [`L.esri.Service.FeatureLayer`]({{assets}}api-reference/services/feature-layer.html) events.
 

--- a/site/source/pages/api-reference/layers/dynamic-map-layer.md
+++ b/site/source/pages/api-reference/layers/dynamic-map-layer.md
@@ -5,7 +5,7 @@ layout: documentation.hbs
 
 # {{page.data.title}}
 
-Inherits from [`L.esri.Layers.RasterLayer`]({{assets}}api-reference/layers/raster-layer.html)
+<!-- Inherits from [`L.esri.Layers.RasterLayer`]({{assets}}api-reference/layers/raster-layer.html) -->
 
 Render and visualize Map Services from ArcGIS Online and ArcGIS Server. L.esri.Layers.DynamicMapLayer also supports custom popups and identification of features.
 
@@ -172,6 +172,19 @@ Option | Type | Default | Description
             .run(function(error, featureCollection){
               console.log(featureCollection);
             });</code></pre>
+            </td>
+        </tr>
+        <tr>
+            <td><code>query()</code></td>
+            <td><code>this</code></td>
+            <td>
+                Returns a new <a href="{{assets}}api-reference/tasks/query.html"><code>L.esri.Tasks.Query</code></a> object that can be used to query this service.
+<pre class="js"><code>mapService.query()
+        .layer(0)
+        .within(latlngbounds)
+        .run(function(error, featureCollection, response){
+          console.log(featureCollection);
+        });</code></pre>
             </td>
         </tr>
     </tbody>

--- a/site/source/pages/api-reference/layers/feature-layer.md
+++ b/site/source/pages/api-reference/layers/feature-layer.md
@@ -132,6 +132,9 @@ You can create a new empty feature service witha  single layer on the [ArcGIS fo
 | --- | --- | --- |
 | `loading` | [<`LoadingEvent`>]({{assets}}api-reference/events.html#loading-event) | Fires when new features start loading. |
 | `load` | [<`LoadEvent`>]({{assets}}api-reference/events.html#load-event) | Fires when all features in the current bounds of the map have loaded. |
+| `createfeature` | [<`CreateFeatureEvent`>]({{assets}}api-reference/events.html#feature-create) | Fired when a feature from the Feature Layer is loaded for the first time. |
+| `removefeature` | [<`RemoveFeatureEvent`>]({{assets}}api-reference/events.html#feature-remove) | Fired when a feature on the layer is removed from the map. |
+| `addfeature` | [<`AddFeatureEvent`>]({{assets}}api-reference/events.html#feature-add) | Fired when a previously removed feature is added back to the map. |
 
 `L.esri.Layer.FeatureLayer` also fires all  [`L.esri.Service.FeatureLayer`]({{assets}}api-reference/services/feature-layer.html) events.
 

--- a/site/source/pages/api-reference/layers/image-map-layer.md
+++ b/site/source/pages/api-reference/layers/image-map-layer.md
@@ -5,7 +5,7 @@ layout: documentation.hbs
 
 # {{page.data.title}}
 
-Inherits from [`L.esri.Layers.RasterLayer`]({{assets}}api-reference/layers/raster-layer.html)
+<!-- Inherits from [`L.esri.Layers.RasterLayer`]({{assets}}api-reference/layers/raster-layer.html) -->
 
 Render and visualize Image Services from ArcGIS Online and ArcGIS Server.
 
@@ -105,6 +105,11 @@ Option | Type | Default | Description
             <td>The pixel type, also known as data type, pertains to the type of values stored in the raster, such as signed integer, unsigned integer, or floating point. Possible values: `C128`, `C64`, `F32`, `F64`, `S16`, `S32`, `S8`, `U1`, `U16`, `U2`, `U32`, `U4`, `U8`, `UNKNOWN`.</td>
         </tr>
         <tr>
+            <td><code>authenticate({{{param 'String' 'token'}}})</code></td>
+            <td><code>this</code></td>
+            <td>Authenticates this service with a new token and runs any pending requests that required a token.</td>
+        </tr>
+        <tr>
             <td><code>metadata({{{param 'Function' 'callback'}}}, {{{param 'Object' 'context'}}})</code></td>
             <td><code>this</code></td>
             <td>
@@ -112,6 +117,18 @@ Option | Type | Default | Description
 <pre class="js"><code>featureLayer.metadata(function(error, metadata){
   console.log(metadata);
 });</code></pre>
+            </td>
+        </tr>
+        <tr>
+            <td><code>query()</code></td>
+            <td><code>this</code></td>
+            <td>
+                Returns a new <a href="{{assets}}api-reference/tasks/query.html"><code>L.esri.Tasks.Query</code></a> object that can be used to query this service.
+<pre class="js"><code>imageService.query()
+            .within(latlngbounds)
+            .run(function(error, featureCollection, response){
+              console.log(featureCollection);
+            });</code></pre>
             </td>
         </tr>
     </tbody>

--- a/site/source/pages/api-reference/services/feature-layer.md
+++ b/site/source/pages/api-reference/services/feature-layer.md
@@ -53,7 +53,7 @@ Inherits from [`L.esri.Service`]({{assets}}api-reference/services/service.html)
 <pre class="js"><code>featureLayer.query()
             .within(latlngbounds)
             .where("Direction = 'WEST'")
-            .run(function(error, featureCollection){
+            .run(function(error, featureCollection, response){
               console.log(featureCollection);
             });</code></pre>
             </td>

--- a/site/source/pages/api-reference/services/image-service.md
+++ b/site/source/pages/api-reference/services/image-service.md
@@ -36,7 +36,29 @@ Inherits from [`L.esri.Service`]({{assets}}api-reference/services/service.html)
 
 ### Methods
 
-No methods.
+<table>
+    <thead>
+        <tr>
+            <th>Method</th>
+            <th>Returns</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>query()</code></td>
+            <td><code>this</code></td>
+            <td>
+                Returns a new <a href="{{assets}}api-reference/tasks/query.html"><code>L.esri.Tasks.Query</code></a> object that can be used to query this service.
+<pre class="js"><code>imageService.query()
+            .within(latlngbounds)
+            .run(function(error, featureCollection, response){
+              console.log(featureCollection);
+            });</code></pre>
+            </td>
+        </tr>
+    </tbody>
+</table>
 
 ### Example
 

--- a/site/source/pages/api-reference/services/map-service.md
+++ b/site/source/pages/api-reference/services/map-service.md
@@ -36,10 +36,58 @@ Inherits from [`L.esri.Service`]({{assets}}api-reference/services/service.html)
 
 ### Methods
 
-| Method | Returns | Description |
-| --- | --- | --- |
-| `identify()` | `this` | Returns a new [`L.esri.Tasks.Identify()`]({{assets}}api-reference/tasks/query.html) object bound to this service. |
-| `find()` | `this` | Returns a new [`L.esri.Tasks.Find()`]({{assets}}api-reference/tasks/find.html) object bound to this service. |
+<table>
+    <thead>
+        <tr>
+            <th>Method</th>
+            <th>Returns</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>query()</code></td>
+            <td><code>this</code></td>
+            <td>
+                Returns a new <a href="{{assets}}api-reference/tasks/query.html"><code>L.esri.Tasks.Query</code></a> object that can be used to query this service.
+<pre class="js"><code>mapService.query()
+        .layer(0)
+        .within(latlngbounds)
+        .run(function(error, featureCollection, response){
+          console.log(featureCollection);
+        });</code></pre>
+            </td>
+        </tr>
+        <tr>
+            <td><code>identify()</code></td>
+            <td><code>this</code></td>
+            <td>
+                Returns a new <a href="{{assets}}api-reference/tasks/identify.html"><code>L.esri.Tasks.Identify</code></a> object that can be used to identify features contained within this service.
+<pre class="js"><code>mapService.identify()
+        .on(map)
+        .at(latlng)
+        .run(function(error, featureCollection, response){
+            console.log(featureCollection)
+        });</code></pre>
+            </td>
+        </tr>
+        <tr>
+            <td><code>find()</code></td>
+            <td><code>this</code></td>
+            <td>
+                Returns a new <a href="{{assets}}api-reference/tasks/find.html"><code>L.esri.Tasks.Find</code></a> object that can be used to find features by text.
+<pre class="js"><code>mapService.find()
+        .layers('18')
+        .text('Colorado')
+        .fields('name')
+        .run(function(error, featureCollection, response){
+            console.log(featureCollection)
+        });</code></pre>
+            </td>
+        </tr>
+
+    </tbody>
+</table>
 
 ### Example
 

--- a/site/source/pages/api-reference/tasks/query.md
+++ b/site/source/pages/api-reference/tasks/query.md
@@ -5,7 +5,9 @@ layout: documentation.hbs
 
 # {{page.data.title}}
 
-`L.esri.Tasks.Query` is an abstraction for the query API that exists on Feature Layers and Map Services. It provides a chainable API for building request parameters and executing queries.
+`L.esri.Tasks.Query` is an abstraction for the query API that exists on Feature Layers Map Services and Image Services. It provides a chainable API for building request parameters and executing queries.
+
+**Note** Depending on the type of service you are querying (Feature Layer, Map Service, Image Service) and the version of ArcGIS Server that hosts the service some of these options my not be available.
 
 ### Constructor
 
@@ -46,7 +48,7 @@ layout: documentation.hbs
         <tr>
             <td><code>nearby({{{param 'LatLng' 'latlng' 'http://leafletjs.com/reference.html#latlng'}}}, {{{param 'Integer' 'distance'}}})</code></td>
             <td><code>this</code></td>
-            <td>Queries features a given distance in meters around a <a href="http://leafletjs.com/reference.html#latlng">LatLng</a>.</td>
+            <td>Queries features a given distance in meters around a <a href="http://leafletjs.com/reference.html#latlng">LatLng</a>. <small>Only available for Feature Layers hosted on ArcGIS Online.</small></td>
         </tr>
         <tr>
             <td><code>where({{{param 'String' 'where'}}})</code></td>
@@ -56,17 +58,17 @@ layout: documentation.hbs
         <tr>
             <td><code>offset({{{param 'Integer' 'offset'}}})</code></td>
             <td><code>this</code></td>
-            <td>Define the offset of the results, when combined with `limit` can be used for paging. Available only for Feature Services hosted on ArcGIS Online.</td>
+            <td>Define the offset of the results, when combined with `limit` can be used for paging. <small>Only available for Feature Layers hosted on ArcGIS Online.</small></td>
         </tr>
         <tr>
             <td><code>limit({{{param 'Integer' 'limit'}}})</code></td>
             <td><code>this</code></td>
-            <td>Limit the number of results returned by this query, when combined with `offset` can be used for paging. Available only for Feature Services hosted on ArcGIS Online.</td>
+            <td>Limit the number of results returned by this query, when combined with `offset` can be used for paging. <small>Only available for Feature Layers hosted on ArcGIS Online.</small></td>
         </tr>
         <tr>
             <td><code>between({{{param 'Date' 'from'}}}, {{{param 'Date' 'to'}}})</code></td>
             <td><code>this</code></td>
-            <td>Queries features within a given time range.</td>
+            <td>Queries features within a given time range. <small>Only available for Layers/Services with `timeInfo` in their metadata.</small></td>
         </tr>
         <tr>
             <td><code>fields({{{param 'Array' 'fields'}}} or {{{param 'String' 'fields'}}})</code></td>
@@ -104,6 +106,16 @@ layout: documentation.hbs
             <td>Adds a token to this request if the service requires authentication. Will be added automatically if used with a service.</td>
         </tr>
         <tr>
+            <td><code>layer({{{param 'String or Integer' 'layer'}}})</code></td>
+            <td><code>this</code></td>
+            <td>Used to select which layer inside a Map Service to perform the query on. <small>Only available for Map Services.</small></td>
+        </tr>
+        <tr>
+            <td><code>pixelSize({{{param 'Point' 'point' 'http://leafletjs.com/reference.html#point'}}})</code></td>
+            <td><code>this</code></td>
+            <td>Override the default pixelSize when querying an Image Service. <small>Only available for Image Services.</small></td>
+        </tr>
+        <tr>
             <td><code>run({{{param 'Function' 'callback'}}}, {{{param 'Object' 'context'}}})</code></td>
             <td><code>this</code></td>
             <td>Exectues the query request with the current parameters, features will be passed to <code>callback</code> as a <a href="http://geojson.org/geojson-spec.html#feature-collection-objects">GeoJSON FeatureCollection</a>. Accepts an optional function context.</td>
@@ -121,7 +133,7 @@ layout: documentation.hbs
         <tr>
             <td><code>bounds({{{param 'Function' 'callback'}}}, {{{param 'Object' 'context'}}})</code></td>
             <td><code>this</code></td>
-            <td>Exectues the query request with the current parameters, passing only the <a href="http://leafletjs.com/reference.html#latlngbounds"><code>LatLngBounds</code></a> of all features the query to callback<code>callback</code>. Accepts an optional function context.</td>
+            <td>Exectues the query request with the current parameters, passing only the <a href="http://leafletjs.com/reference.html#latlngbounds"><code>LatLngBounds</code></a> of all features the query to callback<code>callback</code>. Accepts an optional function context. <small>Only available for Feature Layers hosted on ArcGIS Online.</small></td>
         </tr>
     </tbody>
 </table>

--- a/site/source/partials/sidebar-documentation.hbs
+++ b/site/source/partials/sidebar-documentation.hbs
@@ -11,7 +11,7 @@
     <a href="{{assets}}api-reference/layers/tiled-map-layer.html">TiledMapLayer</a>
     <a href="{{assets}}api-reference/layers/dynamic-map-layer.html">DynamicMapLayer</a>
     <a href="{{assets}}api-reference/layers/image-map-layer.html">ImageMapLayer</a>
-    <a href="{{assets}}api-reference/layers/raster-layer.html">RasterLayer</a>
+    <!-- <a href="{{assets}}api-reference/layers/raster-layer.html">RasterLayer</a> -->
     <a href="{{assets}}api-reference/layers/feature-layer.html">FeatureLayer</a>
     <a href="{{assets}}api-reference/layers/clustered-feature-layer.html">ClusteredFeatureLayer</a>
     <a href="{{assets}}api-reference/layers/heatmap-feature-layer.html">HeatmapFeatureLayer</a>


### PR DESCRIPTION
Adds the following docs for beta 6...
- `createfeature`, `addfeature` and `removefeature` events.
- `query()` on `MapService` and `ImageService`
- New methods on `L.esri.Tasks.Query` for supporting `MapService` and `ImageService`

@robertd I also have commented out the link to `L.esri.RasterLayer` in the sidebar. I did this because I don't want base classes like `L.esri.RasterLayer` and `L.esri.FeatureManager` quite yet. These are pretty key parts of the ecosystem but I want to document them as "Base Classes" and give detailed examples of how to extend them to create your own visualization. Users might be confused about using `RasterLayer` vs `ImageMapLayer` vs `DynamicMapLayer` and I want to make sure we dont run into that.
