### PR TITLE
Make leaflet a 'devDependency'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "esri-leaflet",
   "version": "1.0.0-rc.5",
+  "repository": "Esri/esri-leaflet",
   "description": "Leaflet plugins for consuming ArcGIS Online and ArcGIS Server services",
   "main": "dist/esri-leaflet.js",
   "devDependencies": {
@@ -32,7 +33,8 @@
     "karma-safari-launcher": "^0.1.1",
     "karma-sauce-launcher": "^0.2.10",
     "load-grunt-tasks": "^0.4.0",
-    "sinon": "^1.11.1"
+    "sinon": "^1.11.1",
+    "leaflet": "^0.7.0"
   },
   "scripts": {
     "prepublish": "node -e \"require('grunt').tasks(['prepublish']);\"",
@@ -46,6 +48,5 @@
   "license": "Apache",
   "readmeFilename": "README.md",
   "dependencies": {
-    "leaflet": "^0.7.0"
   }
 }


### PR DESCRIPTION
resolves problems in projects that use browserify and attempt to load a patched version of Leaflet (see #463).
follows the [pattern](https://github.com/Leaflet/Leaflet.toolbar/blob/master/package.json#L9-L36) of other plugins in the Leaflet organization.

also added a 'repository' tag to appease an `npm install` nag.
