### PR TITLE
bump to rc.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Icon
 
 # Node
 node_modules
+npm-debug.log
 
 # Coverage
 coverage

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Here is a quick example to get you started. Just copy/paste into your own .html 
     <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
 
     <!-- Load Esri Leaflet from CDN -->
-    <script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet/1.0.0-rc.5/esri-leaflet.js"></script>
+    <script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet/1.0.0-rc.6/esri-leaflet.js"></script>
 
     <style>
       html, body,  #map {

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "esri-leaflet",
-  "version": "v1.0.0-rc.6",
+  "version": "v1.0.0-rc.7",
   "main": "dist/esri-leaflet.js",
   "ignore": [
     "**/.*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esri-leaflet",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0-rc.7",
   "description": "Leaflet plugins for consuming ArcGIS Online and ArcGIS Server services",
   "main": "dist/esri-leaflet.js",
   "devDependencies": {

--- a/src/EsriLeaflet.js
+++ b/src/EsriLeaflet.js
@@ -1,5 +1,5 @@
 var EsriLeaflet = { //jshint ignore:line
-  VERSION: '1.0.0-rc.6',
+  VERSION: '1.0.0-rc.7',
   Layers: {},
   Services: {},
   Controls: {},


### PR DESCRIPTION
lets get in the habit of updating the release earlier in the development cycle, to lessen the chance that we miss a file when tagging.

also added npm-debug.log to .gitignore and bumped the CDN version in the README code sample to latest official release.