### PR TITLE
bump to jsdelivr latest

### DIFF
--- a/site/source/layouts/example.hbs
+++ b/site/source/layouts/example.hbs
@@ -25,7 +25,8 @@ layout: page.hbs
   <script src="//cdn.jsdelivr.net/leaflet/0.7.3/leaflet.js"></script>
 
   <!-- Load Esri Leaflet from CDN -->
-  <script src="//cdn-geoweb.s3.amazonaws.com/esri-leaflet/1.0.0-rc.6/esri-leaflet.js"></script>
+  <!-- we encourage you to replace 'latest' with a hardcode version number (like '1.0.0-rc.7') in production applications -->
+  <script src="//cdn.jsdelivr.net/leaflet.esri/latest/esri-leaflet.js"></script>
 
   <style>
     body {margin:0;padding:0;}

--- a/site/source/pages/download/index.md
+++ b/site/source/pages/download/index.md
@@ -8,7 +8,7 @@ class: no-sidebar
 
 All builds of Esri Leaflet are available for download on [GitHub](https://github.com/Esri/esri-leaflet/releases/).
 
-<a href="https://github.com/Esri/esri-leaflet/releases/download/v1.0.0-rc.6/esri-leaflet-v1.0.0-rc.6.zip" class="btn">Current Release</a>
+<a href="https://github.com/Esri/esri-leaflet/releases/download/v1.0.0-rc.7/esri-leaflet-v1.0.0-rc.7.zip" class="btn">Current Release</a>
 <a href="https://github.com/Esri/esri-leaflet/releases/" class="btn">Past Releases</a>
 
 # npm
@@ -29,12 +29,13 @@ bower install esri-leaflet
 
 # CDN
 
-Esri Leaflet is currently hosted on Amazon Cloudfront to make it easily available. After the beta period it will be available on [jsDelivr](http://www.jsdelivr.com/).
+Esri Leaflet is hosted on [jsDelivr](http://www.jsdelivr.com/).
 
 #### Standard Build
 
 ```xml
-<script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet/1.0.0-rc.6/esri-leaflet.js"></script>
+<script src="http://cdn.jsdelivr.net/leaflet.esri/1.0.0-rc.7/esri-leaflet.js"></script>
+
 ```
 
 #### Other Builds
@@ -43,22 +44,22 @@ Esri Leaflet is also built into several smaller components and plugins for speci
 
 ```xml
 <!-- Core Build -->
-<script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet/1.0.0-rc.6/esri-leaflet-core.js"></script>
+<script src="http://cdn.jsdelivr.net/leaflet.esri/1.0.0-rc.7/esri-leaflet-core.js"></script>
 
 <!-- Basemaps Only Build -->
-<script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet/1.0.0-rc.6/esri-leaflet-basemaps.js"></script>
+<script src="http://cdn.jsdelivr.net/leaflet.esri/1.0.0-rc.7/esri-leaflet-basemaps.js"></script>
 
 <!-- Feature Layer Only Build -->
-<script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet/1.0.0-rc.6/esri-leaflet-feature-layer.js"></script>
+<script src="http://cdn.jsdelivr.net/leaflet.esri/1.0.0-rc.7/esri-leaflet-feature-layer.js"></script>
 
 <!-- Map Service Only Build -->
-<script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet/1.0.0-rc.6/esri-leaflet-map-service.js"></script>
+<script src="http://cdn.jsdelivr.net/leaflet.esri/1.0.0-rc.7/esri-leaflet-map-service.js"></script>
 
 <!-- Heatmap Feature Layer -->
-<script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-heatmap-feature-layer/1.0.0-rc.2/esri-leaflet-heatmap-feature-layer.js"></script>
+<script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-heatmap-feature-layer/1.0.0-rc.3/esri-leaflet-heatmap-feature-layer.js"></script>
 
 <!-- Clustered Feature Layer -->
-<script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-clustered-feature-layer/1.0.0-rc.2/esri-leaflet-clustered-feature-layer.js"></script>
+<script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-clustered-feature-layer/1.0.0-rc.4/esri-leaflet-clustered-feature-layer.js"></script>
 
 <!-- Geocoding Control -->
 <script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-geocoder/1.0.0-rc.4/esri-leaflet-geocoder.js"></script>

--- a/site/source/pages/examples/simple-dynamic-map-layer.hbs
+++ b/site/source/pages/examples/simple-dynamic-map-layer.hbs
@@ -12,6 +12,7 @@ layout: example.hbs
   L.esri.basemapLayer('Gray').addTo(map);
 
   L.esri.dynamicMapLayer('http://maps1.arcgisonline.com/ArcGIS/rest/services/USA_Federal_Lands/MapServer', {
-    opacity: 0.5
+    opacity: 0.5,
+    useCors: false
   }).addTo(map);
 </script>

--- a/site/source/partials/header.hbs
+++ b/site/source/partials/header.hbs
@@ -37,7 +37,7 @@
   <script src="//cdn.jsdelivr.net/leaflet/0.7.3/leaflet.js"></script>
 
   <!-- Load Esri Leaflet from CDN -->
-  <script src="//cdn-geoweb.s3.amazonaws.com/esri-leaflet/1.0.0-rc.6/esri-leaflet.js"></script>
+  <script src="//cdn.jsdelivr.net/leaflet.esri/latest/esri-leaflet.js"></script>
 
   <!-- Google Analytics -->
   <script>


### PR DESCRIPTION
bump to start using jsdelivr 'latest' url in samples
update dynamic map service sample to account for breaking change
