### PR TITLE
Change param name `key` to `url`

### DIFF
--- a/site/source/pages/api-reference/layers/dynamic-map-layer.md
+++ b/site/source/pages/api-reference/layers/dynamic-map-layer.md
@@ -22,7 +22,7 @@ Map Servers are a way to expose the contents that make up a map as a web service
     </thead>
     <tbody>
         <tr>
-            <td><code class="nobr">new L.esri.Layers.DynamicMapLayer({{{param 'String' 'key'}}}, {{{param 'Object' 'options'}}})</code><br><br><code class="nobr">L.esri.Layers.dynamicMapLayer({{{param 'String' 'key'}}}, {{{param 'Object' 'options'}}})</code><br><br><code class="nobr">new L.esri.DynamicMapLayer({{{param 'String' 'key'}}}, {{{param 'Object' 'options'}}})</code><br><br><code class="nobr">L.esri.dynamicMapLayer({{{param 'String' 'key'}}}, {{{param 'Object' 'options'}}})</code></td>
+            <td><code class="nobr">new L.esri.Layers.DynamicMapLayer({{{param 'String' 'url'}}}, {{{param 'Object' 'options'}}})</code><br><br><code class="nobr">L.esri.Layers.dynamicMapLayer({{{param 'String' 'url'}}}, {{{param 'Object' 'options'}}})</code><br><br><code class="nobr">new L.esri.DynamicMapLayer({{{param 'String' 'url'}}}, {{{param 'Object' 'options'}}})</code><br><br><code class="nobr">L.esri.dynamicMapLayer({{{param 'String' 'url'}}}, {{{param 'Object' 'options'}}})</code></td>
             <td><code>url</code> should be the URL to the Map Service hosted the tiles. The <code>options</code> parameter can accept the same options as <a href="http://leafletjs.com/reference.html#tilelayer"><code>L.TileLayer</code></a></td>
         </tr>
     </tbody>


### PR DESCRIPTION
The param name is already `url` in the constructor description. I also submitted pull request #327 to update the param name in the constructor source code.
