### PR TITLE
added support for setting mosaic rule on export image

### DIFF
--- a/site/source/pages/api-reference/layers/image-map-layer.md
+++ b/site/source/pages/api-reference/layers/image-map-layer.md
@@ -43,6 +43,7 @@ Option | Type | Default | Description
 `pixelType` | `String` | `undefined` | Leave `pixelType` as unspecified, or `UNKNOWN`, in most exportImage use cases, unless such `pixelType` is desired. Possible values: `C128`, `C64`, `F32`, `F64`, `S16`, `S32`, `S8`, `U1`, `U16`, `U2`, `U32`, `U4`, `U8`, `UNKNOWN`.
 `useCors` | `Boolean` | `true` | If this service should use CORS when making GET requests.
 `renderingRule` | `Object` | `undefined` | A JSON representation of a [raster function](http://resources.arcgis.com/en/help/arcgis-rest-api/#/Raster_function_objects/02r3000000rv000000/)
+`mosaicRule` | `Object` | `undefined` | A JSON representation of a [mosaic rule](http://resources.arcgis.com/en/help/arcgis-rest-api/#/Mosaic_rule_objects/02r3000000s4000000/)
 
 ### Methods
 
@@ -141,6 +142,16 @@ Option | Type | Default | Description
             <td><code>setRenderingRule({{{param 'Object' 'renderingRule'}}})</code></td>
             <td><code>this</code></td>
             <td>Redraws the layer with the passed rendering rule.</td>
+        </tr>
+        <tr>
+            <td><code>getMosaicRule()</code></td>
+            <td><code>Object</code></td>
+            <td>Returns the current mosaic rule of the layer.</td>
+        </tr>
+        <tr>
+            <td><code>setMosaicRule({{{param 'Object' 'mosaicRule'}}})</code></td>
+            <td><code>this</code></td>
+            <td>Redraws the layer with the passed mosaic rule.</td>
         </tr>
     </tbody>
 </table>

--- a/site/source/pages/examples/image-map-layer-mosaic-rule.hbs
+++ b/site/source/pages/examples/image-map-layer-mosaic-rule.hbs
@@ -1,0 +1,22 @@
+---
+title: ImageMapLayer MosaicRule
+description: Display an Image Service from ArcGIS Online or ArcGIS Server and apply a mosaic rule to dynamically control how the service combines rasters into a mosaic. This sample shows world temperature using the 8th raster only (August of 1950). More information about Image Services can be found in the <a href="/esri-leaflet/api-reference/layers/image-map-layer.html">L.esri.Layers.ImageMapLayer</a> documentation.
+layout: example.hbs
+---
+
+<div id="map"></div>
+
+<script>
+    var mosaicRule = {
+        mosaicMethod:'esriMosaicLockRaster',
+        lockRasterIds:[8]
+    };
+
+    var map = L.map('map').setView([30,0], 2);
+
+    L.esri.imageMapLayer('http://sampleserver3.arcgisonline.com/ArcGIS/rest/services/World/Temperature/ImageServer', {
+      mosaicRule: mosaicRule
+    }).addTo(map);
+
+    L.esri.basemapLayer('Gray').addTo(map);
+</script>

--- a/site/source/partials/sidebar-examples.hbs
+++ b/site/source/partials/sidebar-examples.hbs
@@ -28,6 +28,7 @@
     <a href="{{assets}}examples/simple-image-map-layer.html">Simple ImageMapLayer</a>
     <a href="{{assets}}examples/infrared-imagery.html">Infrared Imagery using BandIDs</a>
     <a href="{{assets}}examples/image-map-layer-rendering-rule.html">Rendering Rule</a>
+    <a href="{{assets}}examples/image-map-layer-mosaic-rule.html">Mosaic Rule</a>
   </nav>
 
   <h5>Feature Layers</h5>

--- a/spec/Layers/ImageMapLayerSpec.js
+++ b/spec/Layers/ImageMapLayerSpec.js
@@ -169,6 +169,22 @@ describe('L.esri.Layers.ImageMapLayer', function () {
     server.respond();
   });
 
+  it('should get and set mosaic rule', function(done){
+    server.respondWith('GET', new RegExp(/http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockImageService\/ImageServer\/exportImage\?bbox=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&size=500%2C500&format=jpgpng&bboxSR=3857&imageSR=3857&mosaicRule=%7B%22mosaicMethod%22%3A%22esriMosaicLockRaster%22%2C%22lockRasterIds%22%3A%5B8%5D%7D&f=json/), JSON.stringify({
+      href: 'http://placehold.it/500&text=WithMosaicRule'
+    }));
+
+    layer.once('load', function(){
+      expect(layer._currentImage._url).to.equal('http://placehold.it/500&text=WithMosaicRule');
+      done();
+    });
+
+    layer.setMosaicRule({mosaicMethod:'esriMosaicLockRaster','lockRasterIds':[8]});
+    expect(layer.getMosaicRule()).to.deep.equal({mosaicMethod:'esriMosaicLockRaster','lockRasterIds':[8]});
+    layer.addTo(map);
+    server.respond();
+  });
+
   it('should get and set time ranges', function(done){
     server.respondWith('GET', new RegExp(/http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockImageService\/ImageServer\/exportImage\?bbox=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&size=500%2C500&format=jpgpng&bboxSR=3857&imageSR=3857&time=1389254400000%2C1389513600000&f=json/), JSON.stringify({
       href: 'http://placehold.it/500&text=WithTime'

--- a/src/Layers/ImageMapLayer.js
+++ b/src/Layers/ImageMapLayer.js
@@ -50,6 +50,16 @@ L.esri.Layers.ImageMapLayer = L.esri.Layers.RasterLayer.extend({
     return this.options.renderingRule;
   },
 
+  setMosaicRule: function(mosaicRule) {
+    this.options.mosaicRule = mosaicRule;
+    this._update();
+  },
+
+  getMosaicRule: function() {
+    return this.options.mosaicRule;
+  },
+
+
   _buildExportParams: function () {
     var bounds = this._map.getBounds();
     var size = this._map.getSize();
@@ -94,6 +104,10 @@ L.esri.Layers.ImageMapLayer = L.esri.Layers.RasterLayer.extend({
 
     if(this.options.renderingRule) {
       params.renderingRule = JSON.stringify(this.options.renderingRule);
+    }
+
+    if(this.options.mosaicRule) {
+      params.mosaicRule = JSON.stringify(this.options.mosaicRule);
     }
 
     return params;


### PR DESCRIPTION
added test to ImageMapLayerSpec.js
implemented getter/setter functions and updated `_buildExportParams` in ImageMapLayer.js
updated api reference page
added example page using lock rasters to show only one raster in a mosaic

resolves #298
