### PR TITLE
fixes for problems in the editing sample

### DIFF
--- a/site/source/pages/examples/editing.hbs
+++ b/site/source/pages/examples/editing.hbs
@@ -46,10 +46,11 @@ layout: example.hbs
   L.esri.basemapLayer('Streets').addTo(map);
 
   // add our feature layer to the map
-  var pedetrianDistricts = new L.esri.FeatureLayer('http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/PDX_Pedestrian_Districts/FeatureServer/0').addTo(map);
+  var pedestrianDistricts = new L.esri.FeatureLayer('http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/PDX_Pedestrian_Districts/FeatureServer/0').addTo(map);
 
   // variable to track the layer being edited
   var currentlyEditing;
+  var currentlyDeleting = false;
 
   // create a feature group for Leaflet Draw to hook into for delete functionality
   var drawnItems = new L.FeatureGroup();
@@ -60,8 +61,6 @@ layout: example.hbs
 
   // start editing a given layer
   function startEditing(layer) {
-    document.getElementById("form").style.display = 'block';
-    document.getElementById("greeting").innerHTML = null;
     document.getElementById("PEDDISTRIC").value = layer.feature.properties.PEDDISTRIC;
     // read only
     document.getElementById("TRANPLANID").value = layer.feature.properties.TRANPLANID;
@@ -73,11 +72,9 @@ layout: example.hbs
 
   // stop editing a given layer
   function stopEditing() {
-    // is a layer is being editing finish up editing it and disable editing on it.
+    // if a layer is being edited, finish up and disable editing on it afterward.
     if (currentlyEditing) {
       handleEdit(currentlyEditing);
-      document.getElementById("form").style.display = 'none';
-      document.getElementById("greeting").innerHTML = "Lets edit!";
       currentlyEditing.editing.disable();
     }
     currentlyEditing = undefined;
@@ -86,14 +83,25 @@ layout: example.hbs
   function handleEdit(layer) {
     // convert the layer to GeoJSON and build a new updated GeoJSON object for that feature
     layer.feature.properties.PEDDISTRIC = document.getElementById("PEDDISTRIC").value;
-    pedetrianDistricts.updateFeature({
+    pedestrianDistricts.updateFeature({
       type: 'Feature',
       id: layer.feature.id,
       geometry: layer.toGeoJSON().geometry,
       properties: layer.feature.properties
     }, function(error, response) {
       console.log(error, response);
+      displayGreeting();
     });
+  }
+
+  function displayAttributes() {
+    document.getElementById("greeting").innerHTML = null;
+    document.getElementById("form").style.display = 'block';
+  }
+
+  function displayGreeting() {
+    document.getElementById("greeting").innerHTML = "Lets edit!";
+    document.getElementById("form").style.display = 'none';
   }
 
   // when the map is clicked, stop editing
@@ -101,25 +109,28 @@ layout: example.hbs
     stopEditing();
   });
 
-  // when a pedestrian district is clicked, stop editing the current layer and edit the clicked layer
-  pedetrianDistricts.on('click', function(e) {
+  // when a pedestrian district is clicked, stop editing the current feature and edit the clicked feature
+  pedestrianDistricts.on('click', function(e) {
     stopEditing();
     startEditing(e.layer);
+    if (!currentlyDeleting) {
+      displayAttributes();
+    }
   });
 
-  // when pedetrian districts start loading (because of pan/zoom) stop editing
-  pedetrianDistricts.on('loading', function() {
+  // when pedestrian districts start loading (because of pan/zoom) stop editing
+  pedestrianDistricts.on('loading', function() {
     stopEditing();
   });
 
   // when new features are loaded clear our current guides and feature groups
   // then load the current features into the guides and feature group
-  pedetrianDistricts.on('load', function() {
+  pedestrianDistricts.on('load', function() {
     // wipe the current layers available for deltion and clear the current guide layers.
     drawnItems.clearLayers();
 
     // for each feature push the layer representing that feature into the guides and deletion group
-    pedetrianDistricts.eachFeature(function(layer) {
+    pedestrianDistricts.eachFeature(function(layer) {
       drawnItems.addLayer(layer);
     });
   });
@@ -147,27 +158,37 @@ layout: example.hbs
   // add our drawing controls to the map
   map.addControl(drawControl);
 
-  // when we start using deletion or creation tools disable our custom editing
-  map.on('draw:deletestart draw:createstart', function() {
+  // when we start using creation tools disable our custom editing
+  map.on('draw:createstart', function() {
     disableEditing = true;
+  });
+
+  // when we start using deletion tools, hide attributes and disable custom editing
+  map.on('draw:deletestart', function() {
+    disableEditing = true;
+    currentlyDeleting = true;
+    //displayGreeting();
   });
 
   // listen to the draw created event
   map.on('draw:created', function(e) {
     // add the feature as GeoJSON (feature will be converted to ArcGIS JSON internally)
-    pedetrianDistricts.addFeature(e.layer.toGeoJSON(), function(error, response) {
+    pedestrianDistricts.addFeature(e.layer.toGeoJSON(), function(error, response) {
       console.log(error, response);
     });
+    disableEditing = false;
   });
 
   // listen to the draw deleted event
   map.on('draw:deleted', function(e) {
     e.layers.eachLayer(function(layer) {
       var id = layer.feature.id;
-      pedetrianDistricts.deleteFeature(id, function(error, response) {
-        delete pedetrianDistricts._layers[id];
+      pedestrianDistricts.deleteFeature(id, function(error, response) {
+        delete pedestrianDistricts._layers[id];
         console.log(error, response);
       });
     });
+    disableEditing = false;
+    currentlyDeleting = false;
   });
 </script>

--- a/site/source/pages/examples/editing.hbs
+++ b/site/source/pages/examples/editing.hbs
@@ -167,7 +167,6 @@ layout: example.hbs
   map.on('draw:deletestart', function() {
     disableEditing = true;
     currentlyDeleting = true;
-    //displayGreeting();
   });
 
   // listen to the draw created event

--- a/spec/Layers/FeatureLayer/FeatureManagerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureManagerSpec.js
@@ -294,7 +294,7 @@ describe('L.esri.Layers.FeatureManager', function () {
     expect(layer.addLayers).to.have.been.calledWith([2]);
   });
 
-  it('should load more features  with a single time field', function(){
+  it('should load more features with a single time field', function(){
     server.respondWith('GET', 'http://gis.example.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0/query?returnGeometry=true&where=1%3D1&outSr=4326&outFields=*&inSr=4326&geometry=%7B%22xmin%22%3A-122.6953125%2C%22ymin%22%3A45.521743896993634%2C%22xmax%22%3A-122.6513671875%2C%22ymax%22%3A45.55252525134013%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryEnvelope&spatialRel=esriSpatialRelIntersects&geometryPrecision=6&time=1385884800000%2C1389340800000&f=json', JSON.stringify({
       fields: fields,
       features: [feature1],

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -396,6 +396,7 @@
     },
 
     addFeature: function(feature, callback, context){
+      //still need to pass 'undefined' as a placeholder, not sure how to fix
       this._getMetadata(L.Util.bind(function(undefined, error, metadata){
         this._service.addFeature(feature, function(error, response){
           if(!error){

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -385,32 +385,33 @@
 
     _getMetadata: function(callback, context){
       if(this._metadata){
-        callback(undefined, this._metadata, this);
+        var error;
+        callback(context, error, this._metadata);
       } else {
-        this.metadata(L.Util.bind(function(error, response, context) {
+        this.metadata(L.Util.bind(function(error, response) {
           this._metadata = response;
-          callback(error, this._metadata, this);
+          callback(context, error, this._metadata);
         }, this));
       }
     },
 
     addFeature: function(feature, callback, context){
-      this._getMetadata(function(error, metadata, context){
-        context._service.addFeature(feature, function(error, response){
+      this._getMetadata(L.Util.bind(function(undefined, error, metadata){
+        this._service.addFeature(feature, function(error, response){
           if(!error){
             // assign ID from result to appropriate objectid field from service metadata
             feature.properties[metadata.objectIdField] = response.objectId;
 
             // we also need to update the geojson id for createLayers() to function
             feature.id = response.objectId;
-            context.createLayers([feature]);
+            this.createLayers([feature]);
           }
           if(callback){
             callback.call(context, error, response);
           }
-        }, context);
+        }, this);
         return this;
-      }, this);
+      }, this), this);
     },
 
     updateFeature: function(feature, callback, context){

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -386,7 +386,19 @@
     addFeature: function(feature, callback, context){
       this._service.addFeature(feature, function(error, response){
         if(!error){
-          this.refresh();
+          /*
+          this code requires the developer supply an 'idAttribute' in the constructor options
+          currently, 'this._service.options.idAttribute' is hardcoded to 'OBJECTID'
+          */
+          if (this.options.idAttribute){
+            feature.properties[this.options.idAttribute] = response.objectId;
+          }
+          else {
+            feature.properties.OBJECTID = response.objectId;
+          }
+          // we also need to update the geojson id for createLayers() to function
+          feature.id = response.objectId;
+          this.createLayers([feature]);
         }
         if(callback){
           callback.call(context, error, response);
@@ -398,7 +410,8 @@
     updateFeature: function(feature, callback, context){
       return this._service.updateFeature(feature, function(error, response){
         if(!error){
-          this.refresh();
+          this.removeLayers([feature.id], true);
+          this.createLayers([feature]);
         }
         if(callback){
           callback.call(context, error, response);
@@ -416,6 +429,7 @@
         }
       }, this);
     }
+
   });
 
   /**

--- a/src/Services/FeatureLayer.js
+++ b/src/Services/FeatureLayer.js
@@ -46,7 +46,6 @@ EsriLeaflet.Services.FeatureLayer = EsriLeaflet.Services.Service.extend({
       }
     }, context);
   }
-
 });
 
 EsriLeaflet.Services.featureLayer = function(options) {

--- a/src/Services/FeatureLayer.js
+++ b/src/Services/FeatureLayer.js
@@ -18,7 +18,7 @@ EsriLeaflet.Services.FeatureLayer = EsriLeaflet.Services.Service.extend({
     }, function(error, response){
       var result = (response && response.addResults) ? response.addResults[0] : undefined;
       if(callback){
-        callback.call(this, error || response.addResults[0].error, result);
+        callback.call(context, error || response.addResults[0].error, result);
       }
     }, context);
   },


### PR DESCRIPTION
#### included fixes:
- [x] the dialog which assists with editing attributes doesn't disappear after a feature has been deleted.  (it would be preferable if it were not displayed at all in that scenario)
- [x] its not possible to modify the geometry of a feature after deleting something else.
- [x] 'Pedetrian' is misspelled
- [ ] clicking a feature and then clicking the map triggers an `updateFeature` call, even though the feature hasn't changed
- [x] each time an edit is passed, the featureLayer `load` event is triggered and another set of queries to the service fire.  perhaps this is by design, but it seems like it would be preferable if we could update the L.esri.FeatureLayer and L.FeatureGroup for the Draw plugin more surgically.

not sure if its worth doing anything about the other two...