### PR TITLE
make sure fill is set by default for multipolygons

### DIFF
--- a/spec/Layers/FeatureLayer/FeatureLayerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureLayerSpec.js
@@ -274,6 +274,18 @@ describe('L.esri.Layers.FeatureLayer', function () {
     expect(layer.getFeature(1).getLayers()[0].options.color).to.equal('#0033ff');
   });
 
+  it('should draw multi polygon features with a fill', function(){
+    layer = L.esri.featureLayer('http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0').addTo(map);
+
+    layer.createLayers(multiPolygon);
+
+    expect(layer.getFeature(1).getLayers()[0].options.fill).to.equal(true);
+
+    layer.resetStyle(1);
+
+    expect(layer.getFeature(1).getLayers()[0].options.color).to.equal('#0033ff');
+  });
+
   it('should iterate over each feature', function(){
     var spy = sinon.spy();
     layer.eachFeature(spy);

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -173,6 +173,7 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
     else if (!style && !layer.defaultOptions) {
       var dummyPath = new L.Path();
       style = L.Path.prototype.options;
+      style.fill = true; //not set by default
     }
 
     if (layer.setStyle) {


### PR DESCRIPTION
if you run debug/sample.html against RC4, you can see that states that are multipolygons draw with no fill.

this is a bug i introduced in #394 and is caused by the fact that 
`L.Path.prototype.options.fill` returns `false`

please review this patch which sets fill manually (and adds an appropriate test)
