### PR TITLE
added terrain and labels to api reference

### DIFF
--- a/site/source/pages/api-reference/layers/basemap-layer.md
+++ b/site/source/pages/api-reference/layers/basemap-layer.md
@@ -38,6 +38,7 @@ These maps have worldwide coverage at a variety of zoom levels.
 * `DarkGray`
 * `Imagery`
 * `ShadedRelief`
+* `Terrain`
 
 ##### Optional Labels
 
@@ -46,9 +47,10 @@ These are optional layers that add extra text labels to the basemaps.
 * `OceansLabels` - Labels to pair with the `Oceans` basemap
 * `GrayLabels` - Labels to pair with the `Gray` basemap
 * `DarkGrayLabels` - Labels to pair with the `DarkGray` basemap
-* `ImageryLabels` - Labels and political boundaries to pair with the `Imagery` basemap
-* `ImageryTransportation` - A street map for pairing with the `Imagery` basemap=
+* `ImageryLabels` - Labels including political boundaries to pair with the `Imagery` basemap
+* `ImageryTransportation` - Street map labels for pairing with the `Imagery` basemap
 * `ShadedReliefLabels` - Labels for pairing with the `ShadedRelief` base map
+* `TerrainLabels` - Labels for pairing with the `Terrain` base map
 
 ### Options
 

--- a/src/Layers/BasemapLayer.js
+++ b/src/Layers/BasemapLayer.js
@@ -148,7 +148,7 @@
             minZoom: 1,
             maxZoom: 13,
             subdomains: ['server', 'services'],
-            attribution: 'ESRI, NAVTEQ, DeLorme'
+            attribution: 'Esri, NAVTEQ, DeLorme'
           }
         },
         ShadedReliefLabels: {


### PR DESCRIPTION
closes #504

* added `Terrain` and `TerrainLabels` to API Reference
* fixed a couple other typos in the API Reference
* updated the casing of 'Esri' in the attribution for `ShadedRelief`

(i didn't add the basemap to our switcher sample because it doesn't have tiles cooked deep enough in Australia)