### PR TITLE
Change param name `key` to `url`

### DIFF
--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -213,10 +213,10 @@ L.esri.Layers.FeatureLayer = L.esri.Layers.FeatureManager.extend({
 
 L.esri.FeatureLayer = L.esri.Layers.FeatureLayer;
 
-L.esri.Layers.featureLayer = function(key, options){
-  return new L.esri.Layers.FeatureLayer(key, options);
+L.esri.Layers.featureLayer = function(url, options){
+  return new L.esri.Layers.FeatureLayer(url, options);
 };
 
-L.esri.featureLayer = function(key, options){
-  return new L.esri.Layers.FeatureLayer(key, options);
+L.esri.featureLayer = function(url, options){
+  return new L.esri.Layers.FeatureLayer(url, options);
 };


### PR DESCRIPTION
Change to match the `initialize` function, which uses param name `url`. Param name `key` is appropriate for the `basemapLayer` constructor, but `url` seems correct here. I will also submit pull for documentation update.
