### PR TITLE
Use protocol-relative URLs for Google Fonts

### DIFF
--- a/site/source/partials/header.hbs
+++ b/site/source/partials/header.hbs
@@ -25,9 +25,9 @@
   <![endif]-->
 
   <!-- google fonts -->
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Vollkorn:400italic,700italic,400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Source+Code+Pro:300">
-  <link href='http://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
   <!-- stylesheet -->
   <link rel="stylesheet" href="{{assets}}css/style.css">


### PR DESCRIPTION
I updated the Google Fonts URLs to be protocol-relative instead of strictly HTTP -- I was getting mixed content warning in Chrome, and Opera was blocking the files outright. Also, as a side note, GitHub pages supports HTTPS (if you wanted to update the URL in the repo description).