### PR TITLE
Use protocol-relative URL for Google Fonts

### DIFF
--- a/api-reference/events.html
+++ b/api-reference/events.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/api-reference/index.html
+++ b/api-reference/index.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/api-reference/layers/basemap-layer.html
+++ b/api-reference/layers/basemap-layer.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../../esri-leaflet/css/style.css">

--- a/api-reference/layers/clustered-feature-layer.html
+++ b/api-reference/layers/clustered-feature-layer.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../../esri-leaflet/css/style.css">

--- a/api-reference/layers/dynamic-map-layer.html
+++ b/api-reference/layers/dynamic-map-layer.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../../esri-leaflet/css/style.css">

--- a/api-reference/layers/feature-layer.html
+++ b/api-reference/layers/feature-layer.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../../esri-leaflet/css/style.css">

--- a/api-reference/layers/heatmap-feature-layer.html
+++ b/api-reference/layers/heatmap-feature-layer.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../../esri-leaflet/css/style.css">

--- a/api-reference/layers/image-map-layer.html
+++ b/api-reference/layers/image-map-layer.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../../esri-leaflet/css/style.css">

--- a/api-reference/layers/index.html
+++ b/api-reference/layers/index.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../../esri-leaflet/css/style.css">

--- a/api-reference/layers/raster-layer.html
+++ b/api-reference/layers/raster-layer.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../../esri-leaflet/css/style.css">

--- a/api-reference/layers/tiled-map-layer.html
+++ b/api-reference/layers/tiled-map-layer.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../../esri-leaflet/css/style.css">

--- a/api-reference/request.html
+++ b/api-reference/request.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/api-reference/services/feature-layer.html
+++ b/api-reference/services/feature-layer.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../../esri-leaflet/css/style.css">

--- a/api-reference/services/image-service.html
+++ b/api-reference/services/image-service.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../../esri-leaflet/css/style.css">

--- a/api-reference/services/index.html
+++ b/api-reference/services/index.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../../esri-leaflet/css/style.css">

--- a/api-reference/services/map-service.html
+++ b/api-reference/services/map-service.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../../esri-leaflet/css/style.css">

--- a/api-reference/services/service.html
+++ b/api-reference/services/service.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../../esri-leaflet/css/style.css">

--- a/api-reference/tasks/find.html
+++ b/api-reference/tasks/find.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../../esri-leaflet/css/style.css">

--- a/api-reference/tasks/identify-features.html
+++ b/api-reference/tasks/identify-features.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../../esri-leaflet/css/style.css">

--- a/api-reference/tasks/identify-image.html
+++ b/api-reference/tasks/identify-image.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../../esri-leaflet/css/style.css">

--- a/api-reference/tasks/index.html
+++ b/api-reference/tasks/index.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../../esri-leaflet/css/style.css">

--- a/api-reference/tasks/query.html
+++ b/api-reference/tasks/query.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../../esri-leaflet/css/style.css">

--- a/api-reference/tasks/task.html
+++ b/api-reference/tasks/task.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../../esri-leaflet/css/style.css">

--- a/api-reference/util.html
+++ b/api-reference/util.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/download/index.html
+++ b/download/index.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/arcgis-online-auth.html
+++ b/examples/arcgis-online-auth.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/arcgis-server-auth.html
+++ b/examples/arcgis-server-auth.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/basemap-with-labels.html
+++ b/examples/basemap-with-labels.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/center-map-on-address.html
+++ b/examples/center-map-on-address.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/clustering-feature-layers.html
+++ b/examples/clustering-feature-layers.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/customizing-popups.html
+++ b/examples/customizing-popups.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/editing.html
+++ b/examples/editing.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/feature-layer-popups.html
+++ b/examples/feature-layer-popups.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/feature-layer-snapshot.html
+++ b/examples/feature-layer-snapshot.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/finding-features.html
+++ b/examples/finding-features.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/geocoding-control.html
+++ b/examples/geocoding-control.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/getting-service-metadata.html
+++ b/examples/getting-service-metadata.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/gp-plugin.html
+++ b/examples/gp-plugin.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/identifying-features.html
+++ b/examples/identifying-features.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/identifying-imagery.html
+++ b/examples/identifying-imagery.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/image-map-layer-mosaic-rule.html
+++ b/examples/image-map-layer-mosaic-rule.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/image-map-layer-rendering-rule.html
+++ b/examples/image-map-layer-rendering-rule.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/imagery-popups.html
+++ b/examples/imagery-popups.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/index.html
+++ b/examples/index.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/infrared-imagery.html
+++ b/examples/infrared-imagery.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/labeling-features.html
+++ b/examples/labeling-features.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/non-mercator-projection.html
+++ b/examples/non-mercator-projection.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/parse-feature-collection.html
+++ b/examples/parse-feature-collection.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/premium-content.html
+++ b/examples/premium-content.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/querying-feature-layers-1.html
+++ b/examples/querying-feature-layers-1.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/querying-feature-layers-2.html
+++ b/examples/querying-feature-layers-2.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/renderers-plugin.html
+++ b/examples/renderers-plugin.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/retina-basemap.html
+++ b/examples/retina-basemap.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/reverse-geocoding.html
+++ b/examples/reverse-geocoding.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/search-feature-layer.html
+++ b/examples/search-feature-layer.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/search-map-service.html
+++ b/examples/search-map-service.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/showing-a-basemap-boy.html
+++ b/examples/showing-a-basemap-boy.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/showing-a-basemap.html
+++ b/examples/showing-a-basemap.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/simple-dynamic-map-layer.html
+++ b/examples/simple-dynamic-map-layer.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/simple-feature-layer.html
+++ b/examples/simple-feature-layer.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/simple-image-map-layer.html
+++ b/examples/simple-image-map-layer.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/simplifying-complex-features.html
+++ b/examples/simplifying-complex-features.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/spatial-queries.html
+++ b/examples/spatial-queries.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/styling-clusters.html
+++ b/examples/styling-clusters.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/styling-feature-layer-points.html
+++ b/examples/styling-feature-layer-points.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/styling-feature-layer-polygons.html
+++ b/examples/styling-feature-layer-polygons.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/styling-feature-layer-polylines.html
+++ b/examples/styling-feature-layer-polylines.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/styling-heatmaps.html
+++ b/examples/styling-heatmaps.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/switching-basemaps.html
+++ b/examples/switching-basemaps.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/tile-layer-1.html
+++ b/examples/tile-layer-1.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/tile-layer-2.html
+++ b/examples/tile-layer-2.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/visualize-points-as-a-heatmap.html
+++ b/examples/visualize-points-as-a-heatmap.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/visualizing-time-on-dynamic-map-layer.html
+++ b/examples/visualizing-time-on-dynamic-map-layer.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/visualizing-time-with-feature-layer.html
+++ b/examples/visualizing-time-with-feature-layer.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/examples/zooming-to-all-features.html
+++ b/examples/zooming-to-all-features.html
@@ -23,9 +23,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../../esri-leaflet/css/style.css">

--- a/index.html
+++ b/index.html
@@ -21,9 +21,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="../../esri-leaflet/css/style.css">


### PR DESCRIPTION
I updated the Google Fonts URLs to be protocol-relative instead of strictly HTTP -- I was getting mixed content warning in Chrome, and Opera was blocking the files outright. Also, as a side note, GitHub pages supports HTTPS (if you wanted to update the URL in the repo description).