### PR TITLE
Refactor tasks and services to accept only options with url

### DIFF
--- a/spec/Layers/BaseMapLayerSpec.js
+++ b/spec/Layers/BaseMapLayerSpec.js
@@ -49,7 +49,7 @@ describe('L.esri.Layers.BasemapLayer', function () {
     for (var i = 0, len = testmaps.length; i < len; i++) {
       var name = testmaps[i];
       expect(L.esri.basemapLayer(name)).to.be.instanceof(L.esri.Layers.BasemapLayer);
-      expect(L.esri.basemapLayer(name)._url).to.eql(L.esri.BasemapLayer.TILES[name].urlTemplate);
+      expect(L.esri.basemapLayer(name)._url).to.eql(L.esri.BasemapLayer.TILES[name].options.url);
     }
   });
 

--- a/spec/Layers/DymanicMapLayerSpec.js
+++ b/spec/Layers/DymanicMapLayerSpec.js
@@ -47,7 +47,8 @@ describe('L.esri.Layers.DynamicMapLayer', function () {
     server.respondWith('GET',new RegExp(/http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockMapService\/MapServer\/export\?bbox=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&size=500%2C500&dpi=96&format=png24&transparent=true&bboxSR=3857&imageSR=3857&f=json/), JSON.stringify({
       href: 'http://placehold.it/500&text=Image1'
     }));
-    layer = L.esri.dynamicMapLayer(url, {
+    layer = L.esri.dynamicMapLayer({
+      url: url,
       f: 'json'
     });
     map = createMap();
@@ -60,11 +61,12 @@ describe('L.esri.Layers.DynamicMapLayer', function () {
   });
 
  it('should have a L.esri.Layers.dynamicMapLayer alias', function(){
-    expect(L.esri.Layers.dynamicMapLayer(url)).to.be.instanceof(L.esri.Layers.DynamicMapLayer);
+    expect(L.esri.Layers.dynamicMapLayer({url: url})).to.be.instanceof(L.esri.Layers.DynamicMapLayer);
   });
 
  it('should display an attribution if one was passed', function(){
-    L.esri.Layers.dynamicMapLayer(url, {
+    L.esri.Layers.dynamicMapLayer({
+      url: url,
       attribution: 'Esri'
     }).addTo(map);
 
@@ -282,7 +284,7 @@ describe('L.esri.Layers.DynamicMapLayer', function () {
   });
 
   it('should be able to request an image directly from the export service', function(){
-    layer = L.esri.dynamicMapLayer(url);
+    layer = L.esri.dynamicMapLayer({url: url});
     var spy = sinon.spy(layer, '_renderImage');
     layer.addTo(map);
     expect(spy.getCall(0).args[0]).to.match(new RegExp(/http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockMapService\/MapServer\/export\?bbox=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&size=500%2C500&dpi=96&format=png24&transparent=true&bboxSR=3857&imageSR=3857&f=image/));

--- a/spec/Layers/FeatureLayer/FeatureLayerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureLayerSpec.js
@@ -52,7 +52,8 @@ describe('L.esri.Layers.FeatureLayer', function () {
   })];
 
   beforeEach(function(){
-    layer = L.esri.featureLayer('http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0', {
+    layer = L.esri.featureLayer({
+      url: 'http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0',
       timeField: 'time',
       pointToLayer: function(feature, latlng){
         return L.circleMarker(latlng);
@@ -63,7 +64,8 @@ describe('L.esri.Layers.FeatureLayer', function () {
   });
 
   it('should fire a createfeature event', function(done){
-    layer = L.esri.featureLayer('http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0', {
+    layer = L.esri.featureLayer({
+      url: 'http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0',
       timeField: 'time',
       pointToLayer: function(feature, latlng){
         return L.circleMarker(latlng);
@@ -79,7 +81,9 @@ describe('L.esri.Layers.FeatureLayer', function () {
   });
 
   it('should have an alias at L.esri.Layers.featureLayer', function(){
-    var layer = L.esri.Layers.featureLayer('http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0');
+    var layer = L.esri.Layers.featureLayer({
+      url: 'http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0'
+    });
     expect(layer).to.be.an.instanceof(L.esri.Layers.FeatureLayer);
   });
 
@@ -227,7 +231,10 @@ describe('L.esri.Layers.FeatureLayer', function () {
   });
 
   it('should unbind popups on multi polygon features', function(){
-    layer = L.esri.featureLayer('http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0', { timeField: 'time' }).addTo(map);
+    layer = L.esri.featureLayer({
+      url: 'http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0',
+      timeField: 'time'
+    }).addTo(map);
 
     layer.createLayers(multiPolygon);
     layer.bindPopup(function(feature){
@@ -239,7 +246,8 @@ describe('L.esri.Layers.FeatureLayer', function () {
   });
 
   it('should reset style on multi polygon features', function(){
-    layer = L.esri.featureLayer('http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0', {
+    layer = L.esri.featureLayer({
+      url: 'http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0',
       style: {
         color: 'black'
       }
@@ -259,7 +267,9 @@ describe('L.esri.Layers.FeatureLayer', function () {
   });
 
   it('should reset to default style on multi polygon features', function(){
-    layer = L.esri.featureLayer('http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0').addTo(map);
+    layer = L.esri.featureLayer({
+      url: 'http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0'
+    }).addTo(map);
 
     layer.createLayers(multiPolygon);
 
@@ -275,7 +285,9 @@ describe('L.esri.Layers.FeatureLayer', function () {
   });
 
   it('should draw multi polygon features with a fill', function(){
-    layer = L.esri.featureLayer('http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0').addTo(map);
+    layer = L.esri.featureLayer({
+      url: 'http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0'
+    }).addTo(map);
 
     layer.createLayers(multiPolygon);
 
@@ -294,7 +306,8 @@ describe('L.esri.Layers.FeatureLayer', function () {
 
   it('should run a function against every feature', function(){
     var spy = sinon.spy();
-    layer = L.esri.featureLayer('http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0', {
+    layer = L.esri.featureLayer({
+      url: 'http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0',
       onEachFeature: spy
     }).addTo(map);
     layer.createLayers(features);

--- a/spec/Layers/FeatureLayer/FeatureLayerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureLayerSpec.js
@@ -81,7 +81,8 @@ describe('L.esri.Layers.FeatureLayer', function () {
   });
 
   it('should have an alias at L.esri.Layers.featureLayer', function(){
-    var layer = L.esri.Layers.featureLayer('http://gis.example.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0');
+    var layer = L.esri.Layers.featureLayer({
+      url: 'http://gis.example.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0'});
     expect(layer).to.be.an.instanceof(L.esri.Layers.FeatureLayer);
   });
 

--- a/spec/Layers/FeatureLayer/FeatureManagerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureManagerSpec.js
@@ -32,7 +32,8 @@ describe('L.esri.Layers.FeatureManager', function () {
       removeLayers: sandbox.spy()
     });
 
-    layer = new MockLayer(url, {
+    layer = new MockLayer({
+      url: url,
       timeField: 'Time',
       attribution: 'Esri',
       minZoom : 1,
@@ -344,7 +345,8 @@ describe('L.esri.Layers.FeatureManager', function () {
   });
 
   it('should filter existing features with a start and end time field', function(){
-    layer = new MockLayer(url, {
+    layer = new MockLayer({
+      url: url,
       timeField: {
         start: 'StartTime',
         end: 'EndTime'
@@ -373,7 +375,8 @@ describe('L.esri.Layers.FeatureManager', function () {
   });
 
   it('should load more features  with a start and end time field', function(){
-    layer = new MockLayer(url, {
+    layer = new MockLayer({
+      url: url,
       timeField: {
         start: 'StartTime',
         end: 'EndTime'
@@ -530,7 +533,8 @@ describe('L.esri.Layers.FeatureManager', function () {
   });
 
   it('should return true for features with a single feature with start and end time fields in the current time range', function(){
-    var layer = new L.esri.Layers.FeatureManager(url, {
+    var layer = new L.esri.Layers.FeatureManager({
+      url: url,
       from: new Date('Dec 1 2013 GMT-0800'),
       to: new Date('January 12 2014 GMT-0800'),
       timeField: {
@@ -716,7 +720,8 @@ describe('L.esri.Layers.FeatureManager', function () {
       objectIdFieldName: 'OBJECTID',
     }));
 
-    var layer = new MockLayer('http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0/', {
+    var layer = new MockLayer({
+      url: 'http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0/',
       simplifyFactor: 0.5
     });
 

--- a/spec/Layers/ImageMapLayerSpec.js
+++ b/spec/Layers/ImageMapLayerSpec.js
@@ -40,7 +40,8 @@ describe('L.esri.Layers.ImageMapLayer', function () {
     server.respondWith('GET',new RegExp(/http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockImageService\/ImageServer\/exportImage\?bbox=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&size=500%2C500&format=jpgpng&bboxSR=3857&imageSR=3857&f=json/), JSON.stringify({
       href: 'http://placehold.it/500&text=Image1'
     }));
-    layer = L.esri.imageMapLayer(url, {
+    layer = L.esri.imageMapLayer({
+      url: url,
       f: 'json'
     });
     map = createMap();
@@ -53,11 +54,12 @@ describe('L.esri.Layers.ImageMapLayer', function () {
   });
 
   it('should have a L.esri.Layers.imageMapLayer alias', function(){
-    expect(L.esri.Layers.imageMapLayer(url)).to.be.instanceof(L.esri.Layers.ImageMapLayer);
+    expect(L.esri.Layers.imageMapLayer({url: url})).to.be.instanceof(L.esri.Layers.ImageMapLayer);
   });
 
   it('should display an attribution if one was passed', function(){
-    L.esri.Layers.imageMapLayer(url, {
+    L.esri.Layers.imageMapLayer({
+      url: url,
       attribution: 'Esri'
     }).addTo(map);
 
@@ -422,7 +424,7 @@ describe('L.esri.Layers.ImageMapLayer', function () {
   });
 
   it('should be able to request an image directly from the export service', function(){
-    layer = L.esri.imageMapLayer(url);
+    layer = L.esri.imageMapLayer({url: url});
     var spy = sinon.spy(layer, '_renderImage');
     layer.addTo(map);
     expect(spy.getCall(0).args[0]).to.match(new RegExp(/http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockImageService\/ImageServer\/exportImage\?bbox=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&size=500%2C500&format=jpgpng&bboxSR=3857&imageSR=3857&f=image/));

--- a/spec/Layers/TiledMapLayerSpec.js
+++ b/spec/Layers/TiledMapLayerSpec.js
@@ -5,7 +5,7 @@ describe('L.esri.Layers.TiledMapLayer', function () {
 
   beforeEach(function(){
     server = sinon.fakeServer.create();
-    layer = L.esri.tiledMapLayer(url);
+    layer = L.esri.tiledMapLayer({url: url});
   });
 
   afterEach(function(){
@@ -17,7 +17,7 @@ describe('L.esri.Layers.TiledMapLayer', function () {
   });
 
   it('will modify url for tiles.arcgis.com services', function () {
-    var layer = L.esri.tiledMapLayer('http://tiles.arcgisonline.com/ArcGIS/rest/services/USA_Topo_Maps/MapServer');
+    var layer = L.esri.tiledMapLayer({url: 'http://tiles.arcgisonline.com/ArcGIS/rest/services/USA_Topo_Maps/MapServer'});
     expect(layer.tileUrl).to.equal('http://tiles{s}.arcgisonline.com/ArcGIS/rest/services/USA_Topo_Maps/MapServer/tile/{z}/{y}/{x}');
     expect(layer.options.subdomains).to.deep.equal(['1','2','3','4']);
   });
@@ -56,12 +56,13 @@ describe('L.esri.Layers.TiledMapLayer', function () {
   });
 
   it('should have a L.esri.Layers.tiledMapLayer alias', function(){
-    layer = L.esri.Layers.tiledMapLayer(url);
+    layer = L.esri.Layers.tiledMapLayer({url: url});
     expect(layer).to.be.instanceof(L.esri.Layers.TiledMapLayer);
   });
 
   it('should use a token passed in options', function(){
-    layer = L.esri.tiledMapLayer(url, {
+    layer = L.esri.tiledMapLayer({
+      url: url,
       token: 'foo'
     });
 
@@ -69,7 +70,7 @@ describe('L.esri.Layers.TiledMapLayer', function () {
   });
 
   it('should use a token passed with authenticate()', function(){
-    layer = L.esri.tiledMapLayer(url);
+    layer = L.esri.tiledMapLayer({url:url});
 
     layer.authenticate('foo');
 
@@ -77,7 +78,8 @@ describe('L.esri.Layers.TiledMapLayer', function () {
   });
 
   it('should reauthenticate with a token authenticate()', function(){
-    layer = L.esri.tiledMapLayer(url, {
+    layer = L.esri.tiledMapLayer({
+      url: url,
       token: 'foo'
     });
 

--- a/spec/Services/FeatureLayerSpec.js
+++ b/spec/Services/FeatureLayerSpec.js
@@ -12,7 +12,7 @@ describe('L.esri.Services.FeatureLayer', function () {
       requests.push(xhr);
     };
 
-    service = L.esri.Services.featureLayer(url);
+    service = L.esri.Services.featureLayer({url: url});
   });
 
   afterEach(function(){

--- a/spec/Services/ServiceSpec.js
+++ b/spec/Services/ServiceSpec.js
@@ -5,7 +5,7 @@ describe('L.esri.Service', function () {
 
   beforeEach(function(){
     server = sinon.fakeServer.create();
-    service = L.esri.Services.service(url);
+    service = L.esri.Services.service({url: url});
   });
 
   afterEach(function(){

--- a/spec/Tasks/FindSpec.js
+++ b/spec/Tasks/FindSpec.js
@@ -98,7 +98,7 @@ describe('L.esri.Tasks.Find', function () {
 
   beforeEach(function(){
     server = sinon.fakeServer.create();
-    task = L.esri.Tasks.find(url);
+    task = L.esri.Tasks.find({url: url});
   });
 
   afterEach(function(){
@@ -180,7 +180,7 @@ describe('L.esri.Tasks.Find', function () {
   });
 
   it('should use a service to execute the find task', function(done){
-    var service = L.esri.Services.mapService(url);
+    var service = L.esri.Services.mapService({url: url});
 
     server.respondWith('GET', url + 'find?sr=4326&contains=true&returnGeometry=true&returnZ=true&returnM=false&layers=0&searchText=Site&f=json', JSON.stringify(sampleResponse));
 
@@ -196,7 +196,10 @@ describe('L.esri.Tasks.Find', function () {
   });
 
   it('should use JSONP to execute without a service', function(done){
-    var myTask = L.esri.Tasks.find(url, {useCors:false});
+    var myTask = L.esri.Tasks.find({
+      url: url,
+      useCors:false
+    });
 
     var request = myTask.layers('0').text('Site').run(function(error, featureCollection, raw){
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);

--- a/spec/Tasks/IdentifyFeaturesSpec.js
+++ b/spec/Tasks/IdentifyFeaturesSpec.js
@@ -64,7 +64,7 @@ describe('L.esri.Tasks.IdentifyFeatures', function () {
 
   beforeEach(function(){
     server = sinon.fakeServer.create();
-    task = L.esri.Tasks.identifyFeatures(url).on(map).at(latlng);
+    task = L.esri.Tasks.identifyFeatures({url: url}).on(map).at(latlng);
   });
 
   afterEach(function(){
@@ -204,7 +204,7 @@ describe('L.esri.Tasks.IdentifyFeatures', function () {
   });
 
   it('should use a service to execute the request', function(done){
-    var service = L.esri.Services.mapService(url);
+    var service = L.esri.Services.mapService({url: url});
 
     // server.respondWith('GET', url + 'identify?sr=4326&layers=all&tolerance=3&returnGeometry=true&imageDisplay=500%2C500%2C96&mapExtent=-122.66535758972167%2C45.50624163368495%2C-122.65462875366211%2C45.51376023843158&geometry=-122.66%2C45.51&geometryType=esriGeometryPoint&f=json', JSON.stringify(sampleResponse));
 
@@ -228,7 +228,7 @@ describe('L.esri.Tasks.IdentifyFeatures', function () {
   });
 
   it('should use a service to execute the request with simple LatLng', function(done){
-    var service = L.esri.Services.mapService(url);
+    var service = L.esri.Services.mapService({url: url});
 
     // server.respondWith('GET', url + 'identify?sr=4326&layers=all&tolerance=3&returnGeometry=true&imageDisplay=500%2C500%2C96&mapExtent=-122.66535758972167%2C45.50624163368495%2C-122.65462875366211%2C45.51376023843158&geometry=-122.66%2C45.51&geometryType=esriGeometryPoint&f=json', JSON.stringify(sampleResponse));
 

--- a/spec/Tasks/IdentifyImageSpec.js
+++ b/spec/Tasks/IdentifyImageSpec.js
@@ -341,7 +341,7 @@ describe('L.esri.Tasks.IdentifyImage', function () {
 
   beforeEach(function(){
     server = sinon.fakeServer.create();
-    task = L.esri.Tasks.identifyImage(url).at(latlng);
+    task = L.esri.Tasks.identifyImage({url: url}).at(latlng);
   });
 
   afterEach(function(){

--- a/spec/Tasks/QuerySpec.js
+++ b/spec/Tasks/QuerySpec.js
@@ -743,7 +743,7 @@ describe('L.esri.Tasks.Query', function () {
   });
 
   it('should query GeoJSON from ArcGIS Online', function(done){
-    task = L.esri.Tasks.query('http://services.arcgis.com/mock/arcgis/rest/services/MockFeatureService/FeatureServer/0/');
+    task = L.esri.Tasks.query({url: 'http://services.arcgis.com/mock/arcgis/rest/services/MockFeatureService/FeatureServer/0/'});
 
     server.respondWith('GET', 'http://services.arcgis.com/mock/arcgis/rest/services/MockFeatureService/FeatureServer/0/query?returnGeometry=true&where=1%3D1&outSr=4326&outFields=*&f=geojson', JSON.stringify(sampleFeatureCollection));
 

--- a/spec/Tasks/QuerySpec.js
+++ b/spec/Tasks/QuerySpec.js
@@ -214,7 +214,7 @@ describe('L.esri.Tasks.Query', function () {
 
   beforeEach(function(){
     server = sinon.fakeServer.create();
-    task = L.esri.Tasks.query(featureLayerUrl);
+    task = L.esri.Tasks.query({url: featureLayerUrl});
   });
 
   afterEach(function(){
@@ -633,7 +633,7 @@ describe('L.esri.Tasks.Query', function () {
   it('should use a feature layer service to query features', function(done){
     server.respondWith('GET', featureLayerUrl + 'query?returnGeometry=true&where=1%3D1&outSr=4326&outFields=*&f=json', JSON.stringify(sampleQueryResponse));
 
-    var service = new L.esri.Services.FeatureLayer(featureLayerUrl);
+    var service = new L.esri.Services.FeatureLayer({url: featureLayerUrl});
 
     var request = service.query().run(function(error, featureCollection, raw){
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
@@ -649,7 +649,7 @@ describe('L.esri.Tasks.Query', function () {
   it('should use a map service to query features', function(done){
     server.respondWith('GET', mapServiceUrl + '0/query?returnGeometry=true&where=1%3D1&outSr=4326&outFields=*&f=json', JSON.stringify(sampleMapServiceQueryResponse));
 
-    var service = new L.esri.Services.MapService(mapServiceUrl);
+    var service = new L.esri.Services.MapService({url: mapServiceUrl});
 
     service.query().layer(0).run(function(error, featureCollection, raw){
       expect(featureCollection).to.deep.equal(sampleMapServiceCollection);
@@ -663,7 +663,7 @@ describe('L.esri.Tasks.Query', function () {
   it('should use a image service to query features', function(done){
     server.respondWith('GET', imageServiceUrl + 'query?returnGeometry=true&where=1%3D1&outSr=4326&outFields=*&pixelSize=1%2C1&f=json', JSON.stringify(sampleImageServiceQueryResponse));
 
-    var service = new L.esri.Services.MapService(imageServiceUrl);
+    var service = new L.esri.Services.MapService({url: imageServiceUrl});
 
     var request = service.query().pixelSize([1, 1]).run(function(error, featureCollection, raw){
       expect(featureCollection).to.deep.equal(sampleImageServiceCollection);
@@ -679,7 +679,7 @@ describe('L.esri.Tasks.Query', function () {
   it('should make GET queries with no service', function(done){
     server.respondWith('GET', mapServiceUrl + '0/query?returnGeometry=true&where=1%3D1&outSr=4326&outFields=*&f=json', JSON.stringify(sampleMapServiceQueryResponse));
 
-    var queryTask = new L.esri.Tasks.Query(mapServiceUrl + '0');
+    var queryTask = new L.esri.Tasks.Query({url: mapServiceUrl + '0'});
 
     var request = queryTask.where("1=1").run(function(error, featureCollection, raw){
       expect(featureCollection).to.deep.equal(sampleMapServiceCollection);
@@ -691,7 +691,7 @@ describe('L.esri.Tasks.Query', function () {
   });
 
   it('query tasks without services should make GET requests w/ JSONP', function(done){
-    var queryTask = new L.esri.Tasks.Query(mapServiceUrl + '0');
+    var queryTask = new L.esri.Tasks.Query({url: mapServiceUrl + '0'});
     queryTask.options.useCors = false;
 
     var request = queryTask.where("1=1").run(function(error, featureCollection, raw){
@@ -705,7 +705,7 @@ describe('L.esri.Tasks.Query', function () {
 
   it('query tasks without services should make POST requests', function(done){
     server.respondWith('POST', mapServiceUrl + '0/query', JSON.stringify(sampleMapServiceQueryResponse));
-    var queryTask = new L.esri.Tasks.Query(mapServiceUrl + '0');
+    var queryTask = new L.esri.Tasks.Query({url: mapServiceUrl + '0'});
     var request = queryTask.where(
       "this is a dumb way to make sure the request is more than 2000 characters" +
       "this is a dumb way to make sure the request is more than 2000 characters" +

--- a/src/Layers/BasemapLayer.js
+++ b/src/Layers/BasemapLayer.js
@@ -6,9 +6,9 @@
     statics: {
       TILES: {
         Streets: {
-          urlTemplate: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}',
           attributionUrl: 'https://static.arcgis.com/attribution/World_Street_Map',
           options: {
+            url: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}',
             hideLogo: false,
             logoPosition: 'bottomright',
             minZoom: 1,
@@ -18,9 +18,9 @@
           }
         },
         Topographic: {
-          urlTemplate: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}',
           attributionUrl: 'https://static.arcgis.com/attribution/World_Topo_Map',
           options: {
+            url: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}',
             hideLogo: false,
             logoPosition: 'bottomright',
             minZoom: 1,
@@ -30,9 +30,9 @@
           }
         },
         Oceans: {
-          urlTemplate: tileProtocol + '//{s}.arcgisonline.com/arcgis/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}',
           attributionUrl: 'https://static.arcgis.com/attribution/Ocean_Basemap',
           options: {
+            url: tileProtocol + '//{s}.arcgisonline.com/arcgis/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}',
             hideLogo: false,
             logoPosition: 'bottomright',
             minZoom: 1,
@@ -42,8 +42,8 @@
           }
         },
         OceansLabels: {
-          urlTemplate: tileProtocol + '//{s}.arcgisonline.com/arcgis/rest/services/Ocean/World_Ocean_Reference/MapServer/tile/{z}/{y}/{x}',
           options: {
+            url: tileProtocol + '//{s}.arcgisonline.com/arcgis/rest/services/Ocean/World_Ocean_Reference/MapServer/tile/{z}/{y}/{x}',
             hideLogo: true,
             logoPosition: 'bottomright',
             //pane: 'esri-label',
@@ -53,8 +53,8 @@
           }
         },
         NationalGeographic: {
-          urlTemplate: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}',
           options: {
+            url: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}',
             hideLogo: false,
             logoPosition: 'bottomright',
             minZoom: 1,
@@ -64,8 +64,8 @@
           }
         },
         DarkGray: {
-          urlTemplate: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}',
           options: {
+            url: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}',
             hideLogo: false,
             logoPosition: 'bottomright',
             minZoom: 1,
@@ -75,8 +75,8 @@
           }
         },
         DarkGrayLabels: {
-          urlTemplate: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Reference/MapServer/tile/{z}/{y}/{x}',
           options: {
+            url: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Reference/MapServer/tile/{z}/{y}/{x}',
             hideLogo: true,
             logoPosition: 'bottomright',
             //pane: 'esri-label',
@@ -86,8 +86,8 @@
           }
         },
         Gray: {
-          urlTemplate: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}',
           options: {
+            url: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}',
             hideLogo: false,
             logoPosition: 'bottomright',
             minZoom: 1,
@@ -97,19 +97,18 @@
           }
         },
         GrayLabels: {
-          urlTemplate: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Reference/MapServer/tile/{z}/{y}/{x}',
           options: {
+            url: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Reference/MapServer/tile/{z}/{y}/{x}',
             hideLogo: true,
             logoPosition: 'bottomright',
-            //pane: 'esri-label',
             minZoom: 1,
             maxZoom: 16,
             subdomains: ['server', 'services']
           }
         },
         Imagery: {
-          urlTemplate: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
           options: {
+            url: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
             hideLogo: false,
             logoPosition: 'bottomright',
             minZoom: 1,
@@ -119,20 +118,18 @@
           }
         },
         ImageryLabels: {
-          urlTemplate: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}',
           options: {
+            url: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}',
             hideLogo: true,
             logoPosition: 'bottomright',
-            //pane: 'esri-label',
             minZoom: 1,
             maxZoom: 19,
             subdomains: ['server', 'services']
           }
         },
         ImageryTransportation: {
-          urlTemplate: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/Reference/World_Transportation/MapServer/tile/{z}/{y}/{x}',
-          //pane: 'esri-label',
           options: {
+            url: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/Reference/World_Transportation/MapServer/tile/{z}/{y}/{x}',
             hideLogo: true,
             logoPosition: 'bottomright',
             minZoom: 1,
@@ -141,8 +138,8 @@
           }
         },
         ShadedRelief: {
-          urlTemplate: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/World_Shaded_Relief/MapServer/tile/{z}/{y}/{x}',
           options: {
+            url: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/World_Shaded_Relief/MapServer/tile/{z}/{y}/{x}',
             hideLogo: false,
             logoPosition: 'bottomright',
             minZoom: 1,
@@ -152,19 +149,18 @@
           }
         },
         ShadedReliefLabels: {
-          urlTemplate: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places_Alternate/MapServer/tile/{z}/{y}/{x}',
           options: {
+            url: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places_Alternate/MapServer/tile/{z}/{y}/{x}',
             hideLogo: true,
             logoPosition: 'bottomright',
-            //pane: 'esri-label',
             minZoom: 1,
             maxZoom: 12,
             subdomains: ['server', 'services']
           }
         },
         Terrain: {
-          urlTemplate: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer/tile/{z}/{y}/{x}',
           options: {
+            url: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer/tile/{z}/{y}/{x}',
             hideLogo: false,
             logoPosition: 'bottomright',
             minZoom: 1,
@@ -174,11 +170,10 @@
           }
         },
         TerrainLabels: {
-          urlTemplate: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/Reference/World_Reference_Overlay/MapServer/tile/{z}/{y}/{x}',
           options: {
+            url: tileProtocol + '//{s}.arcgisonline.com/ArcGIS/rest/services/Reference/World_Reference_Overlay/MapServer/tile/{z}/{y}/{x}',
             hideLogo: true,
             logoPosition: 'bottomright',
-            //pane: 'esri-label',
             minZoom: 1,
             maxZoom: 13,
             subdomains: ['server', 'services']
@@ -190,19 +185,21 @@
       var config;
 
       // set the config variable with the appropriate config object
-      if (typeof key === 'object' && key.urlTemplate && key.options){
+
+      //key.options.url??
+      if (typeof key === 'object' && key.options.url){
         config = key;
       } else if(typeof key === 'string' && EsriLeaflet.BasemapLayer.TILES[key]){
         config = EsriLeaflet.BasemapLayer.TILES[key];
       } else {
-        throw new Error('L.esri.BasemapLayer: Invalid parameter. Use one of "Streets", "Topographic", "Oceans", "OceansLabels", "NationalGeographic", "Gray", "GrayLabels", "DarkGray", "DarkGrayLabels", "Imagery", "ImageryLabels", "ImageryTransportation", "ShadedRelief", "ShadedReliefLabels", "Terrain" or "TerrainLabels"');
+        throw new Error('L.esri.BasemapLayer: Invalid parameter. Use either "Streets", "Topographic", "Oceans", "OceansLabels", "NationalGeographic", "Gray", "GrayLabels", "DarkGray", "DarkGrayLabels", "Imagery", "ImageryLabels", "ImageryTransportation", "ShadedRelief", "ShadedReliefLabels", "Terrain" or "TerrainLabels"');
       }
 
       // merge passed options into the config options
       var tileOptions = L.Util.extend(config.options, options);
 
       // call the initialize method on L.TileLayer to set everything up
-      L.TileLayer.prototype.initialize.call(this, config.urlTemplate, L.Util.setOptions(this, tileOptions));
+      L.TileLayer.prototype.initialize.call(this, L.Util.setOptions(this, tileOptions));
 
       // if this basemap requires dynamic attribution set it up
       if(config.attributionUrl){

--- a/src/Layers/BasemapLayer.js
+++ b/src/Layers/BasemapLayer.js
@@ -199,7 +199,7 @@
       var tileOptions = L.Util.extend(config.options, options);
 
       // call the initialize method on L.TileLayer to set everything up
-      L.TileLayer.prototype.initialize.call(this, L.Util.setOptions(this, tileOptions));
+      L.TileLayer.prototype.initialize.call(this, tileOptions.url, L.Util.setOptions(this, tileOptions));
 
       // if this basemap requires dynamic attribution set it up
       if(config.attributionUrl){

--- a/src/Layers/DynamicMapLayer.js
+++ b/src/Layers/DynamicMapLayer.js
@@ -11,6 +11,7 @@ EsriLeaflet.Layers.DynamicMapLayer = EsriLeaflet.Layers.RasterLayer.extend({
 
   initialize: function (options) {
     //this.url = EsriLeaflet.Util.cleanUrl(url);
+    options.url = EsriLeaflet.Util.cleanUrl(options.url);
     this._service = new EsriLeaflet.Services.MapService(options);
     this._service.on('authenticationrequired requeststart requestend requesterror requestsuccess', this._propagateEvent, this);
     L.Util.setOptions(this, options);
@@ -126,7 +127,7 @@ EsriLeaflet.Layers.DynamicMapLayer = EsriLeaflet.Layers.RasterLayer.extend({
       }, this);
     } else {
       params.f = 'image';
-      this._renderImage(this.url + 'export' + L.Util.getParamString(params), bounds);
+      this._renderImage(this.options.url + 'export' + L.Util.getParamString(params), bounds);
     }
   }
 });

--- a/src/Layers/DynamicMapLayer.js
+++ b/src/Layers/DynamicMapLayer.js
@@ -9,9 +9,9 @@ EsriLeaflet.Layers.DynamicMapLayer = EsriLeaflet.Layers.RasterLayer.extend({
     transparent: true
   },
 
-  initialize: function (url, options) {
-    this.url = EsriLeaflet.Util.cleanUrl(url);
-    this._service = new EsriLeaflet.Services.MapService(this.url, options);
+  initialize: function (options) {
+    //this.url = EsriLeaflet.Util.cleanUrl(url);
+    this._service = new EsriLeaflet.Services.MapService(options);
     this._service.on('authenticationrequired requeststart requestend requesterror requestsuccess', this._propagateEvent, this);
     L.Util.setOptions(this, options);
   },
@@ -133,10 +133,10 @@ EsriLeaflet.Layers.DynamicMapLayer = EsriLeaflet.Layers.RasterLayer.extend({
 
 EsriLeaflet.DynamicMapLayer = EsriLeaflet.Layers.DynamicMapLayer;
 
-EsriLeaflet.Layers.dynamicMapLayer = function(url, options){
-  return new EsriLeaflet.Layers.DynamicMapLayer(url, options);
+EsriLeaflet.Layers.dynamicMapLayer = function(options){
+  return new EsriLeaflet.Layers.DynamicMapLayer(options);
 };
 
-EsriLeaflet.dynamicMapLayer = function(url, options){
-  return new EsriLeaflet.Layers.DynamicMapLayer(url, options);
+EsriLeaflet.dynamicMapLayer = function(options){
+  return new EsriLeaflet.Layers.DynamicMapLayer(options);
 };

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -8,8 +8,8 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
    * Constructor
    */
 
-  initialize: function (url, options) {
-    EsriLeaflet.Layers.FeatureManager.prototype.initialize.call(this, url, options);
+  initialize: function (options) {
+    EsriLeaflet.Layers.FeatureManager.prototype.initialize.call(this, options);
 
     options = L.setOptions(this, options);
 
@@ -239,10 +239,10 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
 
 EsriLeaflet.FeatureLayer = EsriLeaflet.Layers.FeatureLayer;
 
-EsriLeaflet.Layers.featureLayer = function(url, options){
-  return new EsriLeaflet.Layers.FeatureLayer(url, options);
+EsriLeaflet.Layers.featureLayer = function(options){
+  return new EsriLeaflet.Layers.FeatureLayer(options);
 };
 
-EsriLeaflet.featureLayer = function(url, options){
-  return new EsriLeaflet.Layers.FeatureLayer(url, options);
+EsriLeaflet.featureLayer = function(options){
+  return new EsriLeaflet.Layers.FeatureLayer(options);
 };

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -21,14 +21,15 @@
      * Constructor
      */
 
-    initialize: function (url, options) {
+    initialize: function (options) {
       EsriLeaflet.Layers.FeatureGrid.prototype.initialize.call(this, options);
 
       options = L.setOptions(this, options);
 
-      this.url = EsriLeaflet.Util.cleanUrl(url);
+      //not sure if you can do this
+      options.url = EsriLeaflet.Util.cleanUrl(options.url);
 
-      this._service = new EsriLeaflet.Services.FeatureLayer(this.url, options);
+      this._service = new EsriLeaflet.Services.FeatureLayer(options);
 
       //use case insensitive regex to look for common fieldnames used for indexing
       /*global console */

--- a/src/Layers/ImageMapLayer.js
+++ b/src/Layers/ImageMapLayer.js
@@ -14,9 +14,7 @@ EsriLeaflet.Layers.ImageMapLayer = EsriLeaflet.Layers.RasterLayer.extend({
   },
 
   initialize: function (options) {
-    options.url = EsriLeaflet.Util.cleanUrl(options.url);
-    //this seems a little weird
-    this.url = options.url;
+    this.url = EsriLeaflet.Util.cleanUrl(options.url);
     this._service = new EsriLeaflet.Services.ImageService(options);
     this._service.on('authenticationrequired requeststart requestend requesterror requestsuccess', this._propagateEvent, this);
     L.Util.setOptions(this, options);

--- a/src/Layers/ImageMapLayer.js
+++ b/src/Layers/ImageMapLayer.js
@@ -13,9 +13,9 @@ EsriLeaflet.Layers.ImageMapLayer = EsriLeaflet.Layers.RasterLayer.extend({
     return this._service.identify();
   },
 
-  initialize: function (url, options) {
-    this.url = EsriLeaflet.Util.cleanUrl(url);
-    this._service = new EsriLeaflet.Services.ImageService(this.url, options);
+  initialize: function (options) {
+    //this.url = EsriLeaflet.Util.cleanUrl(options.url);
+    this._service = new EsriLeaflet.Services.ImageService(options);
     this._service.on('authenticationrequired requeststart requestend requesterror requestsuccess', this._propagateEvent, this);
     L.Util.setOptions(this, options);
   },
@@ -182,10 +182,10 @@ EsriLeaflet.Layers.ImageMapLayer = EsriLeaflet.Layers.RasterLayer.extend({
 
 EsriLeaflet.ImageMapLayer = EsriLeaflet.Layers.ImageMapLayer;
 
-EsriLeaflet.Layers.imageMapLayer = function (url, options) {
-  return new EsriLeaflet.Layers.ImageMapLayer(url, options);
+EsriLeaflet.Layers.imageMapLayer = function (options) {
+  return new EsriLeaflet.Layers.ImageMapLayer(options);
 };
 
-EsriLeaflet.imageMapLayer = function (url, options) {
-  return new EsriLeaflet.Layers.ImageMapLayer(url, options);
+EsriLeaflet.imageMapLayer = function (options) {
+  return new EsriLeaflet.Layers.ImageMapLayer(options);
 };

--- a/src/Layers/ImageMapLayer.js
+++ b/src/Layers/ImageMapLayer.js
@@ -14,7 +14,9 @@ EsriLeaflet.Layers.ImageMapLayer = EsriLeaflet.Layers.RasterLayer.extend({
   },
 
   initialize: function (options) {
-    //this.url = EsriLeaflet.Util.cleanUrl(options.url);
+    options.url = EsriLeaflet.Util.cleanUrl(options.url);
+    //this seems a little weird
+    this.url = options.url;
     this._service = new EsriLeaflet.Services.ImageService(options);
     this._service.on('authenticationrequired requeststart requestend requesterror requestsuccess', this._propagateEvent, this);
     L.Util.setOptions(this, options);

--- a/src/Layers/TiledMapLayer.js
+++ b/src/Layers/TiledMapLayer.js
@@ -3,9 +3,9 @@ EsriLeaflet.Layers.TiledMapLayer = L.TileLayer.extend({
     options = L.Util.setOptions(this, options);
 
     // set the urls
-    this.url = L.esri.Util.cleanUrl(options.url);
+    options.url = L.esri.Util.cleanUrl(options.url);
     this.tileUrl = L.esri.Util.cleanUrl(options.url) + 'tile/{z}/{y}/{x}';
-    this._service = new L.esri.Services.MapService(this.url, options);
+    this._service = new L.esri.Services.MapService(options);
     this._service.on('authenticationrequired requeststart requestend requesterror requestsuccess', this._propagateEvent, this);
 
     //if this is looking at the AGO tiles subdomain insert the subdomain placeholder

--- a/src/Layers/TiledMapLayer.js
+++ b/src/Layers/TiledMapLayer.js
@@ -1,10 +1,10 @@
 EsriLeaflet.Layers.TiledMapLayer = L.TileLayer.extend({
-  initialize: function(url, options){
+  initialize: function(options){
     options = L.Util.setOptions(this, options);
 
     // set the urls
-    this.url = L.esri.Util.cleanUrl(url);
-    this.tileUrl = L.esri.Util.cleanUrl(url) + 'tile/{z}/{y}/{x}';
+    this.url = L.esri.Util.cleanUrl(options.url);
+    this.tileUrl = L.esri.Util.cleanUrl(options.url) + 'tile/{z}/{y}/{x}';
     this._service = new L.esri.Services.MapService(this.url, options);
     this._service.on('authenticationrequired requeststart requestend requesterror requestsuccess', this._propagateEvent, this);
 
@@ -52,10 +52,10 @@ EsriLeaflet.Layers.TiledMapLayer = L.TileLayer.extend({
 
 L.esri.TiledMapLayer = L.esri.Layers.tiledMapLayer;
 
-L.esri.Layers.tiledMapLayer = function(url, options){
-  return new L.esri.Layers.TiledMapLayer(url, options);
+L.esri.Layers.tiledMapLayer = function(options){
+  return new L.esri.Layers.TiledMapLayer(options);
 };
 
-L.esri.tiledMapLayer = function(url, options){
-  return new L.esri.Layers.TiledMapLayer(url, options);
+L.esri.tiledMapLayer = function(options){
+  return new L.esri.Layers.TiledMapLayer(options);
 };

--- a/src/Services/FeatureLayer.js
+++ b/src/Services/FeatureLayer.js
@@ -49,6 +49,6 @@ EsriLeaflet.Services.FeatureLayer = EsriLeaflet.Services.Service.extend({
 
 });
 
-EsriLeaflet.Services.featureLayer = function(url, options) {
-  return new EsriLeaflet.Services.FeatureLayer(url, options);
+EsriLeaflet.Services.featureLayer = function(options) {
+  return new EsriLeaflet.Services.FeatureLayer(options);
 };

--- a/src/Services/ImageService.js
+++ b/src/Services/ImageService.js
@@ -9,6 +9,6 @@ EsriLeaflet.Services.ImageService = EsriLeaflet.Services.Service.extend({
   }
 });
 
-EsriLeaflet.Services.imageService = function(url, params){
-  return new EsriLeaflet.Services.ImageService(url, params);
+EsriLeaflet.Services.imageService = function(params){
+  return new EsriLeaflet.Services.ImageService(params);
 };

--- a/src/Services/MapService.js
+++ b/src/Services/MapService.js
@@ -14,6 +14,6 @@ EsriLeaflet.Services.MapService = EsriLeaflet.Services.Service.extend({
 
 });
 
-EsriLeaflet.Services.mapService = function(url, params){
-  return new EsriLeaflet.Services.MapService(url, params);
+EsriLeaflet.Services.mapService = function(params){
+  return new EsriLeaflet.Services.MapService(params);
 };

--- a/src/Services/Service.js
+++ b/src/Services/Service.js
@@ -11,7 +11,6 @@ EsriLeaflet.Services.Service = L.Class.extend({
     this.url = EsriLeaflet.Util.cleanUrl(options.url);
     this._requestQueue = [];
     this._authenticating = false;
-    //is it a problem that this includes options.url now?
     L.Util.setOptions(this, options);
   },
 

--- a/src/Services/Service.js
+++ b/src/Services/Service.js
@@ -7,10 +7,11 @@ EsriLeaflet.Services.Service = L.Class.extend({
     useCors: EsriLeaflet.Support.CORS
   },
 
-  initialize: function (url, options) {
-    this.url = EsriLeaflet.Util.cleanUrl(url);
+  initialize: function (options) {
+    this.url = EsriLeaflet.Util.cleanUrl(options.url);
     this._requestQueue = [];
     this._authenticating = false;
+    //is it a problem that this includes options.url now?
     L.Util.setOptions(this, options);
   },
 
@@ -117,6 +118,6 @@ EsriLeaflet.Services.Service = L.Class.extend({
 
 });
 
-EsriLeaflet.Services.service = function(url, params){
-  return new EsriLeaflet.Services.Service(url, params);
+EsriLeaflet.Services.service = function(params){
+  return new EsriLeaflet.Services.Service(params);
 };

--- a/src/Tasks/Find.js
+++ b/src/Tasks/Find.js
@@ -46,6 +46,6 @@ EsriLeaflet.Tasks.Find = EsriLeaflet.Tasks.Task.extend({
   }
 });
 
-EsriLeaflet.Tasks.find = function (url, params) {
-  return new EsriLeaflet.Tasks.Find(url, params);
+EsriLeaflet.Tasks.find = function (params) {
+  return new EsriLeaflet.Tasks.Find(params);
 };

--- a/src/Tasks/IdentifyFeatures.js
+++ b/src/Tasks/IdentifyFeatures.js
@@ -47,6 +47,6 @@ EsriLeaflet.Tasks.IdentifyFeatures = EsriLeaflet.Tasks.Identify.extend({
 
 });
 
-EsriLeaflet.Tasks.identifyFeatures = function(url, params){
-  return new EsriLeaflet.Tasks.IdentifyFeatures(url, params);
+EsriLeaflet.Tasks.identifyFeatures = function(params){
+  return new EsriLeaflet.Tasks.IdentifyFeatures(params);
 };

--- a/src/Tasks/IdentifyImage.js
+++ b/src/Tasks/IdentifyImage.js
@@ -89,6 +89,6 @@ EsriLeaflet.Tasks.IdentifyImage = EsriLeaflet.Tasks.Identify.extend({
 
 });
 
-EsriLeaflet.Tasks.identifyImage = function(url, params){
-  return new EsriLeaflet.Tasks.IdentifyImage(url, params);
+EsriLeaflet.Tasks.identifyImage = function(params){
+  return new EsriLeaflet.Tasks.IdentifyImage(params);
 };

--- a/src/Tasks/Query.js
+++ b/src/Tasks/Query.js
@@ -214,6 +214,6 @@ EsriLeaflet.Tasks.Query = EsriLeaflet.Tasks.Task.extend({
   }
 });
 
-EsriLeaflet.Tasks.query = function(url, params){
-  return new EsriLeaflet.Tasks.Query(url, params);
+EsriLeaflet.Tasks.query = function(params){
+  return new EsriLeaflet.Tasks.Query(params);
 };

--- a/src/Tasks/Task.js
+++ b/src/Tasks/Task.js
@@ -31,7 +31,7 @@ EsriLeaflet.Tasks.Task = L.Class.extend({
 
   initialize: function(endpoint){
     // options can be either a url to an ArcGIS Rest Service or an instance of EsriLeaflet.Service
-    if(endpoint.url && endpoint.request){
+    if(endpoint.request){
       this._service = endpoint;
       this.url = endpoint.options.url;
     } else {

--- a/src/Tasks/Task.js
+++ b/src/Tasks/Task.js
@@ -31,11 +31,13 @@ EsriLeaflet.Tasks.Task = L.Class.extend({
 
   initialize: function(endpoint, options){
     // endpoint can be either a url to an ArcGIS Rest Service or an instance of EsriLeaflet.Service
-    if(endpoint.url && endpoint.request){
+
+    //not sure if this is right or not
+    if(options.url && endpoint.request){
       this._service = endpoint;
-      this.url = endpoint.url;
+      this.url = endpoint.options.url;
     } else {
-      this.url = EsriLeaflet.Util.cleanUrl(endpoint);
+      this.url = EsriLeaflet.Util.cleanUrl(options.url);
     }
 
     // clone default params into this object

--- a/src/Tasks/Task.js
+++ b/src/Tasks/Task.js
@@ -30,14 +30,12 @@ EsriLeaflet.Tasks.Task = L.Class.extend({
   },
 
   initialize: function(endpoint){
-    // options can be either a url to an ArcGIS Rest Service or an instance of EsriLeaflet.Service
+    // endpoint can be either be a url to an ArcGIS Rest Service (and other options) or an instance of EsriLeaflet.Service
     if(endpoint.request){
       this._service = endpoint;
       this.url = endpoint.options.url;
     } else {
-      //this is actually an options object
       this.url = EsriLeaflet.Util.cleanUrl(endpoint.url);
-      endpoint.url = EsriLeaflet.Util.cleanUrl(endpoint.url);
     }
 
     // clone default params into this object

--- a/src/Tasks/Task.js
+++ b/src/Tasks/Task.js
@@ -37,6 +37,7 @@ EsriLeaflet.Tasks.Task = L.Class.extend({
     } else {
       //this is actually an options object
       this.url = EsriLeaflet.Util.cleanUrl(endpoint.url);
+      endpoint.url = EsriLeaflet.Util.cleanUrl(endpoint.url);
     }
 
     // clone default params into this object
@@ -50,7 +51,7 @@ EsriLeaflet.Tasks.Task = L.Class.extend({
       }
     }
 
-    L.Util.setOptions(this, endpoint.options);
+    L.Util.setOptions(this, endpoint);
   },
 
   token: function(token){

--- a/src/Tasks/Task.js
+++ b/src/Tasks/Task.js
@@ -29,15 +29,14 @@ EsriLeaflet.Tasks.Task = L.Class.extend({
     }
   },
 
-  initialize: function(endpoint, options){
-    // endpoint can be either a url to an ArcGIS Rest Service or an instance of EsriLeaflet.Service
-
-    //not sure if this is right or not
-    if(options.url && endpoint.request){
+  initialize: function(endpoint){
+    // options can be either a url to an ArcGIS Rest Service or an instance of EsriLeaflet.Service
+    if(endpoint.url && endpoint.request){
       this._service = endpoint;
       this.url = endpoint.options.url;
     } else {
-      this.url = EsriLeaflet.Util.cleanUrl(options.url);
+      //this is actually an options object
+      this.url = EsriLeaflet.Util.cleanUrl(endpoint.url);
     }
 
     // clone default params into this object
@@ -51,7 +50,7 @@ EsriLeaflet.Tasks.Task = L.Class.extend({
       }
     }
 
-    L.Util.setOptions(this, options);
+    L.Util.setOptions(this, endpoint.options);
   },
 
   token: function(token){


### PR DESCRIPTION
attempt to resolve #420

this is my first pass at refactoring Service and Task to expect `{url: 'myUrl'}`

i've manually tested about a dozen samples that demo all the different classes in the API and they all behave as expected
i also refactored the tests (which helped me catch a few bugs along the way).
all new tests are passing.

i'll wait to squash until everyone's happy with the code.