### PR TITLE
fix link to license

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-A copy of the license is available in the repository's [license.txt]( https://raw.github.com/Esri/esri-leaflet/master/license.txt) file.
+A copy of the license is available in the repository's [LICENSE](./LICENSE) file.
 
 [](Esri Tags: ArcGIS Web Mapping Leaflet)
 [](Esri Language: JavaScript)


### PR DESCRIPTION
Link to `license.txt` is currently broken (also the file is not called `license.txt` but `LICENSE`). The method in this PR is the preferred method for linking to files in a repo as github tends to change their URL structure so linking to raw.github.com is unreliable. Github will do the job of rendering the correct link in the README if the path is relative to the root of the repo.
