### PR TITLE
set f=json automatically when proxied

### DIFF
--- a/src/Layers/DynamicMapLayer.js
+++ b/src/Layers/DynamicMapLayer.js
@@ -14,6 +14,9 @@ EsriLeaflet.Layers.DynamicMapLayer = EsriLeaflet.Layers.RasterLayer.extend({
     options.url = EsriLeaflet.Util.cleanUrl(url);
     this._service = new EsriLeaflet.Services.MapService(options);
     this._service.on('authenticationrequired requeststart requestend requesterror requestsuccess', this._propagateEvent, this);
+    if (options.proxy){
+      options.f = 'json';
+    }
     L.Util.setOptions(this, options);
   },
 


### PR DESCRIPTION
resolves #464

verified that this has the desired effect of forcing the initial json request through a proxy (and that everything is functioning as expected when working with a secure layer)