### PR TITLE
update DarkGray basemap info for new production servers

### DIFF
--- a/src/Layers/BasemapLayer.js
+++ b/src/Layers/BasemapLayer.js
@@ -64,25 +64,25 @@
           }
         },
         DarkGray: {
-          urlTemplate: tileProtocol + '//tiles{s}.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/World_Dark_Gray_Base_Beta/MapServer/tile/{z}/{y}/{x}',
+          urlTemplate: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}',
           options: {
             hideLogo: false,
             logoPosition: 'bottomright',
             minZoom: 1,
-            maxZoom: 10,
-            subdomains: ['1', '2'],
+            maxZoom: 16,
+            subdomains: ['server', 'services'],
             attribution: 'Esri, DeLorme, HERE'
           }
         },
         DarkGrayLabels: {
-          urlTemplate: tileProtocol + '//tiles{s}.arcgis.com/tiles/P3ePLMYs2RVChkJx/arcgis/rest/services/World_Dark_Gray_Reference_Beta/MapServer/tile/{z}/{y}/{x}',
+          urlTemplate: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Reference/MapServer/tile/{z}/{y}/{x}',
           options: {
             hideLogo: true,
             logoPosition: 'bottomright',
             //pane: 'esri-label',
             minZoom: 1,
-            maxZoom: 10,
-            subdomains: ['1', '2']
+            maxZoom: 16,
+            subdomains: ['server', 'services']
           }
         },
         Gray: {


### PR DESCRIPTION
updated urls, subdomains and zoomLevels for DarkGray basemap and labels, as it has now left beta
grunt tests passing.

http://www.arcgis.com/home/item.html?id=1970c1995b8f44749f4b9b6e81b5ba45
http://services.arcgisonline.com/arcgis/rest/services/Canvas/World_Dark_Gray_Base/MapServer
