### PR TITLE
Only trigger callback once when there is a CORS or other error

### DIFF
--- a/src/Request.js
+++ b/src/Request.js
@@ -40,6 +40,8 @@
     var httpRequest = new XMLHttpRequest();
 
     httpRequest.onerror = function(e) {
+      httpRequest.onreadystatechange = L.Util.falseFn;
+
       callback.call(context, {
         error: {
           code: 500,
@@ -59,7 +61,7 @@
           response = null;
           error = {
             code: 500,
-            message: 'Could not parse response as JSON.'
+            message: 'Could not parse response as JSON. This could also be caused by a CORS or XMLHttpRequest error.'
           };
         }
 
@@ -67,6 +69,8 @@
           error = response.error;
           response = null;
         }
+
+        httpRequest.onerror = L.Util.falseFn;
 
         callback.call(context, error, response);
       }


### PR DESCRIPTION
Resolves https://github.com/Esri/esri-leaflet/issues/465 and enhances the error message for failure states. Callbacks should now only run once. Ever.