### PR TITLE
Refactor Tasks

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -35,6 +35,7 @@ module.exports = function(config) {
       'src/Services/FeatureLayer.js',
       'src/Services/MapService.js',
       'src/Services/ImageService.js',
+      'src/Tasks/Task.js',
       'src/Tasks/Query.js',
       'src/Tasks/Identify.js',
       'src/Tasks/IdentifyFeatures.js',

--- a/src/Request.js
+++ b/src/Request.js
@@ -72,6 +72,21 @@
 
   // AJAX handlers for CORS (modern browsers) or JSONP (older browsers)
   L.esri.Request = {
+    request: function(url, params, callback, context){
+      var paramString = serialize(params);
+      var httpRequest = createRequest(callback, context);
+      var getUrl = url + '?' + paramString;
+      if(getUrl.length < 2000){
+        httpRequest.open('GET', url + '?' + serialize(params), true);
+        httpRequest.send(null);
+      } else {
+        httpRequest.open('POST', url);
+        httpRequest.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+        httpRequest.send(paramString);
+      }
+
+      return httpRequest;
+    },
     post: {
       XMLHTTP: function (url, params, callback, context) {
         var httpRequest = createRequest(callback, context);
@@ -142,5 +157,7 @@
 
   // Always use XMLHttpRequest for posts
   L.esri.post = L.esri.Request.post.XMLHTTP;
+
+  L.esri.request = L.esri.Request.request;
 
 })(L);

--- a/src/Services/Service.js
+++ b/src/Services/Service.js
@@ -22,6 +22,10 @@ L.esri.Services.Service = L.Class.extend({
     return this._request('post', path, params, callback, context);
   },
 
+  request: function (path, params, callback, context) {
+    return this._request('request', path, params, callback, context);
+  },
+
   metadata: function (callback, context) {
     return this._request('get', '', {}, callback, context);
   },
@@ -50,8 +54,7 @@ L.esri.Services.Service = L.Class.extend({
       this._requestQueue.push([method, path, params, callback, context]);
     } else {
       var url = (this.options.proxy) ? this.options.proxy + '?' + this.url + path : this.url + path;
-
-      if(method === 'get' && !this.options.useCors){
+      if((method === 'get' || method === 'request') && !this.options.useCors){
         return L.esri.Request.get.JSONP(url, params, wrappedCallback);
       } else {
         return L.esri[method](url, params, wrappedCallback);

--- a/src/Tasks/Find.js
+++ b/src/Tasks/Find.js
@@ -1,120 +1,104 @@
-L.esri.Tasks.Find = L.Class.extend({
+L.esri.Tasks.Find = L.esri.Tasks.Task.extend({
+  path: 'find',
 
-  initialize: function (endpoint) {
-    if (endpoint.url && endpoint.get) {
-      this._service = endpoint;
-      this.url = endpoint.url;
-    } else {
-      this.url = L.esri.Util.cleanUrl(endpoint);
-    }
-
-    this._params = {
-      sr: 4326,
-      contains: true,
-      returnGeometry: true,
-      returnZ: true,
-      returnM: false
-    };
+  params: {
+    sr: 4326,
+    contains: true,
+    returnGeometry: true,
+    returnZ: true,
+    returnM: false
   },
 
   text: function (text) {
-    this._params.searchText = text;
+    this.params.searchText = text;
     return this;
   },
 
   contains: function (contains) {
-    this._params.contains = contains;
+    this.params.contains = contains;
     return this;
   },
 
   fields: function (fields) {
-    this._params.searchFields = (this._params.searchFields) ? this._params.searchFields + ',' : '';
+    this.params.searchFields = (this.params.searchFields) ? this.params.searchFields + ',' : '';
     if (L.Util.isArray(fields)) {
-      this._params.searchFields += fields.join(',');
+      this.params.searchFields += fields.join(',');
     } else {
-      this._params.searchFields += fields;
+      this.params.searchFields += fields;
     }
     return this;
   },
 
   spatialReference: function (spatialReference) {
-    this._params.sr = spatialReference;
+    this.params.sr = spatialReference;
     return this;
   },
 
   layerDefs: function (id, where) {
-    this._params.layerDefs = (this._params.layerDefs) ? this._params.layerDefs + ';' : '';
-    this._params.layerDefs += ([id, where]).join(':');
+    this.params.layerDefs = (this.params.layerDefs) ? this.params.layerDefs + ';' : '';
+    this.params.layerDefs += ([id, where]).join(':');
     return this;
   },
 
   layers: function (layers) {
     if (L.Util.isArray(layers)) {
-      this._params.layers = layers.join(',');
+      this.params.layers = layers.join(',');
     } else {
-      this._params.layers = layers;
+      this.params.layers = layers;
     }
     return this;
   },
 
   returnGeometry: function (returnGeometry) {
-    this._params.returnGeometry = returnGeometry;
+    this.params.returnGeometry = returnGeometry;
     return this;
   },
 
   maxAllowableOffset: function (num) {
-    this._params.maxAllowableOffset = num;
+    this.params.maxAllowableOffset = num;
     return this;
   },
 
   precision: function (num) {
-    this._params.geometryPrecision = num;
+    this.params.geometryPrecision = num;
     return this;
   },
 
   dynamicLayers: function (dynamicLayers) {
-    this._params.dynamicLayers = dynamicLayers;
+    this.params.dynamicLayers = dynamicLayers;
     return this;
   },
 
   returnZ: function (returnZ) {
-    this._params.returnZ = returnZ;
+    this.params.returnZ = returnZ;
     return this;
   },
 
   returnM: function (returnM) {
-    this._params.returnM = returnM;
+    this.params.returnM = returnM;
     return this;
   },
 
   gdbVersion: function (string) {
-    this._params.gdbVersion = string;
+    this.params.gdbVersion = string;
     return this;
   },
 
   simplify: function(map, factor){
     var mapWidth = Math.abs(map.getBounds().getWest() - map.getBounds().getEast());
-    this._params.maxAllowableOffset = (mapWidth / map.getSize().y) * factor;
+    this.params.maxAllowableOffset = (mapWidth / map.getSize().y) * factor;
     return this;
   },
 
   token: function (token) {
-    this._params.token = token;
+    this.params.token = token;
     return this;
   },
 
   run: function (callback, context) {
-    this._request(function(error, response){
+    this.request(function(error, response){
       callback.call(context, error, (response && L.esri.Util.responseToFeatureCollection(response)), response);
     }, context);
-  },
-
-  _request: function (callback, context) {
-    if(this._service){
-      this._service.get('find', this._params, callback, context);
-    } else {
-      L.esri.get(this.url + 'find', this._params, callback, context);
-    }
   }
 });
 

--- a/src/Tasks/Identify.js
+++ b/src/Tasks/Identify.js
@@ -1,26 +1,19 @@
-L.esri.Tasks.Identify = L.Class.extend({
+L.esri.Tasks.Identify = L.esri.Tasks.Task.extend({
+  path: 'identify',
 
   between: function(start, end){
-    this._params.time = ([start.valueOf(), end.valueOf()]).join(',');
+    this.params.time = ([start.valueOf(), end.valueOf()]).join(',');
     return this;
   },
 
   returnGeometry: function (returnGeometry) {
-    this._params.returnGeometry = returnGeometry;
+    this.params.returnGeometry = returnGeometry;
     return this;
   },
 
   token: function(token){
-    this._params.token = token;
+    this.params.token = token;
     return this;
-  },
-
-  _request: function(callback, context){
-    if(this._service){
-      this._service.get('identify', this._params, callback, context);
-    } else {
-      L.esri.get(this.url + 'identify', this._params, callback, context);
-    }
   }
 
 });

--- a/src/Tasks/IdentifyFeatures.js
+++ b/src/Tasks/IdentifyFeatures.js
@@ -1,64 +1,54 @@
 L.esri.Tasks.IdentifyFeatures = L.esri.Tasks.Identify.extend({
-
-  initialize: function(endpoint){
-    if(endpoint.url && endpoint.get){
-      this._service = endpoint;
-      this.url = endpoint.url;
-    } else {
-      this.url = L.esri.Util.cleanUrl(endpoint);
-    }
-
-    this._params = {
-      sr: 4326,
-      layers: 'all',
-      tolerance: 3,
-      returnGeometry: true
-    };
+  params: {
+    sr: 4326,
+    layers: 'all',
+    tolerance: 3,
+    returnGeometry: true
   },
 
   on: function(map){
     var extent = L.esri.Util.boundsToExtent(map.getBounds());
     var size = map.getSize();
-    this._params.imageDisplay = [size.x, size.y, 96].join(',');
-    this._params.mapExtent=([extent.xmin, extent.ymin, extent.xmax, extent.ymax]).join(',');
+    this.params.imageDisplay = [size.x, size.y, 96].join(',');
+    this.params.mapExtent=([extent.xmin, extent.ymin, extent.xmax, extent.ymax]).join(',');
     return this;
   },
 
   at: function(latlng){
-    this._params.geometry = ([latlng.lng, latlng.lat]).join(',');
-    this._params.geometryType = 'esriGeometryPoint';
+    this.params.geometry = ([latlng.lng, latlng.lat]).join(',');
+    this.params.geometryType = 'esriGeometryPoint';
     return this;
   },
 
   layerDef: function (id, where){
-    this._params.layerDefs = (this._params.layerDefs) ? this._params.layerDefs + ';' : '';
-    this._params.layerDefs += ([id, where]).join(':');
+    this.params.layerDefs = (this.params.layerDefs) ? this.params.layerDefs + ';' : '';
+    this.params.layerDefs += ([id, where]).join(':');
     return this;
   },
 
   layers: function (string){
-    this._params.layers = string;
+    this.params.layers = string;
     return this;
   },
 
   precision: function(num){
-    this._params.geometryPrecision = num;
+    this.params.geometryPrecision = num;
     return this;
   },
 
   simplify: function(map, factor){
     var mapWidth = Math.abs(map.getBounds().getWest() - map.getBounds().getEast());
-    this._params.maxAllowableOffset = (mapWidth / map.getSize().y) * (1 - factor);
+    this.params.maxAllowableOffset = (mapWidth / map.getSize().y) * (1 - factor);
     return this;
   },
 
   tolerance: function(tolerance){
-    this._params.tolerance = tolerance;
+    this.params.tolerance = tolerance;
     return this;
   },
 
   run: function (callback, context){
-    this._request(function(error, response){
+    this.request(function(error, response){
       callback.call(context, error, (response && L.esri.Util.responseToFeatureCollection(response)), response);
     }, context);
   }

--- a/src/Tasks/IdentifyImage.js
+++ b/src/Tasks/IdentifyImage.js
@@ -1,65 +1,55 @@
 L.esri.Tasks.IdentifyImage = L.esri.Tasks.Identify.extend({
-
-  initialize: function(endpoint){
-    if(endpoint.url && endpoint.get){
-      this._service = endpoint;
-      this.url = endpoint.url;
-    } else {
-      this.url = L.esri.Util.cleanUrl(endpoint);
-    }
-
-    this._params = {
-      returnGeometry: false
-    };
+  params: {
+    returnGeometry: false
   },
 
   at: function(latlng){
-    this._params.geometry = JSON.stringify({
+    this.params.geometry = JSON.stringify({
       x: latlng.lng,
       y: latlng.lat,
       spatialReference:{
         wkid: 4326
       }
     });
-    this._params.geometryType = 'esriGeometryPoint';
+    this.params.geometryType = 'esriGeometryPoint';
     return this;
   },
 
   setMosaicRule: function(mosaicRule) {
-    this._params.mosaicRule = mosaicRule;
+    this.params.mosaicRule = mosaicRule;
     return this;
   },
 
   getMosaicRule: function() {
-    return this._params.mosaicRule;
+    return this.params.mosaicRule;
   },
 
   setRenderingRule: function(renderingRule) {
-    this._params.renderingRule = renderingRule;
+    this.params.renderingRule = renderingRule;
     return this;
   },
 
   getRenderingRule: function() {
-    return this._params.renderingRule;
+    return this.params.renderingRule;
   },
 
   setPixelSize: function(pixelSize) {
-    this._params.pixelSize = pixelSize.join ? pixelSize.join(',') : pixelSize;
+    this.params.pixelSize = pixelSize.join ? pixelSize.join(',') : pixelSize;
     return this;
   },
 
   getPixelSize: function() {
-    return this._params.pixelSize;
+    return this.params.pixelSize;
   },
 
   returnCatalogItems: function (returnCatalogItems) {
-    this._params.returnCatalogItems = returnCatalogItems;
+    this.params.returnCatalogItems = returnCatalogItems;
     return this;
   },
 
   run: function (callback, context){
     var _this = this;
-    this._request(function(error, response){
+    this.request(function(error, response){
       callback.call(context, error, (response && _this._responseToGeoJSON(response)), response);
     }, context);
   },

--- a/src/Tasks/Task.js
+++ b/src/Tasks/Task.js
@@ -1,0 +1,19 @@
+L.esri.Tasks.Task = L.Class.extend({
+  initialize: function(endpoint){
+    if(endpoint.url && endpoint.get){
+      this._service = endpoint;
+      this.url = endpoint.url;
+    } else {
+      this.url = L.esri.Util.cleanUrl(endpoint);
+    }
+
+    this.params = L.Util.extend({}, this.params);
+  },
+  request: function(callback, context){
+    if(this._service){
+      this._service.request(this.path, this.params, callback, context);
+    } else {
+      L.esri.request(this.url + this.path, this.params, callback, context);
+    }
+  }
+});


### PR DESCRIPTION
- Refactor common task logic into `L.esri.Tasks.Task` make all tasks inherit from `L.esri.Tasks.Task`
- New `L.esri.request` method that switches between GET and POST based on request length.
