### PR TITLE
trim height of export requests when necessary

### DIFF
--- a/src/Layers/DynamicMapLayer.js
+++ b/src/Layers/DynamicMapLayer.js
@@ -91,12 +91,11 @@ EsriLeaflet.Layers.DynamicMapLayer = EsriLeaflet.Layers.RasterLayer.extend({
     var sw = this._map.options.crs.project(bounds._southWest);
 
     //ensure that we don't ask ArcGIS Server for a taller image than we have actual map displaying
-    var total = this._map.getSize();
     var top = this._map.latLngToLayerPoint(bounds._northEast);
     var bottom = this._map.latLngToLayerPoint(bounds._southWest);
 
-    if (top.y > 0 || bottom.y < total.y){
-      size.y = total.y - top.y - (total.y - bottom.y);
+    if (top.y > 0 || bottom.y < size.y){
+      size.y = bottom.y - top.y;
     }
 
     var params = {

--- a/src/Layers/DynamicMapLayer.js
+++ b/src/Layers/DynamicMapLayer.js
@@ -90,6 +90,15 @@ EsriLeaflet.Layers.DynamicMapLayer = EsriLeaflet.Layers.RasterLayer.extend({
     var ne = this._map.options.crs.project(bounds._northEast);
     var sw = this._map.options.crs.project(bounds._southWest);
 
+    //ensure that we don't ask ArcGIS Server for a taller image than we have actual map displaying
+    var total = this._map.getSize();
+    var top = this._map.latLngToLayerPoint(bounds._northEast);
+    var bottom = this._map.latLngToLayerPoint(bounds._southWest);
+
+    if (top.y > 0 || bottom.y < total.y){
+      size.y = total.y - top.y - (total.y - bottom.y);
+    }
+
     var params = {
       bbox: [sw.x, sw.y, ne.x, ne.y].join(','),
       size: size.x + ',' + size.y,


### PR DESCRIPTION
resolves #450

i was able to correct the distortion seen in DynamicMapLayer overlays in scenarios where whitespace surrounds the map by introducing a quick check into `_buildExportParams` to compare the height of the div to the top and bottom y values of the actual map (in screen coordinates) and trimming if appropriate.

confirmed that display behavior is improved for web mercator basemaps, even when L.tileLayer noWrap is set to true
confirmed that display behavior is appropriate in leaflet-1.0 branch as well (with the exception of the fact that the area below 85deg south isn't cropped appropriately)

happy to include relevant tests prior to merge, just wanted to make sure everyone's happy with the methodology first.
cc @nixta