### PR TITLE
added default value for inSR=4326 to fix queries to arcgis server

### DIFF
--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -14,7 +14,8 @@
       timeField: false,
       timeFilterMode: 'server',
       simplifyFactor: 0,
-      precision: 6
+      precision: 6,
+      inSR:4326
     },
 
     /**


### PR DESCRIPTION
when querying a map service layer and sending in the envelope geometry:

```
{"xmin":90,"ymin":0,"xmax":112.5,"ymax":21.94304553343818,"spatialReference":{"wkid":4326}}
```

The inSR parameter also needed to be set to 4326 to successfully return features.  My guess is that this is a quirk in the arcgis server vs. arcgis online and that agol will successfully read the spatialReference from the envelope json itself, but that ArcGIS Server won't. 
