### PR TITLE
Reset style catch for MultiPolylines and MultiPolygons

### DIFF
--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -167,6 +167,14 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
     if (typeof style === 'function') {
       style = style(layer.feature);
     }
+
+    /*trap inability to access default style options from MultiLine/MultiPolygon
+    please revisit at Leaflet 1.0*/
+    else if (!style && !layer.defaultOptions) {
+      var dummyPath = new L.Path();
+      style = L.Path.prototype.options;
+    }
+
     if (layer.setStyle) {
       layer.setStyle(style);
     }


### PR DESCRIPTION
Catch inability to access default style for MultiLines and MultiPolygons so that resetStyle() functions consistently.  fixes #390
