### PR TITLE
added support for image service noData and noDataInterpretation parameters

### DIFF
--- a/site/source/pages/api-reference/layers/image-map-layer.md
+++ b/site/source/pages/api-reference/layers/image-map-layer.md
@@ -39,7 +39,9 @@ Option | Type | Default | Description
 `opacity` | `Number` | `1` | Opacity of the layer. Should be a value between 0 and 1.
 `position` | `String` | `'front'` | Position of the layer relative to other overlays.
 `proxy` | `String` | `false` | URL of an [ArcGIS API for JavaScript proxies](https://developers.arcgis.com/javascript/jshelp/ags_proxy.html) or [ArcGIS Resource Proxies](https://github.com/Esri/resource-proxy) to use for proxying POST requests.
-`bandIds` | `String` | `undefined` | If there are multiple bands, you can specify a single band to export.
+`bandIds` | `String` | `undefined` | If there are multiple bands, you can specify which bands to export.
+`noData` | `Number` | `undefined` | The pixel value representing no information.
+`noDataInterpretation` | `String` | `undefined` | Interpretation of the `noData` setting.
 `pixelType` | `String` | `undefined` | Leave `pixelType` as unspecified, or `UNKNOWN`, in most exportImage use cases, unless such `pixelType` is desired. Possible values: `C128`, `C64`, `F32`, `F64`, `S16`, `S32`, `S8`, `U1`, `U16`, `U2`, `U32`, `U4`, `U8`, `UNKNOWN`.
 `useCors` | `Boolean` | `true` | If this service should use CORS when making GET requests.
 `renderingRule` | `Object` | `undefined` | A JSON representation of a [raster function](http://resources.arcgis.com/en/help/arcgis-rest-api/#/Raster_function_objects/02r3000000rv000000/)
@@ -95,6 +97,21 @@ Option | Type | Default | Description
             <td><code>setBandIds({{{param 'Array' 'bandIds'}}} or {{{param 'String' 'bandIds'}}})</code></td>
             <td><code>this</code></td>
             <td>Specify a single band to export, or you can change the band combination (red, green, blue) by specifying the band number.</td>
+        </tr>
+        <tr>
+            <td><code>getNoData()</code></td>
+            <td><code>String</code></td>
+            <td>Returns the current no data value.</td>
+        </tr>
+        <tr>
+            <td><code>setNoData({{{param 'Array' 'noData'}}} or {{{param 'Number' 'noData'}}}, {{{param 'String' 'noDataInterpretation'}}})</code></td>
+            <td><code>this</code></td>
+            <td>Specify a single value, or an array of values to treat as no data. No data will values will be rendered transparent.<br />The optional `noDataInterpretation` can be either `esriNoDataMatchAny` | `esriNoDataMatchAll`. The default is `esriNoDataMatchAny` when `noData` is a number, and `esriNoDataMatchAll` when noData is an array. See <a href="http://resources.arcgis.com/en/help/arcgis-rest-api/#/Export_Image/02r3000000wm000000/">Image Service Export Image documentation</a> for more details</td>
+        </tr>
+        <tr>
+            <td><code>getNoDataInterpretation()</code></td>
+            <td><code>String</code></td>
+            <td>Returns the current no data interpretation value.</td>
         </tr>
         <tr>
             <td><code>getPixelType()</code></td>

--- a/spec/Layers/ImageMapLayerSpec.js
+++ b/spec/Layers/ImageMapLayerSpec.js
@@ -233,6 +233,54 @@ describe('L.esri.Layers.ImageMapLayer', function () {
     server.respond();
   });
 
+  it('should get and set noData as a numeric param', function(done){
+    server.respondWith('GET', new RegExp(/http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockImageService\/ImageServer\/exportImage\?bbox=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&size=500%2C500&format=jpgpng&bboxSR=3857&imageSR=3857&noData=0&f=json/), JSON.stringify({
+      href: 'http://placehold.it/500&text=WithNoData'
+    }));
+
+    layer.once('load', function(){
+      expect(layer._currentImage._url).to.equal('http://placehold.it/500&text=WithNoData');
+      done();
+    });
+
+    layer.setNoData(0);
+    expect(layer.getNoData()).to.equal('0');
+    layer.addTo(map);
+    server.respond();
+  });
+
+  it('should get and set noData as an array', function(done){
+    server.respondWith('GET', new RegExp(/http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockImageService\/ImageServer\/exportImage\?bbox=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&size=500%2C500&format=jpgpng&bboxSR=3857&imageSR=3857&noData=58%2C128%2C187&f=json/), JSON.stringify({
+      href: 'http://placehold.it/500&text=WithNoDataArray'
+    }));
+
+    layer.once('load', function(){
+      expect(layer._currentImage._url).to.equal('http://placehold.it/500&text=WithNoDataArray');
+      done();
+    });
+
+    layer.setNoData([58,128,187]);
+    expect(layer.getNoData()).to.deep.equal('58,128,187');
+    layer.addTo(map);
+    server.respond();
+  });
+
+  it('should get and set noDataInterpretation', function(done){
+    server.respondWith('GET', new RegExp(/http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockImageService\/ImageServer\/exportImage\?bbox=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&size=500%2C500&format=jpgpng&bboxSR=3857&imageSR=3857&noData=0&noDataInterpretation=esriNoDataMatchAll&f=json/), JSON.stringify({
+      href: 'http://placehold.it/500&text=WithNoDataInterpretation'
+    }));
+
+    layer.once('load', function(){
+      expect(layer._currentImage._url).to.equal('http://placehold.it/500&text=WithNoDataInterpretation');
+      done();
+    });
+
+    layer.setNoData(0, 'esriNoDataMatchAll');
+    expect(layer.getNoDataInterpretation()).to.equal('esriNoDataMatchAll');
+    layer.addTo(map);
+    server.respond();
+  });
+
   it('should get and set pixelType', function(done){
     server.respondWith('GET', new RegExp(/http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockImageService\/ImageServer\/exportImage\?bbox=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&size=500%2C500&format=jpgpng&bboxSR=3857&imageSR=3857&pixelType=U8&f=json/), JSON.stringify({
       href: 'http://placehold.it/500&text=WithPixelType'

--- a/src/Layers/ImageMapLayer.js
+++ b/src/Layers/ImageMapLayer.js
@@ -31,7 +31,7 @@ L.esri.Layers.ImageMapLayer = L.esri.Layers.RasterLayer.extend({
     if (L.Util.isArray(bandIds)) {
       this.options.bandIds = bandIds.join(',');
     } else {
-      this.options.bandIds = bandIds;
+      this.options.bandIds = bandIds.toString();
     }
     this._update();
     return this;
@@ -39,6 +39,27 @@ L.esri.Layers.ImageMapLayer = L.esri.Layers.RasterLayer.extend({
 
   getBandIds: function () {
     return this.options.bandIds;
+  },
+
+  setNoData: function (noData, noDataInterpretation) {
+    if (L.Util.isArray(noData)) {
+      this.options.noData = noData.join(',');
+    } else {
+      this.options.noData = noData.toString();
+    }
+    if (noDataInterpretation) {
+      this.options.noDataInterpretation = noDataInterpretation;
+    }
+    this._update();
+    return this;
+  },
+
+  getNoData: function () {
+    return this.options.noData;
+  },
+
+  getNoDataInterpretation: function () {
+    return this.options.noDataInterpretation;
   },
 
   setRenderingRule: function(renderingRule) {
@@ -82,10 +103,6 @@ L.esri.Layers.ImageMapLayer = L.esri.Layers.RasterLayer.extend({
       params.pixelType = this.options.pixelType;
     }
 
-    if (this.options.noDataInterpretation) {
-      params.noDataInterpretation = this.options.noDataInterpretation;
-    }
-
     if (this.options.interpolation) {
       params.interpolation = this.options.interpolation;
     }
@@ -96,6 +113,14 @@ L.esri.Layers.ImageMapLayer = L.esri.Layers.RasterLayer.extend({
 
     if (this.options.bandIds) {
       params.bandIds = this.options.bandIds;
+    }
+
+    if (this.options.noData) {
+      params.noData = this.options.noData;
+    }
+
+    if (this.options.noDataInterpretation) {
+      params.noDataInterpretation = this.options.noDataInterpretation;
     }
 
     if (this._service.options.token) {


### PR DESCRIPTION
added tests to ImageMapLayerSpec.js
added getter/setter methods to ImageMapLayer.js
includes optional parameter to set noDataInterpretation when setting noData
updated api reference page w/ new option/methods

resolves #311
