### PR TITLE
added deleteFeatures methods

### DIFF
--- a/site/source/pages/api-reference/layers/feature-layer.md
+++ b/site/source/pages/api-reference/layers/feature-layer.md
@@ -277,7 +277,7 @@ featureLayer.query()
                 Adds a new feature to the feature layer. this also adds the feature to the map if creation is successful.
                 <ul>
                     <li>Requires authentication as a user who has permission to edit the service in ArcGIS Online or the user who created the service.</li>
-                    <li>Requires the <code>Create</code> capability be enabled on the service. You can check if creation exists by checking the metadata of your service under capabilities in the metadata.</li>
+                    <li>Requires the <code>Create</code> capability be enabled on the service. You can check if creation exists by checking the metadata of your service under capabilities.</li>
                 </ul>
             </td>
         </tr>
@@ -288,7 +288,7 @@ featureLayer.query()
                 Update the provided feature on the Feature Layer. This also updates the feature on the map.
                 <ul>
                     <li>Requires authentication as a user who has permission to edit the service in ArcGIS Online or the user who created the service.</li>
-                    <li>Requires the <code>Update</code> capability be enabled on the service. You can check if creation exists by checking the metadata of your service under capabilities in the metadata.</li>
+                    <li>Requires the <code>Update</code> capability be enabled on the service. You can check if this operation exists by checking the metadata of your service under capabilities.</li>
                 </ul>
             </td>
         </tr>
@@ -299,7 +299,18 @@ featureLayer.query()
                 Remove the feature with the provided id from the feature layer. This will also remove the feature from the map if it exists.
                 <ul>
                     <li>Requires authentication as a user who has permission to edit the service in ArcGIS Online or the user who created the service.</li>
-                    <li>Requires the <code>Update</code> capability be enabled on the service. You can check if creation exists by checking the metadata of your service under capabilities in the metadata.</li>
+                    <li>Requires the <code>Delete</code> capability be enabled on the service. You can check if this operation exists by checking the metadata of your service under capabilities.</li>
+                </ul>
+            </td>
+        </tr>
+        <tr>
+            <td><code>deleteFeatures({{{param 'Array of String or Integers' 'ids'}}}, {{{param 'Function' 'callback'}}}, {{{param 'Object' 'context'}}})</code></td>
+            <td><code>this</code></td>
+            <td>
+                Removes an array of features with the provided ids from the feature layer. This will also remove the features from the map if they exist.
+                <ul>
+                    <li>Requires authentication as a user who has permission to edit the service in ArcGIS Online or the user who created the service.</li>
+                    <li>Requires the <code>Delete</code> capability be enabled on the service. You can check if this operation exists by checking the metadata of your service under capabilities.</li>
                 </ul>
             </td>
         </tr>

--- a/site/source/pages/api-reference/services/feature-layer.md
+++ b/site/source/pages/api-reference/services/feature-layer.md
@@ -65,7 +65,7 @@ Inherits from [`L.esri.Service`]({{assets}}api-reference/services/service.html)
                 Adds a new feature to the feature layer. this also adds the feature to the map if creation is successful.
                 <ul>
                     <li>Requires authentication as a user who has permission to edit the service in ArcGIS Online or the user who created the service.</li>
-                    <li>Requires the <code>Create</code> capability be enabled on the service. You can check if creation exists by checking the metadata of your service under capabilities in the metadata.</li>
+                    <li>Requires the <code>Create</code> capability be enabled on the service. You can check if creation exists by checking the metadata of your service under capabilities.</li>
                 </ul>
             </td>
         </tr>
@@ -76,7 +76,7 @@ Inherits from [`L.esri.Service`]({{assets}}api-reference/services/service.html)
                 Update the provided feature on the Feature Layer. This also updates the feature on the map.
                 <ul>
                     <li>Requires authentication as a user who has permission to edit the service in ArcGIS Online or the user who created the service.</li>
-                    <li>Requires the <code>Update</code> capability be enabled on the service. You can check if creation exists by checking the metadata of your service under capabilities in the metadata.</li>
+                    <li>Requires the <code>Update</code> capability be enabled on the service. You can check if this operation exists by checking the metadata of your service under capabilities.</li>
                 </ul>
             </td>
         </tr>
@@ -86,8 +86,19 @@ Inherits from [`L.esri.Service`]({{assets}}api-reference/services/service.html)
             <td>
                 Remove the feature with the provided id from the feature layer. This will also remove the feature from the map if it exists.
                 <ul>
-                    <li>Requires authentication as a user who has permission to edit the service in ArcGIS Online or the user who created the srevice.</li>
-                    <li>Requires the <code>Update</code> capability be enabled on the service. You can check if creation exists by checking the metadata of your service under capabilities in the metadata.</li>
+                    <li>Requires authentication as a user who has permission to edit the service in ArcGIS Online or the user who created the service.</li>
+                    <li>Requires the <code>Delete</code> capability be enabled on the service. You can check if this operation exists by checking the metadata of your service under capabilities.</li>
+                </ul>
+            </td>
+        </tr>
+        <tr>
+            <td><code>deleteFeatures({{{param 'Array of String or Integers' 'ids'}}}, {{{param 'Function' 'callback'}}}, {{{param 'Object' 'context'}}})</code></td>
+            <td><code>this</code></td>
+            <td>
+                Removes an array of features with the provided ids from the feature layer. This will also remove the features from the map if they exist.
+                <ul>
+                    <li>Requires authentication as a user who has permission to edit the service in ArcGIS Online or the user who created the service.</li>
+                    <li>Requires the <code>Delete</code> capability be enabled on the service. You can check if this operation exists by checking the metadata of your service under capabilities.</li>
                 </ul>
             </td>
         </tr>
@@ -96,7 +107,7 @@ Inherits from [`L.esri.Service`]({{assets}}api-reference/services/service.html)
 
 ### Examples
 
-**Note**: These examples use a public feature service on ArcGIS Online that required no authentication.
+**Note**: These examples use a public feature service on ArcGIS Online that does not require authentication.
 
 ##### Adding Features
 ```js

--- a/spec/Layers/FeatureLayer/FeatureLayerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureLayerSpec.js
@@ -116,7 +116,7 @@ describe('L.esri.Layers.FeatureLayer', function () {
     layer.addLayers([1]);
   });
 
-  it('should readd features back to a map', function(){
+  it('should read features back to a map', function(){
     map.removeLayer(layer.getFeature(1));
 
     layer.createLayers([{

--- a/spec/Layers/FeatureLayer/FeatureManagerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureManagerSpec.js
@@ -715,6 +715,30 @@ describe('L.esri.Layers.FeatureManager', function () {
     server.respond();
   });
 
+  it('should wrap the removeFeatures method on the underlying service', function(done){
+    server.respondWith('POST', 'http://gis.example.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0/deleteFeatures', JSON.stringify({
+      'deleteResults' : [{
+        'objectId' : 1,
+        'success' : true
+      },{
+        'objectId' : 2,
+        'success' : true
+      }]
+    }));
+
+    layer.deleteFeatures([1,2], function(error, response){
+      expect(layer.removeLayers).to.have.been.calledWith([1]);
+      expect(layer.removeLayers).to.have.been.calledWith([2]);
+      expect(response[1]).to.deep.equal({
+        'objectId': 2,
+        'success': true
+      });
+      done();
+    });
+
+    server.respond();
+  });
+
   it('should support generalizing geometries', function(){
     server.respondWith('GET', 'http://gis.example.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0/query?returnGeometry=true&where=1%3D1&outSr=4326&outFields=*&inSr=4326&geometry=%7B%22xmin%22%3A-122.6953125%2C%22ymin%22%3A45.521743896993634%2C%22xmax%22%3A-122.6513671875%2C%22ymax%22%3A45.55252525134013%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryEnvelope&spatialRel=esriSpatialRelIntersects&geometryPrecision=6&maxAllowableOffset=0.00004291534423829546&f=json', JSON.stringify({
       fields: fields,

--- a/spec/Services/FeatureLayerSpec.js
+++ b/spec/Services/FeatureLayerSpec.js
@@ -129,7 +129,7 @@ describe('L.esri.Services.FeatureLayer', function () {
     }));
   });
 
-  it('should be able to remove features from the layer', function(){
+  it('should be able to remove a feature from the layer', function(){
     var callback = sinon.spy();
 
     service.deleteFeature(1, callback);
@@ -162,5 +162,33 @@ describe('L.esri.Services.FeatureLayer', function () {
         'success' : true
       }]
     }));
+  });
+
+  it('should be able to remove features from the layer', function(){
+    var callback = sinon.spy();
+
+    service.deleteFeatures([1,2], callback);
+
+    requests[0].respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify({
+      'deleteResults' : [{
+        'objectId' : 1,
+        'success' : true
+      },{
+        'objectId' : 2,
+        'success' : true
+      }]
+    }));
+
+    var requestBody = window.decodeURIComponent(requests[0].requestBody);
+
+    expect(requestBody).to.equal('objectIds=1,2&f=json');
+
+    callback.should.have.been.calledWith(undefined, [{
+      'objectId' : 1,
+      'success' : true
+    },{
+      'objectId' : 2,
+      'success' : true
+    }]);
   });
 });

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -415,7 +415,21 @@
           callback.call(context, error, response);
         }
       }, this);
+    },
+
+    deleteFeatures: function(ids, callback, context){
+      return this._service.deleteFeatures(ids, function(error, response){
+        if(!error && response.length > 0){
+          for (var i=0; i<response.length; i++){
+            this.removeLayers([response[i].objectId], true);
+          }
+        }
+        if(callback){
+          callback.call(context, error, response);
+        }
+      }, this);
     }
+
   });
 
   /**

--- a/src/Services/FeatureLayer.js
+++ b/src/Services/FeatureLayer.js
@@ -45,6 +45,18 @@ EsriLeaflet.Services.FeatureLayer = EsriLeaflet.Services.Service.extend({
         callback.call(context, error || response.deleteResults[0].error, result);
       }
     }, context);
+  },
+
+  deleteFeatures: function(ids, callback, context) {
+    return this.post('deleteFeatures', {
+      objectIds: ids
+    }, function(error, response){
+      // pass back the entire array
+      var result = (response && response.deleteResults) ? response.deleteResults : undefined;
+      if(callback){
+        callback.call(context, error || response.deleteResults[0].error, result);
+      }
+    }, context);
   }
 
 });


### PR DESCRIPTION
i've added a couple methods so that clients can pass an array of objectIds in a single request to the server.

```javascript
map.on('draw:deleted', function(e) {
    var delArray = [];
    e.layers.eachLayer(function(layer) {
      var id = layer.feature.id;
      delArray.push(id);
    });
    pedestrianDistricts.deleteFeatures(delArray, function(error, response) {
      console.log(error, response);
    });
});
```
to do:
- [x] - write tests
- [ ] - update our sample app to use the new method
- [x] - update the doc