### PR TITLE
stop replacing double quotes in where strings

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -262,7 +262,8 @@ module.exports = function(grunt) {
       },
       run: {
         reporters: ['progress'],
-        browsers: browsers
+        browsers: browsers,
+        logLevel: 'VERBOSE'
       },
       coverage: {
         reporters: ['progress', 'coverage'],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -263,7 +263,7 @@ module.exports = function(grunt) {
       run: {
         reporters: ['progress'],
         browsers: browsers,
-        logLevel: 'VERBOSE'
+        logLevel: 'ERROR'
       },
       coverage: {
         reporters: ['progress', 'coverage'],

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -42,8 +42,10 @@ module.exports = function(config) {
       // 'spec/Tasks/*Spec.js',
       // 'spec/Services/*Spec.js',
       // 'spec/Layers/**/*Spec.js',
-      'spec/**/*Spec.js'
-      // 'spec/Layers/ImageMapLayerSpec.js'
+      // 'spec/**/*Spec.js'
+      // 'spec/Layers/ImageMapLayerSpec.js',
+      // 'spec/**/QuerySpec.js',
+      'spec/**/FeatureManagerSpec.js'
     ],
 
     // list of files to exclude

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -37,15 +37,16 @@ module.exports = function(config) {
       'src/Tasks/IdentifyImage.js',
       'src/Tasks/Find.js',
       'src/Controls/Logo.js',
+      'spec/**/*Spec.js'
       // 'spec/UtilSpec.js',
       // 'spec/RequestSpec.js',
       // 'spec/Tasks/*Spec.js',
       // 'spec/Services/*Spec.js',
       // 'spec/Layers/**/*Spec.js',
-      // 'spec/**/*Spec.js'
+
       // 'spec/Layers/ImageMapLayerSpec.js',
       // 'spec/**/QuerySpec.js',
-      'spec/**/FeatureManagerSpec.js'
+      // 'spec/**/FeatureManagerSpec.js'
     ],
 
     // list of files to exclude

--- a/site/source/pages/api-reference/layers/feature-layer.md
+++ b/site/source/pages/api-reference/layers/feature-layer.md
@@ -66,12 +66,12 @@ You can create a new empty feature service with a single layer on the [ArcGIS fo
         <tr>
             <td><code>onEachFeature({{{param 'GeoJSON Feature' 'feature' 'http://geojson.org/geojson-spec.html#feature-objects'}}}, {{{param 'ILayer' 'layer' 'http://leafletjs.com/reference.html#ilayer'}}})</code></td>
             <td><code>Function</code></td>
-            <td> </td>
+            <td>Provides an opportunity to introspect individual GeoJSON features in the layer.</td>
         </tr>
         <tr>
             <td><code>where</code></td>
             <td><code>String</code></td>
-            <td>A server side expression that will be evaluated to filter features. By default this will include all features in a service.</td>
+            <td>An optional expression to filter features server side. String values should be denoted using single quotes ie: `where: "FIELDNAME = 'field value'";` More information about valid SQL can be found <a href="http://resources.arcgis.com/en/help/main/10.2/index.html#/SQL_reference_for_query_expressions_used_in_ArcGIS/00s500000033000000/">here</a>.</td>
         </tr>
         <tr>
             <td><code>minZoom</code></td>
@@ -218,7 +218,7 @@ In addition to the events above, `L.esri.Layers.FeatureLayer` also fires the fol
         <tr>
             <td><code>getFeature({{{param 'String or Integer' id}}} id)</code></td>
             <td><code>Layer</code></td>
-            <td>Given the id of a Feature return the layer on the map that represents it. This will usually be a Leaflet vector layer like <a href="http://leafletjs.com/reference.html#polyline">Polygon</a> or <a href="http://leafletjs.com/reference.html#polyline">Polygon</a>, or a Leaflet <a href="http://leafletjs.com/reference.html#marker">Marker</a>.</td>
+            <td>Given the id of a Feature return the layer on the map that represents it. This will usually be a Leaflet vector layer like <a href="http://leafletjs.com/reference.html#polyline">Polyline</a> or <a href="http://leafletjs.com/reference.html#polygon">Polygon</a>, or a Leaflet <a href="http://leafletjs.com/reference.html#marker">Marker</a>.</td>
         </tr>
         <tr>
             <td><code>getWhere()</code></td>

--- a/site/source/pages/api-reference/tasks/query.md
+++ b/site/source/pages/api-reference/tasks/query.md
@@ -78,7 +78,7 @@ layout: documentation.hbs
         <tr>
             <td><code>where({{{param 'String' 'where'}}})</code></td>
             <td><code>this</code></td>
-            <td>Adds a `where` paramter to the query.</td>
+            <td>Adds a `where` clause to the query.  String values should be denoted using single quotes ie: `query.where("FIELDNAME = 'field value'");` More info about valid SQL can be found <a href="http://resources.arcgis.com/en/help/main/10.2/index.html#/SQL_reference_for_query_expressions_used_in_ArcGIS/00s500000033000000/">here</a>.</td>
         </tr>
         <tr>
             <td><code>offset({{{param 'Integer' 'offset'}}})</code></td>

--- a/spec/Layers/FeatureLayer/FeatureManagerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureManagerSpec.js
@@ -22,6 +22,7 @@ describe('L.esri.Layers.FeatureManager', function () {
   var MockLayer;
   var map = createMap();
   var oldRaf;
+  var requests;
 
   beforeEach(function(){
     xhr = sinon.useFakeXMLHttpRequest();
@@ -458,7 +459,7 @@ describe('L.esri.Layers.FeatureManager', function () {
     }]);
   });
 
-  xit('should filter features with a where parameter', function(){
+  it('should filter features with a where parameter', function(){
     server.respondWith('GET', 'http://gis.example.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0/query?returnGeometry=true&where=Type%3D\'Active\'&outSr=4326&outFields=*&inSr=4326&geometry=%7B%22xmin%22%3A-122.6953125%2C%22ymin%22%3A45.521743896993634%2C%22xmax%22%3A-122.6513671875%2C%22ymax%22%3A45.55252525134013%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryEnvelope&spatialRel=esriSpatialRelIntersects&geometryPrecision=6&f=json', JSON.stringify({
       fields: fields,
       features: [feature1],
@@ -471,13 +472,7 @@ describe('L.esri.Layers.FeatureManager', function () {
       objectIdFieldName: 'OBJECTID'
     }));
 
-    console.log(JSON.stringify({
-      fields: fields,
-      features: [feature1],
-      objectIdFieldName: 'OBJECTID'
-    }));
-
-    layer.setWhere("Type='Active'");
+    layer.setWhere('Type=\'Active\'');
 
     layer.addTo(map);
     server.respond();
@@ -499,7 +494,7 @@ describe('L.esri.Layers.FeatureManager', function () {
 
     var callback = sinon.spy();
 
-    layer.setWhere("Type='Inactive'", callback);
+    layer.setWhere('Type=\'Inactive\'', callback);
 
     server.respond();
 
@@ -652,36 +647,36 @@ describe('L.esri.Layers.FeatureManager', function () {
   });
 
   // this is now really difficult with fakeServer. Should use a simple request list.
-  it('should wrap the addFeature method on the underlying service', function(done){
-    layer._metadata = {
-      objectIdField: 'OBJECTID'
-    };
+  // xit('should wrap the addFeature method on the underlying service', function(done){
+  //   layer._metadata = {
+  //     objectIdField: 'OBJECTID'
+  //   };
 
-    layer.addFeature({
-      type: 'Feature',
-      geometry: {
-        type: 'Point',
-        coordinates: [45, -121]
-      },
-      properties: {
-        foo: 'bar'
-      }
-    }, function(error, response){
-      expect(response).to.deep.equal({
-        'objectId': 1,
-        'success': true
-      });
+  //   layer.addFeature({
+  //     type: 'Feature',
+  //     geometry: {
+  //       type: 'Point',
+  //       coordinates: [45, -121]
+  //     },
+  //     properties: {
+  //       foo: 'bar'
+  //     }
+  //   }, function(error, response){
+  //     expect(response).to.deep.equal({
+  //       'objectId': 1,
+  //       'success': true
+  //     });
 
-      done();
-    });
+  //     done();
+  //   });
 
-    requests[0].respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify({
-      'addResults' : [{
-        'objectId' : 1,
-        'success' : true
-      }]
-    }));
-  });
+  //   requests[0].respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify({
+  //     'addResults' : [{
+  //       'objectId' : 1,
+  //       'success' : true
+  //     }]
+  //   }));
+  // });
 
   it('should wrap the updateFeature method on the underlying service and refresh', function(done){
     server.respondWith('POST', 'http://gis.example.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0/updateFeatures', JSON.stringify({

--- a/spec/Layers/FeatureLayer/FeatureManagerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureManagerSpec.js
@@ -458,7 +458,7 @@ describe('L.esri.Layers.FeatureManager', function () {
     }]);
   });
 
-  it('should filter features with a where parameter', function(){
+  xit('should filter features with a where parameter', function(){
     server.respondWith('GET', 'http://gis.example.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0/query?returnGeometry=true&where=Type%3D\'Active\'&outSr=4326&outFields=*&inSr=4326&geometry=%7B%22xmin%22%3A-122.6953125%2C%22ymin%22%3A45.521743896993634%2C%22xmax%22%3A-122.6513671875%2C%22ymax%22%3A45.55252525134013%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryEnvelope&spatialRel=esriSpatialRelIntersects&geometryPrecision=6&f=json', JSON.stringify({
       fields: fields,
       features: [feature1],
@@ -471,7 +471,13 @@ describe('L.esri.Layers.FeatureManager', function () {
       objectIdFieldName: 'OBJECTID'
     }));
 
-    layer.setWhere('Type="Active"');
+    console.log(JSON.stringify({
+      fields: fields,
+      features: [feature1],
+      objectIdFieldName: 'OBJECTID'
+    }));
+
+    layer.setWhere("Type='Active'");
 
     layer.addTo(map);
     server.respond();
@@ -493,7 +499,7 @@ describe('L.esri.Layers.FeatureManager', function () {
 
     var callback = sinon.spy();
 
-    layer.setWhere('Type="Inactive"', callback);
+    layer.setWhere("Type='Inactive'", callback);
 
     server.respond();
 
@@ -646,7 +652,7 @@ describe('L.esri.Layers.FeatureManager', function () {
   });
 
   // this is now really difficult with fakeServer. Should use a simple request list.
-  xit('should wrap the addFeature method on the underlying service', function(done){
+  it('should wrap the addFeature method on the underlying service', function(done){
     layer._metadata = {
       objectIdField: 'OBJECTID'
     };

--- a/spec/Tasks/QuerySpec.js
+++ b/spec/Tasks/QuerySpec.js
@@ -444,7 +444,7 @@ describe('L.esri.Tasks.Query', function () {
   it('should query features with a where option', function(done){
     server.respondWith('GET', featureLayerUrl + 'query?returnGeometry=true&where=NAME%3D\'Site\'&outSr=4326&outFields=*&f=json', JSON.stringify(sampleQueryResponse));
 
-    task.where('NAME="Site"').run(function(error, featureCollection, raw){
+    task.where("NAME='Site'").run(function(error, featureCollection, raw){
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleQueryResponse);
       done();

--- a/spec/Tasks/QuerySpec.js
+++ b/spec/Tasks/QuerySpec.js
@@ -444,7 +444,7 @@ describe('L.esri.Tasks.Query', function () {
   it('should query features with a where option', function(done){
     server.respondWith('GET', featureLayerUrl + 'query?returnGeometry=true&where=NAME%3D\'Site\'&outSr=4326&outFields=*&f=json', JSON.stringify(sampleQueryResponse));
 
-    task.where("NAME='Site'").run(function(error, featureCollection, raw){
+    task.where('NAME=\'Site\'').run(function(error, featureCollection, raw){
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleQueryResponse);
       done();

--- a/src/Tasks/Query.js
+++ b/src/Tasks/Query.js
@@ -67,8 +67,8 @@ EsriLeaflet.Tasks.Query = EsriLeaflet.Tasks.Task.extend({
   },
 
   where: function(string){
+    // instead of converting double-quotes to single quotes, pass as is, and provide a more informative message if a 400 is encountered
     this.params.where = string;
-    // string.replace(/"/g, "\'"); // jshint ignore:line
     return this;
   },
 
@@ -98,25 +98,16 @@ EsriLeaflet.Tasks.Query = EsriLeaflet.Tasks.Task.extend({
       this.params.f = 'geojson';
 
       return this.request(function(error, response){
-        console.log(error);
-        if (error && console && console.warn){
-          console.warn('one common cause of syntax errors when executing queries is encasing string values in double quotes instead of single quotes');
-        }
-        // this._trapSQLerrors(error);
+        this._trapSQLerrors(error);
         callback.call(context, error, response, response);
-      }, context);
+      }, this);
 
     // otherwise convert it in the callback then pass it on
     } else {
       return this.request(function(error, response){
-        //
-        console.log(error);
-        if (error && console && console.warn){
-          console.warn('one common cause of syntax errors when executing queries is encasing string values in double quotes instead of single quotes');
-        }
-        // this._trapSQLerrors(error);
+        this._trapSQLerrors(error);
         callback.call(context, error, (response && EsriLeaflet.Util.responseToFeatureCollection(response)), response);
-      }, context);
+      }, this);
     }
   },
 
@@ -159,8 +150,10 @@ EsriLeaflet.Tasks.Query = EsriLeaflet.Tasks.Task.extend({
   },
 
   _trapSQLerrors: function(error){
-    if (error && console && console.warn){
-      console.warn('one common cause of syntax errors when executing queries is encasing string values in double quotes instead of single quotes');
+    if (error){
+      if (error.code === '400' && console && console.warn){
+        console.warn('one common syntax error in query requests is encasing string values in double quotes instead of single quotes');
+      }
     }
   },
 

--- a/src/Tasks/Query.js
+++ b/src/Tasks/Query.js
@@ -98,14 +98,25 @@ EsriLeaflet.Tasks.Query = EsriLeaflet.Tasks.Task.extend({
       this.params.f = 'geojson';
 
       return this.request(function(error, response){
-        callback.call(context, this._parseError(error), response, response);
-      }, this);
+        console.log(error);
+        if (error && console && console.warn){
+          console.warn('one common cause of syntax errors when executing queries is encasing string values in double quotes instead of single quotes');
+        }
+        // this._trapSQLerrors(error);
+        callback.call(context, error, response, response);
+      }, context);
 
     // otherwise convert it in the callback then pass it on
     } else {
       return this.request(function(error, response){
-        callback.call(context, this._parseError(error), (response && EsriLeaflet.Util.responseToFeatureCollection(response)), response);
-      }, this);
+        //
+        console.log(error);
+        if (error && console && console.warn){
+          console.warn('one common cause of syntax errors when executing queries is encasing string values in double quotes instead of single quotes');
+        }
+        // this._trapSQLerrors(error);
+        callback.call(context, error, (response && EsriLeaflet.Util.responseToFeatureCollection(response)), response);
+      }, context);
     }
   },
 
@@ -147,17 +158,16 @@ EsriLeaflet.Tasks.Query = EsriLeaflet.Tasks.Task.extend({
     return this;
   },
 
+  _trapSQLerrors: function(error){
+    if (error && console && console.warn){
+      console.warn('one common cause of syntax errors when executing queries is encasing string values in double quotes instead of single quotes');
+    }
+  },
+
   _cleanParams: function(){
     delete this.params.returnIdsOnly;
     delete this.params.returnExtentOnly;
     delete this.params.returnCountOnly;
-  },
-
-  _parseError: function(error){
-    if (error && error.code === 400){
-      error.moreInfo = 'one common cause of syntax errors when executing queries is encasing string values in double quotes instead of single quotes';
-      return error;
-    }
   },
 
   _setGeometry: function(geometry) {

--- a/src/Tasks/Query.js
+++ b/src/Tasks/Query.js
@@ -67,7 +67,8 @@ EsriLeaflet.Tasks.Query = EsriLeaflet.Tasks.Task.extend({
   },
 
   where: function(string){
-    this.params.where = string.replace(/"/g, "\'"); // jshint ignore:line
+    this.params.where = string;
+    // string.replace(/"/g, "\'"); // jshint ignore:line
     return this;
   },
 
@@ -97,14 +98,14 @@ EsriLeaflet.Tasks.Query = EsriLeaflet.Tasks.Task.extend({
       this.params.f = 'geojson';
 
       return this.request(function(error, response){
-        callback.call(context, error, response, response);
-      }, context);
+        callback.call(context, this._parseError(error), response, response);
+      }, this);
 
     // otherwise convert it in the callback then pass it on
     } else {
       return this.request(function(error, response){
-        callback.call(context, error, (response && EsriLeaflet.Util.responseToFeatureCollection(response)), response);
-      }, context);
+        callback.call(context, this._parseError(error), (response && EsriLeaflet.Util.responseToFeatureCollection(response)), response);
+      }, this);
     }
   },
 
@@ -150,6 +151,13 @@ EsriLeaflet.Tasks.Query = EsriLeaflet.Tasks.Task.extend({
     delete this.params.returnIdsOnly;
     delete this.params.returnExtentOnly;
     delete this.params.returnCountOnly;
+  },
+
+  _parseError: function(error){
+    if (error && error.code === 400){
+      error.moreInfo = 'one common cause of syntax errors when executing queries is encasing string values in double quotes instead of single quotes';
+      return error;
+    }
   },
 
   _setGeometry: function(geometry) {


### PR DESCRIPTION
instead:
 * add an example and link to more SQL syntax help in the API reference
 * provide an error in the console explaining that doublequoted strings are a common reason for 400 errors
 * make existing tests syntactically correct