### PR TITLE
disable scrollwheel zooming until someone clicks on the map

### DIFF
--- a/site/source/js/script.js
+++ b/site/source/js/script.js
@@ -15,8 +15,10 @@ L.esri.Layers.basemapLayer('Imagery', {
 
 if (map) {
   map.scrollWheelZoom.disable();
+  map.on("click", accidentalScroll);
+}
 
-  map.on("click", function(){
-    map.scrollWheelZoom.enable();
-  })
+function accidentalScroll() {
+  map.scrollWheelZoom.enable();
+  map.off("click", accidentalScroll);
 }

--- a/site/source/js/script.js
+++ b/site/source/js/script.js
@@ -12,3 +12,11 @@ var bgmap = L.map('background-map', {
 L.esri.Layers.basemapLayer('Imagery', {
   hideLogo: true
 }).addTo(bgmap);
+
+if (map) {
+  map.scrollWheelZoom.disable();
+
+  map.on("click", function(){
+    map.scrollWheelZoom.enable();
+  })
+}


### PR DESCRIPTION
improvement of behavior pointed out in #499.

i felt like the best way to mitigate unintentional scrolling of the map when developers are perusing the website is to disable the behavior until the map has been clicked.

some things to consider:
  1. there might be better place to inject this code so it won't run on pages other than the examples
  2. i'm not 100% certain that all samples follow the same convention of using `map` as a variable name, but i checked about a dozen that were consistent.  if not, no harm..