### PR TITLE
removed references to rogue documentation topic

### DIFF
--- a/site/source/pages/api-reference/layers/clustered-feature-layer.md
+++ b/site/source/pages/api-reference/layers/clustered-feature-layer.md
@@ -95,7 +95,7 @@ More information about Feature Layers can be found in the [`L.esri.Layers.Featur
         <tr>
             <td><code>token</code></td>
             <td><code>String</code></td>
-            <td>If you pass a token in your options it will included in all requests to the service. See [working with authenticated services](#working-with-authenticated-services) for more information.</td>
+            <td>If you pass a token in your options it will be included in all requests to the service.</td>
         </tr>
         <tr>
             <td><code>proxy</code></td>

--- a/site/source/pages/api-reference/layers/dynamic-map-layer.md
+++ b/site/source/pages/api-reference/layers/dynamic-map-layer.md
@@ -44,7 +44,7 @@ Option | Type | Default | Description
 `opacity` | `Number` | `1` | Opacity of the layer. Should be a value between 0 (completely transparent) and 1 (completely opaque).
 `position` | `String` | `'front'` | Position of the layer relative to other overlays.
 `dynamicLayers` | `Object` | `null` | JSON object literal used to manipulate the layer symbology defined in the service itself.  Requires a 10.1 (or above) map service which supports [dynamicLayers](http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Export_Map/02r3000000v7000000/) requests.
-`token` | `String` | `null` | If you pass a token in your options it will included in all requests to the service. See [working with authenticated services](#working-with-authenticated-services) for more information.
+`token` | `String` | `null` | If you pass a token in your options it will be included in all requests to the service.
 `proxy` | `String` | `false` | URL of an [ArcGIS API for JavaScript proxy](https://developers.arcgis.com/javascript/jshelp/ags_proxy.html) or [ArcGIS Resource Proxy](https://github.com/Esri/resource-proxy) to use for proxying POST requests.
 `useCors` | `Boolean` | `true` | If this service should use CORS when making GET requests.
 

--- a/site/source/pages/api-reference/layers/feature-layer.md
+++ b/site/source/pages/api-reference/layers/feature-layer.md
@@ -126,7 +126,7 @@ You can create a new empty feature service with a single layer on the [ArcGIS fo
         <tr>
             <td><code>token</code></td>
             <td><code>String</code></td>
-            <td>If you pass a token in your options it will included in all requests to the service. See [working with authenticated services](#working-with-authenticated-services) for more information.</td>
+            <td>If you pass a token in your options it will be included in all requests to the service.</td>
         </tr>
         <tr>
             <td><code>proxy</code></td>

--- a/site/source/pages/api-reference/layers/heatmap-feature-layer.md
+++ b/site/source/pages/api-reference/layers/heatmap-feature-layer.md
@@ -74,7 +74,7 @@ More information about Feature Layers can be found in the [`L.esri.Layers.Featur
         <tr>
             <td><code>token</code></td>
             <td><code>String</code></td>
-            <td>If you pass a token in your options it will included in all requests to the service. See [working with authenticated services](#working-with-authenticated-services) for more information.</td>
+            <td>If you pass a token in your options it will be included in all requests to the service.</td>
         </tr>
         <tr>
             <td><code>proxy</code></td>

--- a/site/source/pages/api-reference/services/service.md
+++ b/site/source/pages/api-reference/services/service.md
@@ -40,7 +40,7 @@ A generic class representing a hosted resource on ArcGIS Online or ArcGIS Server
 | `requestend` | [<`RequestEvent`>]({{assets}}api-reference/events.html#request-event) | Fired when a request to the service ends. |
 | `requestsuccess` | [<`RequestSuccessEvent`>]({{assets}}api-reference/events.html#request-success-event) | Fired when a request to the service was successful. |
 | `requesterror` | [<`RequestErrorEvent`>]({{assets}}api-reference/events.html#request-error-event) | Fired when a request to the service responsed with an error. |
-| `authenticationrequired` | [<`AuthenticationEvent`>]({{assets}}api-reference/events.html#authentication-event) | This will be fired when a request to the service fails and requires authentication. See [working with authenticated services](#working-with-authenticated-services) for more information. |
+| `authenticationrequired` | [<`AuthenticationEvent`>]({{assets}}api-reference/events.html#authentication-event) | This will be fired when a request to the service fails and requires authentication. |
 
 ### Methods
 


### PR DESCRIPTION
not sure if/when there was a #working-with-authenticated-services subtopic in the esri-leaflet doc.