### PR TITLE
added returnGeometry parameter to Query task

### DIFF
--- a/src/Tasks/Query.js
+++ b/src/Tasks/Query.js
@@ -69,6 +69,11 @@ L.esri.Tasks.Query = L.esri.Tasks.Task.extend({
     return this;
   },
 
+  returnGeometry: function(bool){
+    this.params.returnGeometry = bool;
+    return this;
+  },
+
   run: function(callback, context){
     this._cleanParams();
     return this.request(function(error, response){


### PR DESCRIPTION
added a method which is already mentioned in the API reference, but omitted in the source

http://esri.github.io/esri-leaflet/api-reference/tasks/query.html
