### PR TITLE
set map._hasEsriLogo to false when a basemap is removed

### DIFF
--- a/src/Layers/BasemapLayer.js
+++ b/src/Layers/BasemapLayer.js
@@ -229,6 +229,7 @@
     onRemove: function(map){
       if(this._logo){
         map.removeControl(this._logo);
+        map._hasEsriLogo = false;
       }
 
       L.TileLayer.prototype.onRemove.call(this, map);


### PR DESCRIPTION
i introduced a bug in #398 that is evident when you run the sample 'Switching Basemaps' and toggle a few because i forgot to set `map._hasEsriLogo` back to false when a basemap was manually removed.

this is the patch.
