### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,29 @@
+# Mac
+.DS_Store
+Icon
+._*
+.Spotlight-V100
+
+# SublimeText
+/*.sublime-project
+*.sublime-workspace
+*.sublime-project
+.idea/*
+
+# SASS
+.sass-cache
+
+# Node
+node_modules
+
+# Coverage
+coverage
+
+# Grunt
+.grunt/
+
+# Debugging Files
+working
+
+# Docs Build
+site/build


### PR DESCRIPTION
You don't have a [.npmignore](https://www.npmjs.org/doc/misc/npm-developers.html#keeping-files-out-of-your-package) file so npm is using the `.gitignore`. The compiled output from the pre-publish task is getting axed because of this which makes it difficult to use esri-leaflet with dependency managers such as browserify which expect the `main` file specified in `package.json` to exist.

This pull-request contains a `.npmignore` file which is a duplicate of the current `.gitignore` without the `dist/**/*.js` exclusion.
You will need to re-publish to npm after merging this.
