### PR TITLE
typo fixes

### DIFF
--- a/site/source/pages/api-reference/layers/clustered-feature-layer.md
+++ b/site/source/pages/api-reference/layers/clustered-feature-layer.md
@@ -122,7 +122,7 @@ More information about Feature Layers can be found in the [`L.esri.Layers.Featur
 | `removefeature` | [<`RemoveFeatureEvent`>]({{assets}}api-reference/events.html#feature-remove) | Fired when a feature on the layer is removed from the map. |
 | `addfeature` | [<`AddFeatureEvent`>]({{assets}}api-reference/events.html#feature-add) | Fired when a previously removed feature is added back to the map. |
 
-`L.esri.Layer.FeatureLayer` also fires all  [`L.esri.Service.FeatureLayer`]({{assets}}api-reference/services/feature-layer.html) events.
+`L.esri.Layers.FeatureLayer` also fires all  [`L.esri.Services.FeatureLayer`]({{assets}}api-reference/services/feature-layer.html) events.
 
 In additon to these events `L.esri.FeatureLayer` also fires the following [Mouse Events](http://leafletjs.com/reference.html#event-objects) `click`, `dblclick`, `mouseover`, `mouseout`, `mousemove`, and `contextmenu`, `clusterclick`, `clusterdblclick`, `clustermouseover`, `vmouseout`, `clustermousemove`, and `clustercontextmenu` as well as the following the [Popup Events](http://leafletjs.com/reference.html#event-objects) `popupopen` and `popupclose`.
 

--- a/site/source/pages/api-reference/layers/dynamic-map-layer.md
+++ b/site/source/pages/api-reference/layers/dynamic-map-layer.md
@@ -197,7 +197,7 @@ Option | Type | Default | Description
 | `loading` | [<`LoadingEvent`>]({{assets}}api-reference/events.html#loading-event) | Fires when new features start loading. |
 | `load` | [<`LoadEvent`>]({{assets}}api-reference/events.html#load-event) | Fires when all features in the current bounds of the map have loaded. |
 
-`L.esri.Layer.DynamicMapLayer` also fires all  [`L.esri.Service.MapService`]({{assets}}api-reference/services/map-service.html) events.
+`L.esri.Layers.DynamicMapLayer` also fires all  [`L.esri.Services.MapService`]({{assets}}api-reference/services/map-service.html) events.
 
 ### Example
 

--- a/site/source/pages/api-reference/layers/feature-layer.md
+++ b/site/source/pages/api-reference/layers/feature-layer.md
@@ -5,7 +5,7 @@ layout: documentation.hbs
 
 # {{page.data.title}}
 
-`L.esri.Layer.FeatureLayer` is used to visualize and query vector geographic data hosted in both ArcGIS Online and published using ArcGIS Server.
+`L.esri.Layers.FeatureLayer` is used to visualize and query vector geographic data hosted in both ArcGIS Online and published using ArcGIS Server.
 
 Feature Layers are provided by Feature Services which can contain multiple layers. Feature Layers expose vector geographic information as a web service that can be visualized, styled, queried and edited.
 
@@ -151,9 +151,9 @@ You can create a new empty feature service with a single layer on the [ArcGIS fo
 | `removefeature` | [<`RemoveFeatureEvent`>]({{assets}}api-reference/events.html#feature-remove) | Fired when a feature on the layer is removed from the map. |
 | `addfeature` | [<`AddFeatureEvent`>]({{assets}}api-reference/events.html#feature-add) | Fired when a previously removed feature is added back to the map. |
 
-`L.esri.Layer.FeatureLayer` also fires all  [`L.esri.Service.FeatureLayer`]({{assets}}api-reference/services/feature-layer.html) events.
+`L.esri.Layers.FeatureLayer` also fires all  [`L.esri.Services.FeatureLayer`]({{assets}}api-reference/services/feature-layer.html) events.
 
-In additon to these events `L.esri.Layer.FeatureLayer` also fires the following [Mouse Events](http://leafletjs.com/reference.html#event-objects) `click`, `dblclick`, `mouseover`, `mouseout`, `mousemove`, and `contextmenu` and the following the [Popup Events](http://leafletjs.com/reference.html#event-objects) `popupopen` and `popupclose`
+In additon to these events `L.esri.Layers.FeatureLayer` also fires the following [Mouse Events](http://leafletjs.com/reference.html#event-objects) `click`, `dblclick`, `mouseover`, `mouseout`, `mousemove`, and `contextmenu` and the following the [Popup Events](http://leafletjs.com/reference.html#event-objects) `popupopen` and `popupclose`
 
 ### Methods
 

--- a/site/source/pages/api-reference/layers/heatmap-feature-layer.md
+++ b/site/source/pages/api-reference/layers/heatmap-feature-layer.md
@@ -98,7 +98,7 @@ More information about Feature Layers can be found in the [`L.esri.Layers.Featur
 | `loading` | [&lt;LoadingEvent&gt;]() | Fires when new features start loading. |
 | `load` | [&lt;Load&gt;]() | Fires when all features in the current bounds of the map have loaded. |
 
-`L.esri.Layer.FeatureLayer` also fires all  [`L.esri.Service.FeatureLayer`]({{assets}}api-reference/services/feature-layer.html) events.
+`L.esri.Layers.FeatureLayer` also fires all  [`L.esri.Services.FeatureLayer`]({{assets}}api-reference/services/feature-layer.html) events.
 
 ### Methods
 

--- a/site/source/pages/api-reference/layers/image-map-layer.md
+++ b/site/source/pages/api-reference/layers/image-map-layer.md
@@ -202,7 +202,7 @@ imageService.query()
 | `loading` | [<`LoadingEvent`>]({{assets}}api-reference/events.html#loading-event) | Fires when new features start loading. |
 | `load` | [<`LoadEvent`>]({{assets}}api-reference/events.html#load-event) | Fires when all features in the current bounds of the map have loaded. |
 
-`L.esri.Layer.ImageMapLayer` also fires all  [`L.esri.Service.ImageService`]({{assets}}api-reference/services/image-service.html) events.
+`L.esri.Layers.ImageMapLayer` also fires all  [`L.esri.Services.ImageService`]({{assets}}api-reference/services/image-service.html) events.
 
 ### Example
 

--- a/site/source/pages/api-reference/tasks/query.md
+++ b/site/source/pages/api-reference/tasks/query.md
@@ -26,7 +26,7 @@ layout: documentation.hbs
             <code>L.esri.Tasks.query({{{param 'MapService' 'endpoint' '../../api-reference/services/map-service.html'}}})</code><br><br>
             <code>new L.esri.Tasks.Query({{{param 'Object' 'options'}}})</code><br><br>
             <code>L.esri.Tasks.query({{{param 'Object' 'options'}}})</code></td>
-            <td>Accepts either an `options` object or an instance of <a href="{{assets}}/api-reference/services/map-service.html">MapService</a> or <a href="{{assets}}/api-reference/services/map-service.html">FeatureLayer</a>.</td>
+            <td>Accepts either an `options` object or an instance of <a href="{{assets}}/api-reference/services/map-service.html">MapService</a> or <a href="{{assets}}/api-reference/layers/feature-layer.html">FeatureLayer</a>.</td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
the API reference incorrectly referred to `L.esri.Layer.Something` and `L.esri.Service.Something` in a few places.  updated to `.Layers.` and `.Services.`