### PR TITLE
RC5 documentation updates

### DIFF
--- a/api-reference/index.html
+++ b/api-reference/index.html
@@ -7,11 +7,11 @@
 <head>
   <meta charset="utf-8">
 
-  
-    <title>API Reference | Esri Leaflet</title>
-  
 
-  
+    <title>API Reference | Esri Leaflet</title>
+
+
+
 
   <meta name="description" content="Esri Leaflet">
   <meta name="viewport" content="width=device-width">
@@ -60,10 +60,10 @@
     </div>
     <div id="background-map" class="background-map"></div>
 
-  
+
 
 <div class="container white">
-  
+
 
 <aside class="sidebar">
   <h5>L.esri</h5>
@@ -98,6 +98,7 @@
     <a href="../../../esri-leaflet/api-reference/tasks/identify-image.html">Identify Image</a>
     <a href="../../../esri-leaflet/api-reference/tasks/query.html">Query</a>
     <a href="../../../esri-leaflet/api-reference/tasks/find.html">Find</a>
+    <a href="../../../esri-leaflet/api-reference/tasks/task.html">Task</a>
   </nav>
 
   <h5>Misc.</h5>

--- a/api-reference/layers/basemap-layer.html
+++ b/api-reference/layers/basemap-layer.html
@@ -7,11 +7,11 @@
 <head>
   <meta charset="utf-8">
 
-  
-    <title>L.esri.Layers.BasemapLayer | Esri Leaflet</title>
-  
 
-  
+    <title>L.esri.Layers.BasemapLayer | Esri Leaflet</title>
+
+
+
 
   <meta name="description" content="Esri Leaflet">
   <meta name="viewport" content="width=device-width">
@@ -60,10 +60,10 @@
     </div>
     <div id="background-map" class="background-map"></div>
 
-  
+
 
 <div class="container white">
-  
+
 
 <aside class="sidebar">
   <h5>L.esri</h5>
@@ -98,6 +98,7 @@
     <a href="../../../../esri-leaflet/api-reference/tasks/identify-image.html">Identify Image</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/query.html">Query</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/find.html">Find</a>
+    <a href="../../../../esri-leaflet/api-reference/tasks/task.html">Task</a>
   </nav>
 
   <h5>Misc.</h5>

--- a/api-reference/layers/clustered-feature-layer.html
+++ b/api-reference/layers/clustered-feature-layer.html
@@ -7,11 +7,11 @@
 <head>
   <meta charset="utf-8">
 
-  
-    <title>L.esri.Layers.ClusteredFeatureLayer | Esri Leaflet</title>
-  
 
-  
+    <title>L.esri.Layers.ClusteredFeatureLayer | Esri Leaflet</title>
+
+
+
 
   <meta name="description" content="Esri Leaflet">
   <meta name="viewport" content="width=device-width">
@@ -60,10 +60,10 @@
     </div>
     <div id="background-map" class="background-map"></div>
 
-  
+
 
 <div class="container white">
-  
+
 
 <aside class="sidebar">
   <h5>L.esri</h5>
@@ -98,6 +98,7 @@
     <a href="../../../../esri-leaflet/api-reference/tasks/identify-image.html">Identify Image</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/query.html">Query</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/find.html">Find</a>
+    <a href="../../../../esri-leaflet/api-reference/tasks/task.html">Task</a>
   </nav>
 
   <h5>Misc.</h5>

--- a/api-reference/layers/dynamic-map-layer.html
+++ b/api-reference/layers/dynamic-map-layer.html
@@ -7,11 +7,11 @@
 <head>
   <meta charset="utf-8">
 
-  
-    <title>L.esri.Layers.DynamicMapLayer | Esri Leaflet</title>
-  
 
-  
+    <title>L.esri.Layers.DynamicMapLayer | Esri Leaflet</title>
+
+
+
 
   <meta name="description" content="Esri Leaflet">
   <meta name="viewport" content="width=device-width">
@@ -60,10 +60,10 @@
     </div>
     <div id="background-map" class="background-map"></div>
 
-  
+
 
 <div class="container white">
-  
+
 
 <aside class="sidebar">
   <h5>L.esri</h5>
@@ -98,6 +98,7 @@
     <a href="../../../../esri-leaflet/api-reference/tasks/identify-image.html">Identify Image</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/query.html">Query</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/find.html">Find</a>
+    <a href="../../../../esri-leaflet/api-reference/tasks/task.html">Task</a>
   </nav>
 
   <h5>Misc.</h5>

--- a/api-reference/layers/feature-layer.html
+++ b/api-reference/layers/feature-layer.html
@@ -7,11 +7,11 @@
 <head>
   <meta charset="utf-8">
 
-  
-    <title>L.esri.Layers.FeatureLayer | Esri Leaflet</title>
-  
 
-  
+    <title>L.esri.Layers.FeatureLayer | Esri Leaflet</title>
+
+
+
 
   <meta name="description" content="Esri Leaflet">
   <meta name="viewport" content="width=device-width">
@@ -60,10 +60,10 @@
     </div>
     <div id="background-map" class="background-map"></div>
 
-  
+
 
 <div class="container white">
-  
+
 
 <aside class="sidebar">
   <h5>L.esri</h5>
@@ -98,6 +98,7 @@
     <a href="../../../../esri-leaflet/api-reference/tasks/identify-image.html">Identify Image</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/query.html">Query</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/find.html">Find</a>
+    <a href="../../../../esri-leaflet/api-reference/tasks/task.html">Task</a>
   </nav>
 
   <h5>Misc.</h5>
@@ -115,7 +116,7 @@
 <p>This particular service contains only one Feature Layer. Here is the Feature Layer URL </p>
 <pre><code>http://services.arcgis.com/rOo16HdIMeOBI4Mb/ArcGIS/rest/services/Neighborhoods_pdx/FeatureServer/0</code></pre>
 <p>Note that the Feature Layer URL ends in <code>/FeatureServer/{LAYER_ID}</code>.</p>
-<p>You can create a new empty feature service witha  single layer on the <a href="https://developers.arcgis.com/en/hosted-data/#/new">ArcGIS for Devleopers website</a> or you can use ArcGIS Online to <a href="https://developers.arcgis.com/tools/csv-to-feature-service/">create a Feature Service from a CSV or Shapefile</a>.</p>
+<p>You can create a new empty feature service with a single layer on the <a href="https://developers.arcgis.com/en/hosted-data/#/new">ArcGIS for Developers website</a> or you can use ArcGIS Online to <a href="https://developers.arcgis.com/tools/csv-to-feature-service/">create a Feature Service from a CSV or Shapefile</a>.</p>
 <h3 id="constructor">Constructor</h3>
 <table>
     <thead>
@@ -127,7 +128,7 @@
     <tbody>
         <tr>
             <td><code class="nobr">new L.esri.Layers.FeatureLayer(<nobr class="param"><span>&lt;String&gt;</span> <code>url</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code><br><br><code class="nobr">L.esri.Layers.featureLayer(<nobr class="param"><span>&lt;String&gt;</span> <code>url</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code><br><br><code class="nobr">new L.esri.FeatureLayer(<nobr class="param"><span>&lt;String&gt;</span> <code>url</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code><br><br><code class="nobr">L.esri.featureLayer(<nobr class="param"><span>&lt;String&gt;</span> <code>url</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code></td>
-            <td><code>url</code> should be the URL to the Feature Layer.</td>
+            <td>URL of the Feature Layer.</td>
         </tr>
     </tbody>
 </table>
@@ -196,6 +197,21 @@
             <td><code>precision</code></td>
             <td><code>Integer</code></td>
             <td>How many digits of precision to request from the server. <a href="http://en.wikipedia.org/wiki/Decimal_degrees">Wikipedia</a> has a great reference of digit precision to meters.</td>
+        </tr>
+        <tr>
+            <td><code>minZoom</code></td>
+            <td><code>Integer</code></td>
+            <td>Minimum zoom level of the map that features will display. example:  <code>minZoom:0</code></td>
+        </tr>
+        <tr>
+            <td><code>maxZoom</code></td>
+            <td><code>Integer</code></td>
+            <td>Maximum zoom level of the map that features will display. example:  <code>maxZoom:19</code></td>
+        </tr>
+        <tr>
+            <td><code>cacheLayers</code></td>
+            <td><code>true</code></td>
+            <td>turning off caching for features outside the viewport will preserve memory</td>
         </tr>
         <tr>
             <td><code>token</code></td>

--- a/api-reference/layers/heatmap-feature-layer.html
+++ b/api-reference/layers/heatmap-feature-layer.html
@@ -7,11 +7,11 @@
 <head>
   <meta charset="utf-8">
 
-  
-    <title>L.esri.Layers.HeatMapFeatureLayer | Esri Leaflet</title>
-  
 
-  
+    <title>L.esri.Layers.HeatMapFeatureLayer | Esri Leaflet</title>
+
+
+
 
   <meta name="description" content="Esri Leaflet">
   <meta name="viewport" content="width=device-width">
@@ -60,10 +60,10 @@
     </div>
     <div id="background-map" class="background-map"></div>
 
-  
+
 
 <div class="container white">
-  
+
 
 <aside class="sidebar">
   <h5>L.esri</h5>
@@ -98,6 +98,7 @@
     <a href="../../../../esri-leaflet/api-reference/tasks/identify-image.html">Identify Image</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/query.html">Query</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/find.html">Find</a>
+    <a href="../../../../esri-leaflet/api-reference/tasks/task.html">Task</a>
   </nav>
 
   <h5>Misc.</h5>

--- a/api-reference/layers/image-map-layer.html
+++ b/api-reference/layers/image-map-layer.html
@@ -7,11 +7,11 @@
 <head>
   <meta charset="utf-8">
 
-  
-    <title>L.esri.Layers.ImageMapLayer | Esri Leaflet</title>
-  
 
-  
+    <title>L.esri.Layers.ImageMapLayer | Esri Leaflet</title>
+
+
+
 
   <meta name="description" content="Esri Leaflet">
   <meta name="viewport" content="width=device-width">
@@ -60,10 +60,10 @@
     </div>
     <div id="background-map" class="background-map"></div>
 
-  
+
 
 <div class="container white">
-  
+
 
 <aside class="sidebar">
   <h5>L.esri</h5>
@@ -98,6 +98,7 @@
     <a href="../../../../esri-leaflet/api-reference/tasks/identify-image.html">Identify Image</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/query.html">Query</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/find.html">Find</a>
+    <a href="../../../../esri-leaflet/api-reference/tasks/task.html">Task</a>
   </nav>
 
   <h5>Misc.</h5>

--- a/api-reference/layers/index.html
+++ b/api-reference/layers/index.html
@@ -7,11 +7,11 @@
 <head>
   <meta charset="utf-8">
 
-  
-    <title>Esri Leaflet</title>
-  
 
-  
+    <title>Esri Leaflet</title>
+
+
+
 
   <meta name="description" content="Esri Leaflet">
   <meta name="viewport" content="width=device-width">
@@ -60,10 +60,10 @@
     </div>
     <div id="background-map" class="background-map"></div>
 
-  
+
 
 <div class="container white">
-  
+
 
 <aside class="sidebar">
   <h5>L.esri</h5>
@@ -98,6 +98,7 @@
     <a href="../../../../esri-leaflet/api-reference/tasks/identify-image.html">Identify Image</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/query.html">Query</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/find.html">Find</a>
+    <a href="../../../../esri-leaflet/api-reference/tasks/task.html">Task</a>
   </nav>
 
   <h5>Misc.</h5>

--- a/api-reference/layers/raster-layer.html
+++ b/api-reference/layers/raster-layer.html
@@ -7,11 +7,11 @@
 <head>
   <meta charset="utf-8">
 
-  
-    <title>L.esri.Layers.RasterLayer | Esri Leaflet</title>
-  
 
-  
+    <title>L.esri.Layers.RasterLayer | Esri Leaflet</title>
+
+
+
 
   <meta name="description" content="Esri Leaflet">
   <meta name="viewport" content="width=device-width">
@@ -60,10 +60,10 @@
     </div>
     <div id="background-map" class="background-map"></div>
 
-  
+
 
 <div class="container white">
-  
+
 
 <aside class="sidebar">
   <h5>L.esri</h5>
@@ -98,6 +98,7 @@
     <a href="../../../../esri-leaflet/api-reference/tasks/identify-image.html">Identify Image</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/query.html">Query</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/find.html">Find</a>
+    <a href="../../../../esri-leaflet/api-reference/tasks/task.html">Task</a>
   </nav>
 
   <h5>Misc.</h5>

--- a/api-reference/layers/tiled-map-layer.html
+++ b/api-reference/layers/tiled-map-layer.html
@@ -7,11 +7,11 @@
 <head>
   <meta charset="utf-8">
 
-  
-    <title>L.esri.Layers.TiledMapLayer | Esri Leaflet</title>
-  
 
-  
+    <title>L.esri.Layers.TiledMapLayer | Esri Leaflet</title>
+
+
+
 
   <meta name="description" content="Esri Leaflet">
   <meta name="viewport" content="width=device-width">
@@ -60,10 +60,10 @@
     </div>
     <div id="background-map" class="background-map"></div>
 
-  
+
 
 <div class="container white">
-  
+
 
 <aside class="sidebar">
   <h5>L.esri</h5>
@@ -98,6 +98,7 @@
     <a href="../../../../esri-leaflet/api-reference/tasks/identify-image.html">Identify Image</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/query.html">Query</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/find.html">Find</a>
+    <a href="../../../../esri-leaflet/api-reference/tasks/task.html">Task</a>
   </nav>
 
   <h5>Misc.</h5>

--- a/api-reference/services/feature-layer.html
+++ b/api-reference/services/feature-layer.html
@@ -7,11 +7,11 @@
 <head>
   <meta charset="utf-8">
 
-  
-    <title>L.esri.Services.FeatureLayer | Esri Leaflet</title>
-  
 
-  
+    <title>L.esri.Services.FeatureLayer | Esri Leaflet</title>
+
+
+
 
   <meta name="description" content="Esri Leaflet">
   <meta name="viewport" content="width=device-width">
@@ -60,10 +60,10 @@
     </div>
     <div id="background-map" class="background-map"></div>
 
-  
+
 
 <div class="container white">
-  
+
 
 <aside class="sidebar">
   <h5>L.esri</h5>
@@ -98,6 +98,7 @@
     <a href="../../../../esri-leaflet/api-reference/tasks/identify-image.html">Identify Image</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/query.html">Query</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/find.html">Find</a>
+    <a href="../../../../esri-leaflet/api-reference/tasks/task.html">Task</a>
   </nav>
 
   <h5>Misc.</h5>
@@ -109,7 +110,7 @@
 <div class="main-content">
   <h1 id="l-esri-services-featurelayer">L.esri.Services.FeatureLayer</h1>
 <p>Inherits from <a href="../../../../esri-leaflet/api-reference/services/service.html"><code>L.esri.Service</code></a></p>
-<p><code>L.esri.Services.FeatureLayer</code> is an abstraction interacting with Feature Layers running on ArcGIS Online and ArcGIS server that allows you to make requests to the API, as well as query, add, update and remove features from the service.</p>
+<p><code>L.esri.Services.FeatureLayer</code> is an abstraction for interacting with Feature Layers running on ArcGIS Online and ArcGIS Server that allows you to make requests to the API, as well as query, add, update and remove features from the service.</p>
 <h3 id="constructor">Constructor</h3>
 <table>
     <thead>
@@ -120,8 +121,8 @@
     </thead>
     <tbody>
         <tr>
-            <td><code class="nobr">new L.esri.Services.FeatureLayer(<nobr class="param"><span>&lt;String&gt;</span> <code>url</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code><br><br><code class="nobr">L.esri.Services.featureLayer(<nobr class="param"><span>&lt;String&gt;</span> <code>url</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code></td>
-            <td>The <code>url</code> parameter is the URL to the ArcGIS Server or ArcGIS Online feature layer you would like to consume.</td>
+            <td><code class="nobr">new L.esri.Services.FeatureLayer(<nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code><br><br><code class="nobr">L.esri.Services.featureLayer(<nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code></td>
+            <td>Options includes a <code>url</code> parameter which refers to the ArcGIS Server or ArcGIS Online service you would like to consume.</td>
         </tr>
     </tbody>
 </table>
@@ -145,12 +146,15 @@
             <td><code>this</code></td>
             <td>
                 Returns a new <a href="../../../../esri-leaflet/api-reference/tasks/query.html"><code>L.esri.Tasks.Query</code></a> object that can be used to query this layer.
-<pre class="js"><code>featureLayer.query()
-            .within(latlngbounds)
-            .where(&quot;Direction = &#39;WEST&#39;&quot;)
-            .run(function(error, featureCollection, response){
-              console.log(featureCollection);
-            });</code></pre>
+<pre class="js">
+<code>
+featureLayer.query()
+  .within(latlngbounds)
+  .where(&quot;Direction = &#39;WEST&#39;&quot;)
+  .run(function(error, featureCollection, response){
+    console.log(featureCollection);
+  });
+</code></pre>
             </td>
         </tr>
         <tr>

--- a/api-reference/services/image-service.html
+++ b/api-reference/services/image-service.html
@@ -7,11 +7,11 @@
 <head>
   <meta charset="utf-8">
 
-  
-    <title>L.esri.Services.ImageService | Esri Leaflet</title>
-  
 
-  
+    <title>L.esri.Services.ImageService | Esri Leaflet</title>
+
+
+
 
   <meta name="description" content="Esri Leaflet">
   <meta name="viewport" content="width=device-width">
@@ -60,10 +60,10 @@
     </div>
     <div id="background-map" class="background-map"></div>
 
-  
+
 
 <div class="container white">
-  
+
 
 <aside class="sidebar">
   <h5>L.esri</h5>
@@ -98,6 +98,7 @@
     <a href="../../../../esri-leaflet/api-reference/tasks/identify-image.html">Identify Image</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/query.html">Query</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/find.html">Find</a>
+    <a href="../../../../esri-leaflet/api-reference/tasks/task.html">Task</a>
   </nav>
 
   <h5>Misc.</h5>
@@ -109,7 +110,7 @@
 <div class="main-content">
   <h1 id="l-esri-services-imageservice">L.esri.Services.ImageService</h1>
 <p>Inherits from <a href="../../../../esri-leaflet/api-reference/services/service.html"><code>L.esri.Service</code></a></p>
-<p><code>L.esri.Services.ImageService</code> is an abstraction interacting with Image Services running on ArcGIS Online and ArcGIS server that allows you to make requests to the API, as well as query and identify features on the service.</p>
+<p><code>L.esri.Services.ImageService</code> is an abstraction for interacting with Map Services running on ArcGIS Online and ArcGIS Server that allows you to make requests to the API, as well as query and identify published features.</p>
 <h3 id="constructor">Constructor</h3>
 <table>
     <thead>
@@ -120,8 +121,8 @@
     </thead>
     <tbody>
         <tr>
-            <td><code class="nobr">new L.esri.Services.ImageService(<nobr class="param"><span>&lt;String&gt;</span> <code>url</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code><br><br><code class="nobr">L.esri.Services.imageService(<nobr class="param"><span>&lt;String&gt;</span> <code>url</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code></td>
-            <td>The <code>url</code> parameter is the URL to the ArcGIS Server or ArcGIS Online map service you would like to consume.</td>
+            <td><code class="nobr">new L.esri.Services.ImageService(<nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code><br><br><code class="nobr">L.esri.Services.imageService(<nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code></td>
+            <td>Options includes a <code>url</code> parameter which refers to the ArcGIS Server or ArcGIS Online service you would like to consume.</td>
         </tr>
     </tbody>
 </table>

--- a/api-reference/services/index.html
+++ b/api-reference/services/index.html
@@ -7,11 +7,11 @@
 <head>
   <meta charset="utf-8">
 
-  
-    <title>L.esri.Services | Esri Leaflet</title>
-  
 
-  
+    <title>L.esri.Services | Esri Leaflet</title>
+
+
+
 
   <meta name="description" content="Esri Leaflet">
   <meta name="viewport" content="width=device-width">
@@ -60,10 +60,10 @@
     </div>
     <div id="background-map" class="background-map"></div>
 
-  
+
 
 <div class="container white">
-  
+
 
 <aside class="sidebar">
   <h5>L.esri</h5>
@@ -98,6 +98,7 @@
     <a href="../../../../esri-leaflet/api-reference/tasks/identify-image.html">Identify Image</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/query.html">Query</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/find.html">Find</a>
+    <a href="../../../../esri-leaflet/api-reference/tasks/task.html">Task</a>
   </nav>
 
   <h5>Misc.</h5>

--- a/api-reference/services/map-service.html
+++ b/api-reference/services/map-service.html
@@ -7,11 +7,11 @@
 <head>
   <meta charset="utf-8">
 
-  
-    <title>L.esri.Services.MapService | Esri Leaflet</title>
-  
 
-  
+    <title>L.esri.Services.MapService | Esri Leaflet</title>
+
+
+
 
   <meta name="description" content="Esri Leaflet">
   <meta name="viewport" content="width=device-width">
@@ -60,10 +60,10 @@
     </div>
     <div id="background-map" class="background-map"></div>
 
-  
+
 
 <div class="container white">
-  
+
 
 <aside class="sidebar">
   <h5>L.esri</h5>
@@ -98,6 +98,7 @@
     <a href="../../../../esri-leaflet/api-reference/tasks/identify-image.html">Identify Image</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/query.html">Query</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/find.html">Find</a>
+    <a href="../../../../esri-leaflet/api-reference/tasks/task.html">Task</a>
   </nav>
 
   <h5>Misc.</h5>
@@ -109,7 +110,7 @@
 <div class="main-content">
   <h1 id="l-esri-services-mapservice">L.esri.Services.MapService</h1>
 <p>Inherits from <a href="../../../../esri-leaflet/api-reference/services/service.html"><code>L.esri.Service</code></a></p>
-<p><code>L.esri.Services.MapService</code> is an abstraction interacting with Map Services running on ArcGIS Online and ArcGIS server that allows you to make requests to the API, as well as query and identify features on the service.</p>
+<p><code>L.esri.Services.MapService</code> is an abstraction for interacting with Map Services running on ArcGIS Online and ArcGIS Server that allows you to make requests to the API, as well as query and identify published features.</p>
 <h3 id="constructor">Constructor</h3>
 <table>
     <thead>
@@ -120,8 +121,8 @@
     </thead>
     <tbody>
         <tr>
-            <td><code class="nobr">new L.esri.Services.MapService(<nobr class="param"><span>&lt;String&gt;</span> <code>url</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code><br><br><code class="nobr">L.esri.Services.mapService(<nobr class="param"><span>&lt;String&gt;</span> <code>url</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code></td>
-            <td>The <code>url</code> parameter is the URL to the ArcGIS Server or ArcGIS Online map service you would like to consume.</td>
+            <td><code class="nobr">new L.esri.Services.MapService(<nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code><br><br><code class="nobr">L.esri.Services.mapService(<nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code></td>
+            <td>Options includes a <code>url</code> parameter which refers to the ArcGIS Server or ArcGIS Online service you would like to consume.</td>
         </tr>
     </tbody>
 </table>

--- a/api-reference/tasks/find.html
+++ b/api-reference/tasks/find.html
@@ -7,11 +7,11 @@
 <head>
   <meta charset="utf-8">
 
-  
-    <title>L.esri.Tasks.Find | Esri Leaflet</title>
-  
 
-  
+    <title>L.esri.Tasks.Find | Esri Leaflet</title>
+
+
+
 
   <meta name="description" content="Esri Leaflet">
   <meta name="viewport" content="width=device-width">
@@ -60,10 +60,10 @@
     </div>
     <div id="background-map" class="background-map"></div>
 
-  
+
 
 <div class="container white">
-  
+
 
 <aside class="sidebar">
   <h5>L.esri</h5>
@@ -98,6 +98,7 @@
     <a href="../../../../esri-leaflet/api-reference/tasks/identify-image.html">Identify Image</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/query.html">Query</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/find.html">Find</a>
+    <a href="../../../../esri-leaflet/api-reference/tasks/task.html">Task</a>
   </nav>
 
   <h5>Misc.</h5>
@@ -125,7 +126,7 @@
                 <code>new L.esri.Tasks.Find(<nobr class="param"><span>&lt;String&gt;</span> <code>endpoint</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code><br><br>
                 <code>L.esri.Tasks.find(<nobr class="param"><span>&lt;String&gt;</span> <code>endpoint</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code>
             </td>
-            <td>The <code>endpoint</code> parameter is the service that you want to find either an  ArcGIS Server or ArcGIS Online service. You can also pass the URL to a service directly as a string. See <a href="#service-urls">service URLs</a> for more information on how to find these URLs.</td>
+            <td>The <code>endpoint</code> parameter refers to the ArcGIS Server or ArcGIS Online service that you want to find features in. Alternatively, you can also pass the URL to a service directly within options. See <a href="#service-urls">service URLs</a> for more information on how to find these URLs.</td>
         </tr>
     </tbody>
 </table>
@@ -142,16 +143,22 @@
 </thead>
 <tbody>
 <tr>
+<td><code>url</code></td>
+<td><code>String</code></td>
+<td><code></code></td>
+<td>URL of the ArcGIS Server or ArcGIS Online service you would like to consume.</td>
+</tr>
+<tr>
 <td><code>proxy</code></td>
 <td><code>String</code></td>
 <td><code>false</code></td>
-<td>URL of an <a href="https://developers.arcgis.com/javascript/jshelp/ags_proxy.html">ArcGIS API for JavaScript proxies</a> or <a href="https://github.com/Esri/resource-proxy">ArcGIS Resource Proxies</a> to use for proxying POST requests.</td>
+<td>URL of an <a href="https://developers.arcgis.com/javascript/jshelp/ags_proxy.html">ArcGIS API for JavaScript proxy</a> or <a href="https://github.com/Esri/resource-proxy">ArcGIS Resource Proxy</a> to use for proxying POST requests.</td>
 </tr>
 <tr>
 <td><code>useCors</code></td>
 <td><code>Boolean</code></td>
 <td><code>true</code></td>
-<td>If this service should use CORS when making GET requests.</td>
+<td>If this task should use CORS when making GET requests.</td>
 </tr>
 </tbody>
 </table>

--- a/api-reference/tasks/identify-features.html
+++ b/api-reference/tasks/identify-features.html
@@ -7,11 +7,11 @@
 <head>
   <meta charset="utf-8">
 
-  
-    <title>L.esri.Tasks.IdentifyFeatures | Esri Leaflet</title>
-  
 
-  
+    <title>L.esri.Tasks.IdentifyFeatures | Esri Leaflet</title>
+
+
+
 
   <meta name="description" content="Esri Leaflet">
   <meta name="viewport" content="width=device-width">
@@ -60,10 +60,10 @@
     </div>
     <div id="background-map" class="background-map"></div>
 
-  
+
 
 <div class="container white">
-  
+
 
 <aside class="sidebar">
   <h5>L.esri</h5>
@@ -98,6 +98,7 @@
     <a href="../../../../esri-leaflet/api-reference/tasks/identify-image.html">Identify Image</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/query.html">Query</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/find.html">Find</a>
+    <a href="../../../../esri-leaflet/api-reference/tasks/task.html">Task</a>
   </nav>
 
   <h5>Misc.</h5>
@@ -123,7 +124,7 @@
             <code>L.esri.Tasks.identifyFeatures(<nobr class="param"><span>&lt;<a href="../../api-reference/services/map-service.html">MapService</a>&gt;</span> <code>endpoint</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code><br><br>
             <code>new L.esri.Tasks.IdentifyFeatures(<nobr class="param"><span>&lt;String&gt;</span> <code>endpoint</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code><br><br>
             <code>L.esri.Tasks.identifyFeatures(<nobr class="param"><span>&lt;String&gt;</span> <code>endpoint</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code><br></td>
-            <td>The <code>endpoint</code> parameter is the service that you want to identify either an  ArcGIS Server or ArcGIS Online service. You can also pass the URL to a service directly as a string. See <a href="#service-urls">service URLs</a> for more information on how to find these URLs.</td>
+            <td>The <code>endpoint</code> parameter is the ArcGIS Server or ArcGIS Online service that you want to identify features in. Alternatively, you can also pass the URL to a service directly within options. See <a href="#service-urls">service URLs</a> for more information on how to find these URLs.</td>
         </tr>
     </tbody>
 </table>
@@ -140,16 +141,22 @@
 </thead>
 <tbody>
 <tr>
+<td><code>url</code></td>
+<td><code>String</code></td>
+<td><code></code></td>
+<td>URL of the ArcGIS Server or ArcGIS Online service you would like to consume.</td>
+</tr>
+<tr>
 <td><code>proxy</code></td>
 <td><code>String</code></td>
 <td><code>false</code></td>
-<td>URL of an <a href="https://developers.arcgis.com/javascript/jshelp/ags_proxy.html">ArcGIS API for JavaScript proxies</a> or <a href="https://github.com/Esri/resource-proxy">ArcGIS Resource Proxies</a> to use for proxying POST requests.</td>
+<td>URL of an <a href="https://developers.arcgis.com/javascript/jshelp/ags_proxy.html">ArcGIS API for JavaScript proxy</a> or <a href="https://github.com/Esri/resource-proxy">ArcGIS Resource Proxy</a> to use for proxying POST requests.</td>
 </tr>
 <tr>
 <td><code>useCors</code></td>
 <td><code>Boolean</code></td>
 <td><code>true</code></td>
-<td>If this service should use CORS when making GET requests.</td>
+<td>If this task should use CORS when making GET requests.</td>
 </tr>
 </tbody>
 </table>

--- a/api-reference/tasks/identify-image.html
+++ b/api-reference/tasks/identify-image.html
@@ -7,11 +7,11 @@
 <head>
   <meta charset="utf-8">
 
-  
-    <title>L.esri.Tasks.IdentifyImage | Esri Leaflet</title>
-  
 
-  
+    <title>L.esri.Tasks.IdentifyImage | Esri Leaflet</title>
+
+
+
 
   <meta name="description" content="Esri Leaflet">
   <meta name="viewport" content="width=device-width">
@@ -60,10 +60,10 @@
     </div>
     <div id="background-map" class="background-map"></div>
 
-  
+
 
 <div class="container white">
-  
+
 
 <aside class="sidebar">
   <h5>L.esri</h5>
@@ -98,6 +98,7 @@
     <a href="../../../../esri-leaflet/api-reference/tasks/identify-image.html">Identify Image</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/query.html">Query</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/find.html">Find</a>
+    <a href="../../../../esri-leaflet/api-reference/tasks/task.html">Task</a>
   </nav>
 
   <h5>Misc.</h5>
@@ -123,7 +124,7 @@
             <code>L.esri.Tasks.identifyImage(<nobr class="param"><span>&lt;<a href="../../api-reference/services/image-service.html">ImageService</a>&gt;</span> <code>endpoint</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code><br><br>
             <code>new L.esri.Tasks.IdentifyImage(<nobr class="param"><span>&lt;String&gt;</span> <code>endpoint</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code><br><br>
             <code>L.esri.Tasks.identifyImage(<nobr class="param"><span>&lt;String&gt;</span> <code>endpoint</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code><br></td>
-            <td>The <code>endpoint</code> parameter is the service that you want to identify either an  ArcGIS Server or ArcGIS Online service. You can also pass the URL to a service directly as a string. See <a href="#service-urls">service URLs</a> for more information on how to find these URLs.</td>
+            <td>The <code>endpoint</code> parameter is the ArcGIS Server or ArcGIS Online service that you want to identify features in. Alternatively, you can also pass the URL to a service directly within options. See <a href="#service-urls">service URLs</a> for more information on how to find these URLs.</td>
         </tr>
     </tbody>
 </table>
@@ -140,16 +141,22 @@
 </thead>
 <tbody>
 <tr>
+<td><code>url</code></td>
+<td><code>String</code></td>
+<td><code></code></td>
+<td>URL of the ArcGIS Server or ArcGIS Online service you would like to consume.</td>
+</tr>
+<tr>
 <td><code>proxy</code></td>
 <td><code>String</code></td>
 <td><code>false</code></td>
-<td>URL of an <a href="https://developers.arcgis.com/javascript/jshelp/ags_proxy.html">ArcGIS API for JavaScript proxies</a> or <a href="https://github.com/Esri/resource-proxy">ArcGIS Resource Proxies</a> to use for proxying POST requests.</td>
+<td>URL of an <a href="https://developers.arcgis.com/javascript/jshelp/ags_proxy.html">ArcGIS API for JavaScript proxy</a> or <a href="https://github.com/Esri/resource-proxy">ArcGIS Resource Proxy</a> to use for proxying POST requests.</td>
 </tr>
 <tr>
 <td><code>useCors</code></td>
 <td><code>Boolean</code></td>
 <td><code>true</code></td>
-<td>If this service should use CORS when making GET requests.</td>
+<td>If this task should use CORS when making GET requests.</td>
 </tr>
 </tbody>
 </table>

--- a/api-reference/tasks/index.html
+++ b/api-reference/tasks/index.html
@@ -7,11 +7,11 @@
 <head>
   <meta charset="utf-8">
 
-  
-    <title>L.esri.Tasks | Esri Leaflet</title>
-  
 
-  
+    <title>L.esri.Tasks | Esri Leaflet</title>
+
+
+
 
   <meta name="description" content="Esri Leaflet">
   <meta name="viewport" content="width=device-width">
@@ -60,10 +60,10 @@
     </div>
     <div id="background-map" class="background-map"></div>
 
-  
+
 
 <div class="container white">
-  
+
 
 <aside class="sidebar">
   <h5>L.esri</h5>
@@ -98,6 +98,7 @@
     <a href="../../../../esri-leaflet/api-reference/tasks/identify-image.html">Identify Image</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/query.html">Query</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/find.html">Find</a>
+    <a href="../../../../esri-leaflet/api-reference/tasks/task.html">Task</a>
   </nav>
 
   <h5>Misc.</h5>

--- a/api-reference/tasks/query.html
+++ b/api-reference/tasks/query.html
@@ -7,11 +7,11 @@
 <head>
   <meta charset="utf-8">
 
-  
-    <title>L.esri.Tasks.Query | Esri Leaflet</title>
-  
 
-  
+    <title>L.esri.Tasks.Query | Esri Leaflet</title>
+
+
+
 
   <meta name="description" content="Esri Leaflet">
   <meta name="viewport" content="width=device-width">
@@ -60,10 +60,10 @@
     </div>
     <div id="background-map" class="background-map"></div>
 
-  
+
 
 <div class="container white">
-  
+
 
 <aside class="sidebar">
   <h5>L.esri</h5>
@@ -98,6 +98,7 @@
     <a href="../../../../esri-leaflet/api-reference/tasks/identify-image.html">Identify Image</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/query.html">Query</a>
     <a href="../../../../esri-leaflet/api-reference/tasks/find.html">Find</a>
+    <a href="../../../../esri-leaflet/api-reference/tasks/task.html">Task</a>
   </nav>
 
   <h5>Misc.</h5>
@@ -124,7 +125,7 @@
             <code>L.esri.Tasks.query(<nobr class="param"><span>&lt;<a href="../../api-reference/services/feature-layer.html">FeatureLayer</a>&gt;</span> <code>endpoint</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code><br><br>
             <code>new L.esri.Tasks.Query(<nobr class="param"><span>&lt;String&gt;</span> <code>endpoint</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code><br><br>
             <code>L.esri.Tasks.query(<nobr class="param"><span>&lt;String&gt;</span> <code>endpoint</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code></td>
-            <td>The <code>endpoint</code> parameter is the service that you want to query either an  ArcGIS Server or ArcGIS Online service. You can also pass the URL to a service directly as a string. See <a href="#service-urls">service URLs</a> for more information on how to find these URLs.</td>
+            <td>The <code>endpoint</code> parameter is the ArcGIS Server or ArcGIS Online service that you want to query features in. Alternatively, you can also pass the URL to a service directly within options. See <a href="#service-urls">service URLs</a> for more information on how to find these URLs.</td>
         </tr>
     </tbody>
 </table>
@@ -141,16 +142,22 @@
 </thead>
 <tbody>
 <tr>
+<td><code>url</code></td>
+<td><code>String</code></td>
+<td><code></code></td>
+<td>URL of the ArcGIS Server or ArcGIS Online service you would like to consume.</td>
+</tr>
+<tr>
 <td><code>proxy</code></td>
 <td><code>String</code></td>
 <td><code>false</code></td>
-<td>URL of an <a href="https://developers.arcgis.com/javascript/jshelp/ags_proxy.html">ArcGIS API for JavaScript proxies</a> or <a href="https://github.com/Esri/resource-proxy">ArcGIS Resource Proxies</a> to use for proxying POST requests.</td>
+<td>URL of an <a href="https://developers.arcgis.com/javascript/jshelp/ags_proxy.html">ArcGIS API for JavaScript proxy</a> or <a href="https://github.com/Esri/resource-proxy">ArcGIS Resource Proxy</a> to use for proxying POST requests.</td>
 </tr>
 <tr>
 <td><code>useCors</code></td>
 <td><code>Boolean</code></td>
 <td><code>true</code></td>
-<td>If this service should use CORS when making GET requests.</td>
+<td>If this task should use CORS when making GET requests.</td>
 </tr>
 </tbody>
 </table>

--- a/api-reference/tasks/task.html
+++ b/api-reference/tasks/task.html
@@ -108,8 +108,8 @@
 </aside>
 
 <div class="main-content">
-  <h1 id="l-esri-service">L.esri.Services.Service</h1>
-<p>A generic class representing a hosted resource on ArcGIS Online or ArcGIS Server. This class can be extended to provide support for making requests as well as a standard for authentication and proxying.</p>
+  <h1 id="l-esri-service">L.esri.Tasks.Task</h1>
+<p>A generic class that provides the foundation for calling operations on ArcGIS Online and ArcGIS Server Services like query, find and identify.</p>
 <h3 id="constructor">Constructor</h3>
 <table>
     <thead>
@@ -120,7 +120,7 @@
     </thead>
     <tbody>
         <tr>
-            <td><code class="nobr">new L.esri.Services.Service(<nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code><br><br><code class="nobr">L.esri.Services.service(<nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code></td>
+            <td><code class="nobr">new L.esri.Tasks.Task(<nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code><br><br><code class="nobr">L.esri.Tasks.task(<nobr class="param"><span>&lt;Object&gt;</span> <code>options</code></nobr>)</code></td>
             <td>Options includes a <code>url</code> parameter which refers to the ArcGIS Server or ArcGIS Online service you would like to consume.</td>
         </tr>
     </tbody>
@@ -147,50 +147,13 @@
 <td><code>proxy</code></td>
 <td><code>String</code></td>
 <td><code>false</code></td>
-<td>URL of an <a href="https://developers.arcgis.com/javascript/jshelp/ags_proxy.html">ArcGIS API for JavaScript proxies</a> or <a href="https://github.com/Esri/resource-proxy">ArcGIS Resource Proxies</a> to use for proxying POST requests.</td>
+<td>URL of an <a href="https://developers.arcgis.com/javascript/jshelp/ags_proxy.html">ArcGIS API for JavaScript proxy</a> or <a href="https://github.com/Esri/resource-proxy">ArcGIS Resource Proxy</a> to use for proxying POST requests.</td>
 </tr>
 <tr>
 <td><code>useCors</code></td>
 <td><code>Boolean</code></td>
 <td><code>true</code></td>
-<td>If this service should use CORS when making GET requests.</td>
-</tr>
-</tbody>
-</table>
-<h3 id="events">Events</h3>
-<table>
-<thead>
-<tr>
-<th>Event</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>requeststart</code></td>
-<td><a href="../../../../esri-leaflet/api-reference/events.html#request-event">&lt;<code>RequestEvent</code>&gt;</a></td>
-<td>Fired when a request to the service begins.</td>
-</tr>
-<tr>
-<td><code>requestend</code></td>
-<td><a href="../../../../esri-leaflet/api-reference/events.html#request-event">&lt;<code>RequestEvent</code>&gt;</a></td>
-<td>Fired when a request to the service ends.</td>
-</tr>
-<tr>
-<td><code>requestsuccess</code></td>
-<td><a href="../../../../esri-leaflet/api-reference/events.html#request-success-event">&lt;<code>RequestSuccessEvent</code>&gt;</a></td>
-<td>Fired when a request to the service was successful.</td>
-</tr>
-<tr>
-<td><code>requesterror</code></td>
-<td><a href="../../../../esri-leaflet/api-reference/events.html#request-error-event">&lt;<code>RequestErrorEvent</code>&gt;</a></td>
-<td>Fired when a request to the service responsed with an error.</td>
-</tr>
-<tr>
-<td><code>authenticationrequired</code></td>
-<td><a href="../../../../esri-leaflet/api-reference/events.html#authentication-event">&lt;<code>AuthenticationEvent</code>&gt;</a></td>
-<td>This will be fired when a request to the service fails and requires authentication. See <a href="#working-with-authenticated-services">working with authenticated services</a> for more information.</td>
+<td>If this task should use CORS when making GET requests.</td>
 </tr>
 </tbody>
 </table>
@@ -205,24 +168,14 @@
     </thead>
     <tbody>
         <tr>
-            <td><code>get(<nobr class="param"><span>&lt;String&gt;</span> <code>url</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>params</code></nobr>, <nobr class="param"><span>&lt;Function&gt;</span> <code>callback</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>context</code></nobr>)</code></td>
+            <td><code>request(<nobr class="param"><span>&lt;String&gt;</span> <code>url</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>params</code></nobr>, <nobr class="param"><span>&lt;Function&gt;</span> <code>callback</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>context</code></nobr>)</code></td>
             <td><code>this</code></td>
-            <td>Makes a GET request to the service. The service's URL will be combined with the <code>path</code> option and parameters will be serialized to a query string. Accepts an optional function context for the callback.</td>
+            <td>Makes a request to the associated service. The service's URL will be combined with the <code>path</code> option and parameters will be serialized. Accepts an optional function context for the callback.</td>
         </tr>
         <tr>
-            <td><code>post(<nobr class="param"><span>&lt;String&gt;</span> <code>url</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>params</code></nobr>, <nobr class="param"><span>&lt;Function&gt;</span> <code>callback</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>context</code></nobr>)</code></td>
+            <td><code>token(<nobr class="param"><span>&lt;String&gt;</span> <code>token</code></nobr>)</code></td>
             <td><code>this</code></td>
-            <td>Makes a POST request to the service. The service's URL will be combined with the <code>path</code> option and parameters will be serialized. Accepts an optional function context for the callback.</td>
-        </tr>
-        <tr>
-            <td><code>metadata(<nobr class="param"><span>&lt;Function&gt;</span> <code>callback</code></nobr>, <nobr class="param"><span>&lt;Object&gt;</span> <code>context</code></nobr>)</code></td>
-            <td><code>this</code></td>
-            <td>Requests the metadata about the service. This is an alias for get(&quot;/&quot;, {}, callback, context).</td>
-        </tr>
-        <tr>
-            <td><code>authenticate(<nobr class="param"><span>&lt;String&gt;</span> <code>token</code></nobr>)</code></td>
-            <td><code>this</code></td>
-            <td>Authenticates this service with a new token and runs any pending requests that required a token.</td>
+            <td>Adds a token to this request if the service requires authentication. Will be added automatically if used with a service.</td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
modified constructor documentation for all `Tasks` and `Services` to note that url is now supplied within options
added a new `L.esri.Tasks.Task` api-reference page
added documentation for minZoom, maxZoom and cacheLayers FeatureLayer constructor options
other minor copy edits throughout

resolves #430 (w/ the exception of updates to the changelog) and #425 