### PR TITLE
make sure appropriate icon for each marker is used when calling FeatureLayer.refresh();

### DIFF
--- a/debug/refresh-circle.html
+++ b/debug/refresh-circle.html
@@ -1,0 +1,142 @@
+  <!DOCTYPE html>
+  <html>
+  <head>
+    <meta charset=utf-8 />
+    <title>refresh circleMarkers</title>
+    <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+
+    <!-- Load Leaflet from CDN-->
+    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
+    <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
+
+    <!-- Load Esri Leaflet from source-->
+    <script src="../src/EsriLeaflet.js"></script>
+    <script src="../src/Request.js"></script>
+    <script src="../src/Util.js"></script>
+    <script src="../src/Controls/Logo.js"></script>
+
+    <script src="../src/Services/Service.js"></script>
+    <script src="../src/Services/FeatureLayer.js"></script>
+    <script src="../src/Services/ImageService.js"></script>
+    <script src="../src/Services/MapService.js"></script>
+
+    <script src="../src/Layers/FeatureLayer/FeatureGrid.js"></script>
+    <script src="../src/Layers/FeatureLayer/FeatureManager.js"></script>
+    <script src="../src/Layers/FeatureLayer/FeatureLayer.js"></script>
+
+    <script src="../src/Layers/RasterLayer.js"></script>
+    <script src="../src/Layers/ImageMapLayer.js"></script>
+    <script src="../src/Layers/TiledMapLayer.js"></script>
+    <script src="../src/Layers/BasemapLayer.js"></script>
+    <script src="../src/Layers/DynamicMapLayer.js"></script>
+
+    <script src="../src/Tasks/Task.js"></script>
+    <script src="../src/Tasks/Find.js"></script>
+    <script src="../src/Tasks/Identify.js"></script>
+    <script src="../src/Tasks/IdentifyFeatures.js"></script>
+    <script src="../src/Tasks/IdentifyImage.js"></script>
+    <script src="../src/Tasks/Query.js"></script>
+
+    <style>
+      body {
+        margin:0;
+        padding:0;
+      }
+
+      #map {
+        position: absolute;
+        top:0;
+        bottom:0;
+        right:0;left:0;
+      }
+
+      #info-pane {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        z-index: 10;
+        padding: 1em;
+        background: white;
+      }
+
+    </style>
+  </head>
+  <body>
+
+  <div id="map"></div>
+  <div id="info-pane" class="leaflet-bar">
+    <label>
+    status '0' - red circle<br>
+    status '1' - green circle<br><br>
+
+    <button onclick='postEdits()'>update 'status' attribute of objectid: 149478</button><br><br>
+    <div id='status-status'>current status of objectid: 150689 - ?</div><br>
+    <button onclick='refresh()'>refresh feature layer</button>
+    </label>
+  </div>
+  <script>
+    var bool = 0;
+
+    var map = L.map('map').setView([34.051, -117.199], 14);
+    L.esri.basemapLayer('Topographic').addTo(map);
+
+    var fl = L.esri.featureLayer('http://sampleserver6.arcgisonline.com/arcgis/rest/services/RedlandsEmergencyVehicles/FeatureServer/0', {
+      pointToLayer: function (geojson, latlng) {
+        if (geojson.properties.status === 0){
+            return L.circleMarker(latlng, {
+              color: 'red',
+              weight: 2,
+              opacity: 0.85,
+              fillOpacity: 0.5
+            });
+        }
+        else {
+          return L.circleMarker(latlng, {
+            color: 'green',
+            weight: 2,
+            opacity: 0.85,
+            fillOpacity: 0.5
+          });
+        }
+      }
+    }).addTo(map);
+
+    function postEdits () {
+      /*
+      original:
+      X: -117.20879371400002
+      Y: 34.05838465599999
+
+      freeway-ish
+      -117.2015
+      34.0635
+      */
+
+      /*
+      to do:
+      why aren't deleted features removed?
+      */
+
+      var updated = [{"geometry": { "x": -117.2015, "y": 34.0635 }, "attributes":{"OBJECTID":150689,"status":bool }}];
+
+      L.esri.post('http://sampleserver6.arcgisonline.com/arcgis/rest/services/RedlandsEmergencyVehicles/FeatureServer/0/updateFeatures', {
+          features: updated,
+          f: 'json'
+        }, function(error, response){
+        if(error){
+          console.log(error);
+        } else {
+          console.log(response);
+          document.getElementById('status-status').innerHTML = 'current status of objectid: 150689 - ' + bool;
+          bool = 1 - bool;
+        }
+      });
+    }
+
+    function refresh () {
+      fl.refresh();
+    }
+  </script>
+
+  </body>
+  </html>

--- a/debug/refresh-style.html
+++ b/debug/refresh-style.html
@@ -73,7 +73,7 @@
   <div id="map"></div>
   <div id="info-pane" class="leaflet-bar">
     <label>
-    <button onclick='postEdits()'>update status attribute of objectid: 149478</button><br>
+    <button onclick='postEdits()'>update 'status' attribute of objectid: 149478</button><br>
     <button onclick='refresh()'>refresh feature layer</button>
     </label>
   </div>
@@ -102,7 +102,17 @@
     }).addTo(map);
 
     function postEdits () {
-      var updated = [{"geometry": { "x": -117.20879371400002, "y": 34.05838465599999 }, "attributes":{"OBJECTID":149478,"status":0 }}];
+      /*
+      original:
+      X: -117.20879371400002
+      Y: 34.05838465599999
+
+      freeway-ish
+      -117.2015
+      34.0635
+      */
+
+      var updated = [{"geometry": { "x": -117.20879371400002, "y": 34.05838465599999 }, "attributes":{"OBJECTID":149478,"status":bool }}];
 
       L.esri.post('http://sampleserver6.arcgisonline.com/arcgis/rest/services/RedlandsEmergencyVehicles/FeatureServer/0/updateFeatures', {
           features: updated,
@@ -112,7 +122,7 @@
           console.log(error);
         } else {
           console.log(response);
-          bool = 1;
+          bool = 1 - bool;
         }
       });
     }

--- a/debug/refresh-style.html
+++ b/debug/refresh-style.html
@@ -73,7 +73,11 @@
   <div id="map"></div>
   <div id="info-pane" class="leaflet-bar">
     <label>
-    <button onclick='postEdits()'>update 'status' attribute of objectid: 149478</button><br>
+    status '0' - blue icon<br>
+    status '1' - red icon<br><br>
+
+    <button onclick='postEdits()'>update 'status' attribute of objectid: 149478</button><br><br>
+    <div id='status-status'>current status of objectid: 149478 - ?</div><br>
     <button onclick='refresh()'>refresh feature layer</button>
     </label>
   </div>
@@ -123,6 +127,7 @@
         } else {
           console.log(response);
           bool = 1 - bool;
+          document.getElementById('status-status').innerHTML = 'current status of objectid: 149478 - ' + bool;
         }
       });
     }

--- a/debug/refresh-style.html
+++ b/debug/refresh-style.html
@@ -125,9 +125,9 @@
         if(error){
           console.log(error);
         } else {
-          console.log(response);
-          bool = 1 - bool;
+          // console.log(response);
           document.getElementById('status-status').innerHTML = 'current status of objectid: 149478 - ' + bool;
+          bool = 1 - bool;
         }
       });
     }

--- a/debug/refresh-style.html
+++ b/debug/refresh-style.html
@@ -125,7 +125,6 @@
         if(error){
           console.log(error);
         } else {
-          // console.log(response);
           document.getElementById('status-status').innerHTML = 'current status of objectid: 149478 - ' + bool;
           bool = 1 - bool;
         }

--- a/debug/refresh-style.html
+++ b/debug/refresh-style.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+  <html>
+  <head>
+    <meta charset=utf-8 />
+    <title>refresh point icons</title>
+    <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+
+    <!-- Load Leaflet from CDN-->
+    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
+    <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
+
+    <!-- Load Esri Leaflet from source-->
+    <script src="../src/EsriLeaflet.js"></script>
+    <script src="../src/Request.js"></script>
+    <script src="../src/Util.js"></script>
+    <script src="../src/Controls/Logo.js"></script>
+
+    <script src="../src/Services/Service.js"></script>
+    <script src="../src/Services/FeatureLayer.js"></script>
+    <script src="../src/Services/ImageService.js"></script>
+    <script src="../src/Services/MapService.js"></script>
+
+    <script src="../src/Layers/FeatureLayer/FeatureGrid.js"></script>
+    <script src="../src/Layers/FeatureLayer/FeatureManager.js"></script>
+    <script src="../src/Layers/FeatureLayer/FeatureLayer.js"></script>
+
+    <script src="../src/Layers/RasterLayer.js"></script>
+    <script src="../src/Layers/ImageMapLayer.js"></script>
+    <script src="../src/Layers/TiledMapLayer.js"></script>
+    <script src="../src/Layers/BasemapLayer.js"></script>
+    <script src="../src/Layers/DynamicMapLayer.js"></script>
+
+    <script src="../src/Tasks/Task.js"></script>
+    <script src="../src/Tasks/Find.js"></script>
+    <script src="../src/Tasks/Identify.js"></script>
+    <script src="../src/Tasks/IdentifyFeatures.js"></script>
+    <script src="../src/Tasks/IdentifyImage.js"></script>
+    <script src="../src/Tasks/Query.js"></script>
+
+    <style>
+      body {
+        margin:0;
+        padding:0;
+      }
+
+      #map {
+        position: absolute;
+        top:0;
+        bottom:0;
+        right:0;left:0;
+      }
+
+      #info-pane {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        z-index: 10;
+        padding: 1em;
+        background: white;
+      }
+      .red-div-icon {
+        background: red;
+        border: 1px solid #666;
+      }
+      .blue-div-icon {
+        background: blue;
+        border: 1px solid #666;
+      }
+    </style>
+  </head>
+  <body>
+
+  <div id="map"></div>
+  <div id="info-pane" class="leaflet-bar">
+    <label>
+    <button onclick='postEdits()'>update status attribute of objectid: 149478</button><br>
+    <button onclick='refresh()'>refresh feature layer</button>
+    </label>
+  </div>
+  <script>
+    var bool = 0;
+
+    var map = L.map('map').setView([34.051, -117.199], 14);
+    L.esri.basemapLayer('Topographic').addTo(map);
+
+    var activeIcon = L.divIcon({className: 'blue-div-icon'});
+    var inactiveIcon = L.divIcon({className: 'red-div-icon'});
+
+    var fl = L.esri.featureLayer('http://sampleserver6.arcgisonline.com/arcgis/rest/services/RedlandsEmergencyVehicles/FeatureServer/0', {
+      pointToLayer: function (geojson, latlng) {
+        if (geojson.properties.status === 0){
+            return L.marker(latlng, {
+            icon: activeIcon
+          });
+        }
+          else {
+            return L.marker(latlng, {
+            icon: inactiveIcon
+          });
+        }
+      }
+    }).addTo(map);
+
+    function postEdits () {
+      var updated = [{"geometry": { "x": -117.20879371400002, "y": 34.05838465599999 }, "attributes":{"OBJECTID":149478,"status":0 }}];
+
+      L.esri.post('http://sampleserver6.arcgisonline.com/arcgis/rest/services/RedlandsEmergencyVehicles/FeatureServer/0/updateFeatures', {
+          features: updated,
+          f: 'json'
+        }, function(error, response){
+        if(error){
+          console.log(error);
+        } else {
+          console.log(response);
+          bool = 1;
+        }
+      });
+    }
+
+    function refresh () {
+      fl.refresh();
+    }
+  </script>
+
+  </body>
+  </html>

--- a/spec/Layers/FeatureLayer/FeatureLayerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureLayerSpec.js
@@ -39,6 +39,30 @@ describe('L.esri.Layers.FeatureLayer', function () {
     }
   }];
 
+  var pointFeatures = [({
+        type: 'Feature',
+        id: 1,
+        geometry: {
+          type: 'Point',
+          coordinates: [-122, 45]
+        },
+        properties: {
+          time: new Date('January 1 2014').valueOf(),
+          type: 'good'
+        }
+      }),{
+    type: 'Feature',
+    id: 2,
+    geometry: {
+      type: 'Point',
+      coordinates: [-123, 46]
+    },
+    properties: {
+      time: new Date('Febuary 1 2014').valueOf(),
+      type: 'bad'
+    }
+  }];
+
   var multiPolygon = [({
       type : 'Feature',
       id: 1,
@@ -330,6 +354,49 @@ describe('L.esri.Layers.FeatureLayer', function () {
     }]);
 
     expect(layer.getFeature(3).options.color).to.equal('red');
+  });
+
+  it('should update symbology if a relevant attribute is updated', function(){
+    layer = L.esri.featureLayer('http://gis.example.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0', {
+      timeField: 'time',
+      pointToLayer: function(feature, latlng){
+        if (feature.properties.type === 'good') {
+          return L.circleMarker(latlng, {
+            color: 'purple'
+          });
+        }
+        else if (feature.properties.type === 'bad') {
+          return L.circleMarker(latlng, {
+            color: 'yellow'
+          });
+        }
+        else
+          return L.circleMarker(latlng, {
+            color: 'black'
+          });
+      }
+    }).addTo(map);
+
+    layer.createLayers(pointFeatures);
+
+    expect(layer.getFeature(1).options.color).to.equal('purple');
+    expect(layer.getFeature(2).options.color).to.equal('yellow');
+
+    var updatedFeature = {
+        type: 'Feature',
+        id: 1,
+        geometry: {
+          type: 'Point',
+          coordinates: [-122, 45]
+        },
+        properties: {
+          time: new Date('January 1 2014').valueOf(),
+          type: 'bad'
+        }
+      }
+    var bogusCoords = "2:6";
+    layer._addFeatures([updatedFeature], bogusCoords);
+    expect(layer.getFeature(1).options.color).to.equal('yellow');
   });
 
   it('should propagate events from individual features', function(){

--- a/spec/Layers/FeatureLayer/FeatureLayerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureLayerSpec.js
@@ -17,7 +17,7 @@ describe('L.esri.Layers.FeatureLayer', function () {
 
   var layer;
   var map = createMap();
-  var features = [({
+  var features = [{
         type: 'Feature',
         id: 1,
         geometry: {
@@ -25,9 +25,10 @@ describe('L.esri.Layers.FeatureLayer', function () {
           coordinates: [[-122, 45], [-121, 40]]
         },
         properties: {
-          time: new Date('January 1 2014').valueOf()
+          time: new Date('January 1 2014').valueOf(),
+          type: 'good'
         }
-      }),{
+      },{
     type: 'Feature',
     id: 2,
     geometry: {
@@ -35,7 +36,8 @@ describe('L.esri.Layers.FeatureLayer', function () {
       coordinates: [[-123, 46], [-120, 45]]
     },
     properties: {
-      time: new Date('Febuary 1 2014').valueOf()
+      time: new Date('Febuary 1 2014').valueOf(),
+      type: 'bad'
     }
   }];
 
@@ -356,7 +358,7 @@ describe('L.esri.Layers.FeatureLayer', function () {
     expect(layer.getFeature(3).options.color).to.equal('red');
   });
 
-  it('should update symbology if a relevant attribute is updated', function(){
+  it('should update L.CircleMarker symbology if a relevant attribute is updated', function(){
     layer = L.esri.featureLayer('http://gis.example.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0', {
       timeField: 'time',
       pointToLayer: function(feature, latlng){
@@ -397,6 +399,43 @@ describe('L.esri.Layers.FeatureLayer', function () {
     var bogusCoords = "2:6";
     layer._addFeatures([updatedFeature], bogusCoords);
     expect(layer.getFeature(1).options.color).to.equal('yellow');
+  });
+
+  it('should update polyline symbology if a relevant attribute is updated', function(){
+    layer = L.esri.featureLayer('http://gis.example.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0', {
+      timeField: 'time',
+      style: function(feature){
+        if (feature.properties.type === 'good') {
+          return { color: 'purple' };
+        }
+        else if (feature.properties.type === 'bad') {
+          return { color: 'yellow' };
+        }
+        else
+          return { color: 'black' };
+      }
+    }).addTo(map);
+
+    layer.createLayers(features);
+
+    expect(layer.getFeature(1).options.color).to.equal('purple');
+    expect(layer.getFeature(2).options.color).to.equal('yellow');
+
+    var updatedFeature = {
+        type: 'Feature',
+        id: 1,
+        geometry: {
+          type: 'LineString',
+          coordinates: [[-122, 45], [-121, 40]]
+        },
+        properties: {
+          time: new Date('January 1 2014').valueOf(),
+          type: 'the worst'
+        }
+      }
+    var bogusCoords = "2:6";
+    layer._addFeatures([updatedFeature], bogusCoords);
+    expect(layer.getFeature(1).options.color).to.equal('black');
   });
 
   it('should propagate events from individual features', function(){

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -110,11 +110,25 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
       // points
       if (layer && layer.setLatLng) {
         this._updateLayer(layer, geojson);
-        // update custom symbology, if necessary
-        if (this.options.pointToLayer){
-          var getCustomIcon = this.options.pointToLayer(geojson, L.latLng(geojson.geometry.coordinates[1], geojson.geometry.coordinates[0]));
-          var updatedIcon = getCustomIcon.options.icon;
-          layer.setIcon(updatedIcon);
+        // L.marker check
+        if (layer && layer.setIcon) {
+          // update custom symbology, if necessary
+          if (this.options.pointToLayer){
+            var getIcon = this.options.pointToLayer(geojson, L.latLng(geojson.geometry.coordinates[1], geojson.geometry.coordinates[0]));
+            var updatedIcon = getIcon.options.icon;
+            layer.setIcon(updatedIcon);
+          }
+        }
+        // L.circleMarker check
+        if (layer && layer.setStyle) {
+          if (this.options.pointToLayer){
+            var getStyle = this.options.pointToLayer(geojson, L.latLng(geojson.geometry.coordinates[1], geojson.geometry.coordinates[0]));
+            var updatedStyle = getStyle.options;
+            this.setFeatureStyle(geojson.id, updatedStyle);
+          }
+          else {
+            this.resetStyle(geojson.id);
+          }
         }
         return;
       }
@@ -122,7 +136,18 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
       if(!layer){
         newLayer =  this.createNewLayer(geojson);
         newLayer.feature = geojson;
-        newLayer._originalStyle = this.options.style;
+
+        if (this.options.style) {
+          newLayer._originalStyle = this.options.style;
+        }
+
+        // check to see if a custom function determines L.circleMarker feature symbology
+        if (newLayer.setStyle) {
+          if (this.options.pointToLayer) {
+            newLayer._originalStyle = this.options.pointToLayer;
+          }
+        }
+
         newLayer._leaflet_id = this._key + '_' + geojson.id;
 
         this._leafletIds[newLayer._leaflet_id] = geojson.id;

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -103,7 +103,6 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
         this._updateLayer(layer, geojson);
         // update custom symbology, if necessary
         this.resetStyle(geojson.id);
-        return;
       }
 
       // points
@@ -129,7 +128,7 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
             this.resetStyle(geojson.id);
           }
         }
-        return;
+        // return;
       }
 
       if(!layer){

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -57,14 +57,15 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
     var latlngs = [];
     var coordsToLatLng = this.options.coordsToLatLng || L.GeoJSON.coordsToLatLng;
 
-    // copy in new attributes, if present
+    // copy new attributes, if present
     if (geojson.properties) {
       layer.feature.properties = geojson.properties;
     }
 
     switch(geojson.geometry.type){
       case 'Point':
-        // still need to figure out how to insert modified geometry appropriately
+        latlngs = L.GeoJSON.coordsToLatLng(geojson.geometry.coordinates);
+        layer.setLatLng(latlngs);
         break
       case 'LineString':
         latlngs = L.GeoJSON.coordsToLatLngs(geojson.geometry.coordinates, 0, coordsToLatLng);

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -27,7 +27,7 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
     else {
       this._originalIcon = function (geojson, latlng) {
         return L.marker(latlng);
-      }
+      };
     }
 
     this._layers = {};
@@ -75,7 +75,7 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
       case 'Point':
         latlngs = L.GeoJSON.coordsToLatLng(geojson.geometry.coordinates);
         layer.setLatLng(latlngs);
-        break
+        break;
       case 'LineString':
         latlngs = L.GeoJSON.coordsToLatLngs(geojson.geometry.coordinates, 0, coordsToLatLng);
         layer.setLatLngs(latlngs);

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -21,15 +21,6 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
     //   options.style =
     // }
 
-    if (this.options.pointToLayer) {
-      this._originalIcon = this.options.pointToLayer;
-    }
-    else {
-      this._originalIcon = function (geojson, latlng) {
-        return L.marker(latlng);
-      };
-    }
-
     this._layers = {};
     this._leafletIds = {};
     this._key = 'c'+(Math.random() * 1e9).toString(36).replace('.', '_');
@@ -123,10 +114,9 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
       // points
       if (layer && layer.setLatLng) {
         this._updateLayer(layer, geojson);
-        // to do: identify hook need a hook to ensure appropriate icon is set here
-        var iconTest = this._originalIcon(geojson, L.latLng(geojson.geometry.coordinates[1], geojson.geometry.coordinates[0]));
-        var correctIcon = iconTest.options.icon;
-        layer.setIcon(correctIcon);
+        var iconTest = this.options.pointToLayer(geojson, L.latLng(geojson.geometry.coordinates[1], geojson.geometry.coordinates[0]));
+        var updatedIcon = iconTest.options.icon;
+        layer.setIcon(updatedIcon);
         return;
       }
 

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -110,9 +110,12 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
       // points
       if (layer && layer.setLatLng) {
         this._updateLayer(layer, geojson);
-        var iconTest = this.options.pointToLayer(geojson, L.latLng(geojson.geometry.coordinates[1], geojson.geometry.coordinates[0]));
-        var updatedIcon = iconTest.options.icon;
-        layer.setIcon(updatedIcon);
+        // update custom symbology for layer if necessary
+        if (this.options.pointToLayer){
+          var getCustomIcon = this.options.pointToLayer(geojson, L.latLng(geojson.geometry.coordinates[1], geojson.geometry.coordinates[0]));
+          var updatedIcon = getCustomIcon.options.icon;
+          layer.setIcon(updatedIcon);
+        }
         return;
       }
 

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -102,8 +102,8 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
       // polylines and polygons
       if (layer && layer.setLatLngs) {
         this._updateLayer(layer, geojson);
-        // to do: make sure appropriate style is set
-        // this.resetStyle();  ?
+        // update custom symbology for layer if necessary
+        this.resetStyle(geojson.id);
         return;
       }
 

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -21,6 +21,8 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
     //   options.style =
     // }
 
+    this._originalIcon = this.options.pointToLayer;
+
     this._layers = {};
     this._leafletIds = {};
     this._key = 'c'+(Math.random() * 1e9).toString(36).replace('.', '_');
@@ -106,16 +108,18 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
       // polylines and polygons
       if (layer && layer.setLatLngs) {
         this._updateLayer(layer, geojson);
-        // we need to make sure appropriate style is set
+        // to do: make sure appropriate style is set
+        // this.resetStyle();  ?
         return;
       }
 
-      // if it's a point
+      // points
       if (layer && layer.setLatLng) {
         this._updateLayer(layer, geojson);
-
-        // need a hook to ensure appropriate icon is set here
-        // layer.setIcon(appropriate icon)
+        // to do: identify hook need a hook to ensure appropriate icon is set here
+        var iconTest = this._originalIcon(geojson, L.latLng(geojson.geometry.coordinates[1], geojson.geometry.coordinates[0]));
+        var correctIcon = iconTest.options.icon;
+        layer.setIcon(correctIcon);
         return;
       }
 

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -17,10 +17,6 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
 
     options = L.setOptions(this, options);
 
-    // if (!options.style){
-    //   options.style =
-    // }
-
     this._layers = {};
     this._leafletIds = {};
     this._key = 'c'+(Math.random() * 1e9).toString(36).replace('.', '_');

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -21,7 +21,14 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
     //   options.style =
     // }
 
-    this._originalIcon = this.options.pointToLayer;
+    if (this.options.pointToLayer) {
+      this._originalIcon = this.options.pointToLayer;
+    }
+    else {
+      this._originalIcon = function (geojson, latlng) {
+        return L.marker(latlng);
+      }
+    }
 
     this._layers = {};
     this._leafletIds = {};

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -137,14 +137,6 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
         newLayer =  this.createNewLayer(geojson);
         newLayer.feature = geojson;
         newLayer._originalStyle = this.options.style;
-        newLayer._leaflet_id = this._key + '_' + geojson.id;
-
-        this._leafletIds[newLayer._leaflet_id] = geojson.id;
-
-        // bubble events from layers to this
-        // @TODO Leaflet 0.8
-        // newLayer.addEventParent(this);
-
         newLayer.on(EsriLeaflet.Layers.FeatureLayer.EVENTS, this._propagateEvent, this);
 
         // bind a popup if we have one

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -136,18 +136,7 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
       if(!layer){
         newLayer =  this.createNewLayer(geojson);
         newLayer.feature = geojson;
-
-        if (this.options.style) {
-          newLayer._originalStyle = this.options.style;
-        }
-
-        // check to see if a custom function determines L.circleMarker feature symbology
-        if (newLayer.setStyle) {
-          if (this.options.pointToLayer) {
-            newLayer._originalStyle = this.options.pointToLayer;
-          }
-        }
-
+        newLayer._originalStyle = this.options.style;
         newLayer._leaflet_id = this._key + '_' + geojson.id;
 
         this._leafletIds[newLayer._leaflet_id] = geojson.id;

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -102,7 +102,7 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
       // polylines and polygons
       if (layer && layer.setLatLngs) {
         this._updateLayer(layer, geojson);
-        // update custom symbology for layer if necessary
+        // update custom symbology, if necessary
         this.resetStyle(geojson.id);
         return;
       }
@@ -110,7 +110,7 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
       // points
       if (layer && layer.setLatLng) {
         this._updateLayer(layer, geojson);
-        // update custom symbology for layer if necessary
+        // update custom symbology, if necessary
         if (this.options.pointToLayer){
           var getCustomIcon = this.options.pointToLayer(geojson, L.latLng(geojson.geometry.coordinates[1], geojson.geometry.coordinates[0]));
           var updatedIcon = getCustomIcon.options.icon;

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -17,6 +17,10 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
 
     options = L.setOptions(this, options);
 
+    // if (!options.style){
+    //   options.style =
+    // }
+
     this._layers = {};
     this._leafletIds = {};
     this._key = 'c'+(Math.random() * 1e9).toString(36).replace('.', '_');
@@ -47,13 +51,21 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
     return L.GeoJSON.geometryToLayer(geojson, this.options.pointToLayer, L.GeoJSON.coordsToLatLng, this.options);
   },
 
-  _updateLayerGeometry: function(layer, geojson){
+  _updateLayer: function(layer, geojson){
     // convert the geojson coordinates into a Leaflet LatLng array/nested arrays
     // pass it to setLatLngs to update layer geometries
     var latlngs = [];
     var coordsToLatLng = this.options.coordsToLatLng || L.GeoJSON.coordsToLatLng;
 
+    // copy in new attributes, if present
+    if (geojson.properties) {
+      layer.feature.properties = geojson.properties;
+    }
+
     switch(geojson.geometry.type){
+      case 'Point':
+        // still need to figure out how to insert modified geometry appropriately
+        break
       case 'LineString':
         latlngs = L.GeoJSON.coordsToLatLngs(geojson.geometry.coordinates, 0, coordsToLatLng);
         layer.setLatLngs(latlngs);
@@ -74,7 +86,7 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
   },
 
   /**
-   * Feature Managment Methods
+   * Feature Management Methods
    */
 
   createLayers: function(features){
@@ -90,8 +102,19 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
         return;
       }
 
+      // polylines and polygons
       if (layer && layer.setLatLngs) {
-        this._updateLayerGeometry(layer, geojson);
+        this._updateLayer(layer, geojson);
+        // we need to make sure appropriate style is set
+        return;
+      }
+
+      // if it's a point
+      if (layer && layer.setLatLng) {
+        this._updateLayer(layer, geojson);
+
+        // need a hook to ensure appropriate icon is set here
+        // layer.setIcon(appropriate icon)
         return;
       }
 

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -139,6 +139,12 @@
         var id = features[i].id;
         this._currentSnapshot.push(id);
         this._cache[key].push(id);
+        /*
+        should we refactor the code in FeatureManager.setWhere()
+        so that we can reuse it to make sure that we remove features
+        on the client that are removed from the service?
+        */
+
       }
 
       if(this.options.timeField){
@@ -176,7 +182,7 @@
       this.options.where = (where && where.length) ? where : '1=1';
 
       var oldSnapshot = [];
-      var newShapshot = [];
+      var newSnapshot = [];
       var pendingRequests = 0;
       var requestError = null;
       var requestCallback = L.Util.bind(function(error, featureCollection){
@@ -186,18 +192,18 @@
 
         if(featureCollection){
           for (var i = featureCollection.features.length - 1; i >= 0; i--) {
-            newShapshot.push(featureCollection.features[i].id);
+            newSnapshot.push(featureCollection.features[i].id);
           }
         }
 
         pendingRequests--;
 
         if(pendingRequests <= 0){
-          this._currentSnapshot = newShapshot;
+          this._currentSnapshot = newSnapshot;
           // schedule adding features until the next animation frame
           EsriLeaflet.Util.requestAnimationFrame(L.Util.bind(function(){
             this.removeLayers(oldSnapshot);
-            this.addLayers(newShapshot);
+            this.addLayers(newSnapshot);
             if(callback) {
               callback.call(context, requestError);
             }


### PR DESCRIPTION
#### problem:
currently we fail to restyle features after fetching from the server.  

because point features implement L.Marker icons, existing methods pertaining to setting `style` aren't relevant.

#### STR:
1. load sample app `debug/refresh-style` and use the button to update the status of the test feature so that it has an attribute which should alter the icon its drawn with.
2. refresh the feature layer (using included button) and notice that the symbology of the feature in the topleft corner has not changed.

#### changes introduced in this pull request:
* ensure that new attributes from the server are injected in clientside feature collections (and not just changes to geometry)
* renamed `FeatureLayer._updateLayerGeometry()` to `_updateLayer()` to reflect the new addition
* add a new check within `createLayers()` so that we appropriately trap changes to point feature geometries
* make sure a call is made to `setIcon` to refresh symbology appropriately.

#### to do:
- [x] still need to test with polylines to confirm that all that's necessary for comparable coverage is a call to `resetStyle()`

cc/ @kneemer.  

i'm curious to hear how you in particular feel about these changes.  especially in regard to how it will affect esri-leaflet-renderers