### PR TITLE
add circleMarker check to createLayers

### DIFF
--- a/spec/Layers/FeatureLayer/FeatureLayerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureLayerSpec.js
@@ -51,11 +51,25 @@ describe('L.esri.Layers.FeatureLayer', function () {
       }
   })];
 
+  var point = [({
+      type : 'Feature',
+      id: 1,
+      geometry: {
+        type: 'Point',
+        coordinates: [-95, 43]
+      },
+      properties: {
+        time: new Date('Febuary 1 2014').valueOf()
+      }
+  })];
+
   beforeEach(function(){
     layer = L.esri.featureLayer('http://gis.example.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0', {
       timeField: 'time',
       pointToLayer: function(feature, latlng){
-        return L.circleMarker(latlng);
+        return L.circleMarker(latlng, {
+          color: 'green'
+        });
       }
     }).addTo(map);
 
@@ -199,6 +213,20 @@ describe('L.esri.Layers.FeatureLayer', function () {
     expect(layer.getFeature(3)._popup.options.minWidth).to.equal(500);
   });
 
+  it('should style L.circleMarker features appropriately', function(){
+    layer = L.esri.featureLayer('http://gis.example.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0', {
+      timeField: 'time',
+      pointToLayer: function(feature, latlng){
+        return L.circleMarker(latlng, {
+          color: 'green'
+        });
+      }
+    }).addTo(map);
+
+    layer.createLayers(point);
+    expect(layer.getFeature(1).options.color).to.equal('green');
+  });
+
   it('should unbind popups on features', function(){
     layer.bindPopup(function(feature){
       return 'ID: ' + feature.id;
@@ -229,6 +257,8 @@ describe('L.esri.Layers.FeatureLayer', function () {
     }).addTo(map);
 
     layer.createLayers(multiPolygon);
+
+    expect(layer.getFeature(1).getLayers()[0].options.color).to.equal('black');
 
     layer.setFeatureStyle(1, {
       color: 'red'

--- a/spec/Layers/FeatureLayer/FeatureLayerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureLayerSpec.js
@@ -271,6 +271,27 @@ describe('L.esri.Layers.FeatureLayer', function () {
     expect(layer.getFeature(1).getLayers()[0].options.color).to.equal('black');
   });
 
+  it('should reset L.circleMarker style', function(){
+    layer = L.esri.featureLayer('http://gis.example.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0', {
+      pointToLayer: function(feature, latlng){
+        return L.circleMarker(latlng, {
+          color: 'green'
+        });
+      }
+    }).addTo(map);
+
+    layer.createLayers(point);
+    expect(layer.getFeature(1).options.color).to.equal('green');
+
+    layer.setStyle({
+      color: 'red'
+    });
+    expect(layer.getFeature(1).options.color).to.equal('red');
+
+    layer.resetStyle(1);
+    expect(layer.getFeature(1).options.color).to.equal('green');
+  });
+
   it('should reset to default style on multi polygon features', function(){
     layer = L.esri.featureLayer('http://gis.example.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0').addTo(map);
 

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -104,7 +104,7 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
         }
 
         // circleMarker check
-        if (newLayer.setStyle) {
+        else if (newLayer.setStyle) {
           newLayer._originalStyle = newLayer.options;
         }
 

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -98,7 +98,16 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
       if(!layer){
         newLayer =  this.createNewLayer(geojson);
         newLayer.feature = geojson;
-        newLayer._originalStyle = this.options.style;
+
+        if (this.options.style) {
+          newLayer._originalStyle = this.options.style;
+        }
+
+        // circleMarker check
+        if (newLayer.setStyle) {
+          newLayer._originalStyle = newLayer.options;
+        }
+
         newLayer._leaflet_id = this._key + '_' + geojson.id;
 
         this._leafletIds[newLayer._leaflet_id] = geojson.id;


### PR DESCRIPTION
closes #534

added a check into `FeatureLayer.createLayers()` to ensure that a null style isn't passed accidently when a client application leverages `L.circleMarker` symbols for point features.

resolves a bug that i'm pretty sure was introduced by changes here 28f4d980222cccacd31e6a3b802d7d18436032d4

to be perfectly honest, my brain isn't working well enough to comprehend what other edge cases we need to make sure we are trapping, but i'll chew on it tomorrow.