### PR TITLE
better check to make sure logo hasn't already been removed

### DIFF
--- a/spec/Layers/BaseMapLayerSpec.js
+++ b/spec/Layers/BaseMapLayerSpec.js
@@ -49,7 +49,22 @@ describe('L.esri.Layers.BasemapLayer', function () {
     for (var i = 0, len = testmaps.length; i < len; i++) {
       var name = testmaps[i];
       expect(L.esri.basemapLayer(name)).to.be.instanceof(L.esri.Layers.BasemapLayer);
-      expect(L.esri.basemapLayer(name)._url).to.eql(L.esri.BasemapLayer.TILES[name].urlTemplate);
+      expect(L.esri.basemapLayer(name)._url).to.equal(L.esri.BasemapLayer.TILES[name].urlTemplate);
+    }
+  });
+
+  it('can survive adding/removing basemaps w/ labels', function () {
+    var moremaps = ['Oceans', 'DarkGray', 'Gray', 'Imagery', 'ShadedRelief', 'Terrain'];
+    for (var i = 0, len = moremaps.length; i < len; i++) {
+      var layer = L.esri.basemapLayer(moremaps[i]).addTo(map);
+      var layerWithLabels = L.esri.basemapLayer(moremaps[i] +'Labels').addTo(map);
+      expect(map.hasLayer(layer)).to.equal(true);
+      expect(map.hasLayer(layerWithLabels)).to.equal(true);
+
+      map.removeLayer(layer);
+      map.removeLayer(layerWithLabels);
+      expect(map.hasLayer(layer)).to.equal(false);
+      expect(map.hasLayer(layerWithLabels)).to.equal(false);
     }
   });
 

--- a/src/Layers/BasemapLayer.js
+++ b/src/Layers/BasemapLayer.js
@@ -228,7 +228,7 @@
     },
     onRemove: function(map){
       // check to make sure the logo hasn't already been removed
-      if(this._logo._container){
+      if(this._logo && this._logo._container){
         map.removeControl(this._logo);
         map._hasEsriLogo = false;
       }

--- a/src/Layers/BasemapLayer.js
+++ b/src/Layers/BasemapLayer.js
@@ -227,7 +227,8 @@
       map.on('moveend', this._updateMapAttribution, this);
     },
     onRemove: function(map){
-      if(this._logo){
+      // check to make sure the logo hasn't already been removed
+      if(this._logo._container){
         map.removeControl(this._logo);
         map._hasEsriLogo = false;
       }


### PR DESCRIPTION
resolves #455.  previously we checked for `this._logo`, prior to attempting to remove it from the map, but this is still an object (without a corresponding DOM node)

the new approach of checking for the presence of `this._logo._container` resolves problems that manifested when a basemap and corresponding label layer were removed from the map simultaneously.  

i've added a new test to trap problems like this in the future as well.