### PR TITLE
Correct web mercator services that have non-standard zoom levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ Esri welcomes contributions from anyone and everyone. Please see our [guidelines
 
 ### Credit
 
-`L.esri.Layers.DynamicMapLayer` originally used code from https://github.com/sanborn/leaflet-ags/blob/master/src/AGS.Layer.Dynamic.js
+* `L.esri.Layers.DynamicMapLayer` originally used code from https://github.com/sanborn/leaflet-ags/blob/master/src/AGS.Layer.Dynamic.js
+* `L.esri.Layers.TiledMapLayer` adapts some code from https://github.com/gisinc/arcgis-level-fixer
 
 ### Licensing
 Copyright 2015 Esri

--- a/site/source/pages/api-reference/layers/tiled-map-layer.md
+++ b/site/source/pages/api-reference/layers/tiled-map-layer.md
@@ -34,6 +34,8 @@ Is you have Feature Services published in ArcGIS Online you can create a static 
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
+| `correctZoomLevels` | `Boolean` | `true` | If your tiles were generated in web mercator but at non-standard zoom levels this will remap then to the standard zoom levels. 
+| `zoomOffsetAllowance` | `Number` | `0.1` | If `correctZoomLevels` is enabled this controls the amount of tolerence if the difference at each scale level for remapping tile levels.
 | `proxy` | `String` | `false` | URL of an [ArcGIS API for JavaScript proxy](https://developers.arcgis.com/javascript/jshelp/ags_proxy.html) or [ArcGIS Resource Proxy](https://github.com/Esri/resource-proxy) to use for proxying POST requests. |
 | `useCors` | `Boolean` | `true` | Dictates if the service should use CORS when making GET requests. |
 | `token` | `String` | `null` | Will use this token to authenticate all calls to the service.

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -39,8 +39,8 @@
             oidCheck = true;
           }
         }
-        if (oidCheck === false && console && console.warn){
-          console.warn('no known esriFieldTypeOID field detected in fields Array.  Please add an attribute field containing unique IDs to ensure the layer can be drawn correctly.');
+        if (oidCheck === false) {
+          EsriLeaflet.Util.warn('no known esriFieldTypeOID field detected in fields Array.  Please add an attribute field containing unique IDs to ensure the layer can be drawn correctly.');
         }
       }
 

--- a/src/Layers/TiledMapLayer.js
+++ b/src/Layers/TiledMapLayer.js
@@ -68,10 +68,10 @@ EsriLeaflet.Layers.TiledMapLayer = L.TileLayer.extend({
   },
 
   onAdd: function(map){
-    if (!this._lodMap) {
+    if (!this._lodMap && this.options.correctZoomLevels) {
       this._lodMap = {}; // make sure we always have an lod map even if its empty
       this.metadata(function(error, metadata) {
-        if(!error && this.options.correctZoomLevels) {
+        if(!error) {
           var sr = metadata.spatialReference.latestWkid || metadata.spatialReference.wkid;
 
           if (sr === 102100 || sr === 3857) {

--- a/src/Request.js
+++ b/src/Request.js
@@ -103,14 +103,13 @@
 
       // request is longer then 2000 characters and the browser does not support CORS, log a warning
       } else {
-        if(console && console.warn){
-          console.warn('a request to ' + url + ' was longer then 2000 characters and this browser cannot make a cross-domain post request. Please use a proxy http://esri.github.io/esri-leaflet/api-reference/request.html');
-          return;
-        }
+        EsriLeaflet.Util.warn('a request to ' + url + ' was longer then 2000 characters and this browser cannot make a cross-domain post request. Please use a proxy http://esri.github.io/esri-leaflet/api-reference/request.html');
+        return;
       }
 
       return httpRequest;
     },
+
     post: {
       XMLHTTP: function (url, params, callback, context) {
         var httpRequest = createRequest(callback, context);

--- a/src/Tasks/Query.js
+++ b/src/Tasks/Query.js
@@ -151,8 +151,8 @@ EsriLeaflet.Tasks.Query = EsriLeaflet.Tasks.Task.extend({
 
   _trapSQLerrors: function(error){
     if (error){
-      if (error.code === '400' && console && console.warn){
-        console.warn('one common syntax error in query requests is encasing string values in double quotes instead of single quotes');
+      if (error.code === '400'){
+        EsriLeaflet.Util.warn('one common syntax error in query requests is encasing string values in double quotes instead of single quotes');
       }
     }
   },
@@ -215,9 +215,7 @@ EsriLeaflet.Tasks.Query = EsriLeaflet.Tasks.Task.extend({
 
     // warn the user if we havn't found a
     /* global console */
-    if(console && console.warn) {
-      console.warn('invalid geometry passed to spatial query. Should be an L.LatLng, L.LatLngBounds or L.Marker or a GeoJSON Point Line or Polygon object');
-    }
+    EsriLeaflet.Util.warn('invalid geometry passed to spatial query. Should be an L.LatLng, L.LatLngBounds or L.Marker or a GeoJSON Point Line or Polygon object');
 
     return;
   }

--- a/src/Util.js
+++ b/src/Util.js
@@ -433,4 +433,10 @@
 
   EsriLeaflet.Util.requestAnimationFrame = L.Util.bind(raf, window);
 
+  EsriLeaflet.Util.warn = function (message) {
+    if(console && console.warn) {
+      console.warn(message);
+    }
+  };
+
 })(EsriLeaflet);


### PR DESCRIPTION
Fixes https://github.com/Esri/esri-leaflet/issues/530

This updates `L.esri.TiledMapLayer` to support mercator services that were published at non-standard zoom levels. It borrows the zoom level correcting logic from https://github.com/gisinc/arcgis-level-fixer and bakes in a metadata request.

@jonahadkins @cbupp @jgravois for review.