### PR TITLE
Change param name `key` to `url`

### DIFF
--- a/src/Layers/DynamicMapLayer.js
+++ b/src/Layers/DynamicMapLayer.js
@@ -178,10 +178,10 @@ L.esri.Layers.DynamicMapLayer = L.esri.Layers.RasterLayer.extend({
 
 L.esri.DynamicMapLayer = L.esri.Layers.DynamicMapLayer;
 
-L.esri.Layers.dynamicMapLayer = function(key, options){
-  return new L.esri.Layers.DynamicMapLayer(key, options);
+L.esri.Layers.dynamicMapLayer = function(url, options){
+  return new L.esri.Layers.DynamicMapLayer(url, options);
 };
 
-L.esri.dynamicMapLayer = function(key, options){
-  return new L.esri.Layers.DynamicMapLayer(key, options);
+L.esri.dynamicMapLayer = function(url, options){
+  return new L.esri.Layers.DynamicMapLayer(url, options);
 };


### PR DESCRIPTION
Change to match the `initialize` function, which uses param name `url`. Param name `key` is appropriate for the `basemapLayer` constructor, but `url` seems correct here. I will also submit pull for documentation update.
