### PR TITLE
ensure that grunt-s3 gzips content prior to uploading

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -376,6 +376,7 @@ module.exports = function(grunt) {
         secret: '<%= aws.secret %>',
         bucket: '<%= aws.bucket %>',
         access: 'public-read',
+        gzip: true,
         headers: {
           // 1 Year cache policy (1000 * 60 * 60 * 24 * 365)
           'Cache-Control': 'max-age=630720000, public',


### PR DESCRIPTION
that was easier than i expected it to be (because of [this](https://github.com/pifantastic/grunt-s3/blob/master/tasks/lib/s3.js#L174))...

closes #489 

i'm not sure whether [this](http://stackoverflow.com/questions/5442011/serving-gzipped-css-and-javascript-from-amazon-cloudfront-via-s3) is stale information, but since s3 doesn't support gzipping on the fly, if there are still clients that can't understand static gzipped content, we might want to consider either not merging this or maintaining a seperate directory of gzipped source.

in general, the initial downloads are substantially smaller!
```html
<script src="//cdn-geoweb.s3.amazonaws.com/esri-leaflet-compressed/1.0.0-rc.7/esri-leaflet.js"></script>
```
> esri-leaflet.js clocks in at **13.3**kb (from 51.5kb)
> esri-leaflet.js.map clocks in at **41.1**kb (from 160kb)