### PR TITLE
fix cleanUrl regex so that spaces in folder names arent trimmed

### DIFF
--- a/spec/UtilSpec.js
+++ b/spec/UtilSpec.js
@@ -44,6 +44,11 @@ describe('L.esri.Util', function () {
     expect(url).to.equal('http://arcgis.com/');
   });
 
+  it('shouldnt trim spaces in the middle', function(){
+    var url = L.esri.Util.cleanUrl('   http://arcgis.com/cool folder/anotherfolder ');
+    expect(url).to.equal('http://arcgis.com/cool folder/anotherfolder/');
+  });
+
   it('should convert a GeoJSON Point to an ArcGIS Point', function() {
     var input = {
       'type': 'Point',

--- a/src/Util.js
+++ b/src/Util.js
@@ -386,9 +386,10 @@
     return featureCollection;
   };
 
-    // trim whitespace and add a tailing slash is needed to a url
+    // trim url whitespace and add a trailing slash if needed
   EsriLeaflet.Util.cleanUrl = function(url){
-    url = url.replace(/\s\s*/g, '');
+    //trim leading and trailing spaces, but not spaces inside the url
+    url = url.replace(/^\s+|\s+$|\A\s+|\s+\z/g, '');
 
     //add a trailing slash to the url if the user omitted it
     if(url[url.length-1] !== '/'){


### PR DESCRIPTION
i noticed this morning that L.Util.cleanUrl incorrectly trims spaces inside url folder names.

```javascript
L.esri.Util.cleanUrl('http://utility.arcgisonline.com/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export Web Map Task/execute  ');
//Export Web Map Task becomes ExportWebMapTask (and induces 400 errors in requests)
>>"http://utility.arcgisonline.com/arcgis/rest/services/Utilities/PrintingTools/GPServer/ExportWebMapTask/execute/"
```
i've fixed using another regex i found on the internet.