### PR TITLE
fix hosted feature service regex

### DIFF
--- a/spec/UtilSpec.js
+++ b/spec/UtilSpec.js
@@ -12,6 +12,10 @@ describe('L.esri.Util', function () {
     [45.52, -122.64] //ne lat lng
   ]);
 
+  var hostedFeatureServiceUrl = 'http://services.arcgis.com/rOo.../arcgis/rest/services/RawsomeServiceName/FeatureServer/0';
+  var otherServiceUrl = 'http://demographics4.arcgis.com/arcgis/rest/services/USA_Demographics_and_Boundaries_2014/MapServer/9';
+  var normalFeatureServiceUrl = 'http://oneofoursampleservers.arcgisonline.com/arcgis/rest/services/WorldTimeZones/MapServer/2';
+
   it('should return a L.LatLngBounds object from extentToBounds', function () {
     var bounds = L.esri.Util.extentToBounds(sampleExtent);
     expect(bounds).to.be.an.instanceof(L.LatLngBounds);
@@ -1066,6 +1070,12 @@ describe('L.esri.Util', function () {
         'id': 1,
       }]
     });
+  });
+
+  it('should know the difference between a hosted feature service and everything else', function () {
+    expect(L.esri.Util.isArcgisOnline(hostedFeatureServiceUrl)).to.be.true;
+    expect(L.esri.Util.isArcgisOnline(otherServiceUrl)).to.be.false;
+    expect(L.esri.Util.isArcgisOnline(normalFeatureServiceUrl)).to.be.false;
   });
 
 });

--- a/src/Util.js
+++ b/src/Util.js
@@ -399,7 +399,10 @@
   };
 
   EsriLeaflet.Util.isArcgisOnline = function(url){
-    return (/\.arcgis\.com/g).test(url);
+    /* hosted feature services can emit geojson natively.
+    our check for 'geojson' support will need to be revisted
+    once the functionality makes its way to ArcGIS Server*/
+    return (/\.arcgis\.com.*?FeatureServer/g).test(url);
   };
 
   EsriLeaflet.Util.geojsonTypeToArcGIS = function (geoJsonType) {


### PR DESCRIPTION
resolves #486 
added a new test and confirmed manually that all relevant feature layer service inputs are now drawing appropriately.

i'm a hack with regex, so please seriously consider the possibility that there's a superior way to seek out urls that contain both 'arcgis.' and 'FeatureServer' than what i'm suggesting.

@kgerrow is there any reason why we should be invoking a more complicated mechanism of checking for the ability of a hosted feature service to emit native GeoJson than searching the url as i described above?