### PR TITLE
tag identifyFeatures task output with parent layerId

### DIFF
--- a/spec/Tasks/IdentifyFeaturesSpec.js
+++ b/spec/Tasks/IdentifyFeaturesSpec.js
@@ -58,7 +58,8 @@ describe('L.esri.Tasks.IdentifyFeatures', function () {
         'OBJECTID': 1,
         'Name': 'Site'
       },
-      'id': 1
+      'id': 1,
+      'layerId': 0
     }]
   };
 
@@ -247,6 +248,18 @@ describe('L.esri.Tasks.IdentifyFeatures', function () {
     expect(request.url).to.match(/mapExtent=\-122\.\d+%2C45\.\d+%2C\-122\.\d+%2C45\.\d+/g);
     expect(request.url).to.contain('geometryType=esriGeometryPoint');
     expect(request.url).to.contain('geometry=-122.66%2C45.51');
+
+    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
+  });
+
+  it('should return layerId of features in response', function(done){
+    var service = L.esri.Services.mapService({url: mapServiceUrl});
+
+    var request = service.identify().on(map).at(rawLatlng).run(function(error, featureCollection, raw){
+      expect(featureCollection.features[0].layerId).to.deep.equal(0);
+      expect(raw).to.deep.equal(sampleResponse);
+      done();
+    });
 
     request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });

--- a/src/Tasks/IdentifyFeatures.js
+++ b/src/Tasks/IdentifyFeatures.js
@@ -42,7 +42,17 @@ EsriLeaflet.Tasks.IdentifyFeatures = EsriLeaflet.Tasks.Identify.extend({
 
   run: function (callback, context){
     return this.request(function(error, response){
-      callback.call(context, error, (response && EsriLeaflet.Util.responseToFeatureCollection(response)), response);
+      var featureCollection = EsriLeaflet.Util.responseToFeatureCollection(response);
+      var count = featureCollection.features.length;
+      // tag each feature with the Id of its parent layer
+      if(!error && count > 0){
+        response.results = response.results.reverse();
+        for (var i = 0; i < count; i++) {
+          var feature = featureCollection.features[i];
+          feature.layerId = response.results[i].layerId;
+        }
+      }
+      callback.call(context, error, (response && featureCollection), response);
     }, context);
   }
 


### PR DESCRIPTION
resolves #443
had to update existing tests.  they're passing locally.

it seemed most sensible to me to just add this info whenever we're identifying features.

the benefit, (as we discussed on [twitter](https://twitter.com/bcw_gis/status/558030037434507266)), is that developers can now chain requests to do things like snagging attachments associated with a particular feature.

this is kind of a tangent, but it seems worth updating Util.responseToFeatureCollection() so that it returns an array of features whose order is the same as the input.  right?