### PR TITLE
add support for supplying 0,0 to designate unrestricted min/maxZoom constructor values

### DIFF
--- a/spec/Layers/FeatureLayer/FeatureManagerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureManagerSpec.js
@@ -821,4 +821,31 @@ describe('L.esri.Layers.FeatureManager', function () {
 
   });
 
+  it('should also respect 0/0 as min/max intended to force unrestricted drawing', function (done) {
+
+    map.setZoom(14);
+    layer.options.minZoom = 0;
+    layer.options.maxZoom = 0;
+
+    server.respondWith('GET', 'http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0/query?returnGeometry=true&where=1%3D1&outSr=4326&outFields=*&inSr=4326&geometry=%7B%22xmin%22%3A-122.6953125%2C%22ymin%22%3A45.521743896993634%2C%22xmax%22%3A-122.6513671875%2C%22ymax%22%3A45.55252525134013%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryEnvelope&spatialRel=esriSpatialRelIntersects&geometryPrecision=6&f=json', JSON.stringify({
+      fields: fields,
+      features: [feature1, feature2],
+      objectIdFieldName: 'OBJECTID'
+    }));
+
+    layer.addTo(map);
+
+    map.once('zoomend', function () {
+
+      server.respond();
+
+      expect(layer.createLayers).to.have.been.called;
+      done();
+    });
+
+    map.setZoom(11);
+
+
+  });
+
 });

--- a/src/Layers/FeatureLayer/FeatureGrid.js
+++ b/src/Layers/FeatureLayer/FeatureGrid.js
@@ -47,6 +47,12 @@ EsriLeaflet.Layers.FeatureGrid = L.Class.extend({
     return this;
   },
 
+  _updateZoomRestrictions : function () {
+    if (this.options.maxZoom === 0) {
+      this.options.maxZoom = this._map.getMaxZoom();
+    }
+  },
+
   _onZoom : function () {
     var zoom = this._map.getZoom();
 
@@ -108,6 +114,8 @@ EsriLeaflet.Layers.FeatureGrid = L.Class.extend({
     var bounds = this._map.getPixelBounds(),
         zoom = this._map.getZoom(),
         cellSize = this._getCellSize();
+
+    this._updateZoomRestrictions();
 
     if (zoom > this.options.maxZoom ||
         zoom < this.options.minZoom) { return; }

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -134,6 +134,7 @@
       }
 
       var zoom = this._map.getZoom();
+      this._updateZoomRestrictions();
 
       if (zoom > this.options.maxZoom ||
           zoom < this.options.minZoom) { return; }

--- a/src/Util.js
+++ b/src/Util.js
@@ -379,7 +379,7 @@
     return featureCollection;
   };
 
-    // trim whitespace and add a tailing slash is needed to a url
+  // trim whitespace and add a tailing slash is needed to a url
   EsriLeaflet.Util.cleanUrl = function(url){
     url = url.replace(/\s\s*/g, '');
 
@@ -414,6 +414,19 @@
       break;
     }
     return arcgisGeometryType;
+  };
+
+  /*
+  this is an inversion of L.ICRS.scale()
+  and only valid for wkid:3857
+  */
+  EsriLeaflet.Util.scaleToLevel = function(scale){
+    if (scale === 0) {
+      return scale;
+    }
+    else {
+      return Math.log10(scale/256) / Math.log10(2);
+    }
   };
 
 })(EsriLeaflet);


### PR DESCRIPTION
when trying to call FeatureLayer.metadata() to update min/maxZoom with values provided by the service itself, i ran into a couple hiccups...
- feature services present raw scale values, which must be translated into zoom levels
- a value of 0 in the service metadata indicates that the layer does not have a drawing restriction.  for maxZoom, this needs to be replaced by the largest actual zoom level available in the map
1. This pull request introduces support for using 0/0 as zoom constructor values, resulting in a layer that draws at all scales.

```js
var counties = new L.esri.Layers.FeatureLayer('http://sampleserver5.arcgisonline.com/arcgis/rest/services/Census/MapServer/2', {
  minZoom: 0,
  maxZoom: 0
});
```
1. I also added a utility method to L.esri.Util to translate raw scale values into zoom levels.
2. test coverage is included as well.

this is my test code:

```js
var map = L.map('map').setView([37.75, -122.23], 12);
L.esri.basemapLayer('Topographic').addTo(map);

var blockGroups = new L.esri.Layers.FeatureLayer('http://sampleserver5.arcgisonline.com/arcgis/rest/services/Census/MapServer/1').addTo(map);

// create the layer and add it to the map, then update zoom values based on service metadata
blockGroups.metadata(function(error, response) {
  dynMin = L.esri.Util.scaleToLevel(response.minScale);
  blockGroups.options.minZoom = dynMin;

  dynMax = L.esri.Util.scaleToLevel(response.maxScale);
  blockGroups.options.maxZoom = dynMax;
});
```

cc @MandarinConLaBarba
