### PR TITLE
Change param name `key` to `url`

### DIFF
--- a/site/source/pages/api-reference/layers/feature-layer.md
+++ b/site/source/pages/api-reference/layers/feature-layer.md
@@ -36,7 +36,7 @@ You can create a new empty feature service witha  single layer on the [ArcGIS fo
     </thead>
     <tbody>
         <tr>
-            <td><code class="nobr">new L.esri.Layers.FeatureLayer({{{param 'String' 'key'}}}, {{{param 'Object' 'options'}}})</code><br><br><code class="nobr">L.esri.Layers.featureLayer({{{param 'String' 'key'}}}, {{{param 'Object' 'options'}}})</code><br><br><code class="nobr">new L.esri.FeatureLayer({{{param 'String' 'key'}}}, {{{param 'Object' 'options'}}})</code><br><br><code class="nobr">L.esri.featureLayer({{{param 'String' 'key'}}}, {{{param 'Object' 'options'}}})</code></td>
+            <td><code class="nobr">new L.esri.Layers.FeatureLayer({{{param 'String' 'url'}}}, {{{param 'Object' 'options'}}})</code><br><br><code class="nobr">L.esri.Layers.featureLayer({{{param 'String' 'url'}}}, {{{param 'Object' 'options'}}})</code><br><br><code class="nobr">new L.esri.FeatureLayer({{{param 'String' 'url'}}}, {{{param 'Object' 'options'}}})</code><br><br><code class="nobr">L.esri.featureLayer({{{param 'String' 'url'}}}, {{{param 'Object' 'options'}}})</code></td>
             <td><code>url</code> should be the URL to the Feature Layer.</td>
         </tr>
     </tbody>


### PR DESCRIPTION
The param name is already `url` in the constructor description. I also submitted pull request #330 to update the param name in the constructor source code.
