### PR TITLE
new zoom to bounds sample for legacy feature services

### DIFF
--- a/site/source/layouts/example.hbs
+++ b/site/source/layouts/example.hbs
@@ -25,7 +25,7 @@ layout: page.hbs
   <script src="//cdn.jsdelivr.net/leaflet/0.7.3/leaflet.js"></script>
 
   <!-- Load Esri Leaflet from CDN -->
-  <!-- we encourage you to replace 'latest' with a hardcode version number (like '1.0.0-rc.7') in production applications -->
+  <!-- we encourage you to replace 'latest' with a hardcoded version number (like '1.0.0-rc.8') in production applications -->
   <script src="//cdn.jsdelivr.net/leaflet.esri/latest/esri-leaflet.js"></script>
 
   <style>

--- a/site/source/pages/examples/clustering-feature-layers.hbs
+++ b/site/source/pages/examples/clustering-feature-layers.hbs
@@ -1,6 +1,6 @@
 ---
 title: Clustering points
-description: Visualize dense services as clusters of points with the <a href="https://github.com/Leaflet/Leaflet.markercluster">L.markercluster</a> plugin. More information about Feature Layers can be found in the <a href="/esri-leaflet/api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
+description: Visualize dense services as clusters of points with the <a href="https://github.com/Leaflet/Leaflet.markercluster">L.markercluster</a> plugin. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
 layout: example.hbs
 ---
 

--- a/site/source/pages/examples/feature-layer-popups.hbs
+++ b/site/source/pages/examples/feature-layer-popups.hbs
@@ -1,6 +1,6 @@
 ---
 title: Custom popups
-description: Customize popups on a Feature Layer. More information about Feature Layers can be found in the <a href="/esri-leaflet/api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
+description: Customize popups on a Feature Layer. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
 layout: example.hbs
 ---
 

--- a/site/source/pages/examples/getting-service-metadata.hbs
+++ b/site/source/pages/examples/getting-service-metadata.hbs
@@ -1,6 +1,6 @@
 ---
 title: Getting service metadata
-description: Retrieving service metadata such as name, bounding box and capabilities. More information about Feature Layers can be found in the <a href="/esri-leaflet/api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
+description: Retrieving service metadata such as name, bounding box and capabilities. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
 layout: example.hbs
 ---
 

--- a/site/source/pages/examples/querying-feature-layers-1.hbs
+++ b/site/source/pages/examples/querying-feature-layers-1.hbs
@@ -1,6 +1,6 @@
 ---
 title: Querying features
-description: Configuring a query to filter features on a <code>L.esri.Layers.FeatureLayer</code>. More information about Feature Layers can be found in the <a href="/esri-leaflet/api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
+description: Configuring a query to filter features on a <code>L.esri.Layers.FeatureLayer</code>. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
 layout: example.hbs
 ---
 

--- a/site/source/pages/examples/querying-feature-layers-2.hbs
+++ b/site/source/pages/examples/querying-feature-layers-2.hbs
@@ -1,6 +1,6 @@
 ---
 title: Querying features
-description: Performing advanced queries on a Feature Layer. Click on the map to query all features within 500 meters. More information about Feature Layers can be found in the <a href="/esri-leaflet/api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
+description: Performing advanced queries on a Feature Layer. Click on the map to query all features within 500 meters. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
 layout: example.hbs
 ---
 

--- a/site/source/pages/examples/simple-feature-layer.hbs
+++ b/site/source/pages/examples/simple-feature-layer.hbs
@@ -1,6 +1,6 @@
 ---
 title: Simple FeatureLayer
-description: Display a feature layer from ArcGIS Online or ArcGIS server. More information about Feature Layers can be found in the <a href="/esri-leaflet/api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
+description: Display a feature layer from ArcGIS Online or ArcGIS server. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
 layout: example.hbs
 ---
 

--- a/site/source/pages/examples/simplifying-complex-features.hbs
+++ b/site/source/pages/examples/simplifying-complex-features.hbs
@@ -1,6 +1,6 @@
 ---
 title: Simplifying complex features
-description: Complex features can be simplified on the server for faster response times. Zoom in and watch as higher resolution vectors are loaded from the service. Hover over features for effects. More information about Feature Layers can be found in the <a href="/esri-leaflet/api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
+description: Complex features can be simplified on the server for faster response times. Zoom in and watch as higher resolution vectors are loaded from the service. Hover over features for effects. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
 layout: example.hbs
 ---
 

--- a/site/source/pages/examples/styling-clusters.hbs
+++ b/site/source/pages/examples/styling-clusters.hbs
@@ -1,6 +1,6 @@
 ---
 title: Styling clusters
-description: Customizing the display of clusters and markers with <code>L.DivIcon</code> and <code>L.MarkerClusterGroup</code> options. More information about Feature Layers can be found in the <a href="/esri-leaflet/api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
+description: Customizing the display of clusters and markers with <code>L.DivIcon</code> and <code>L.MarkerClusterGroup</code> options. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
 layout: example.hbs
 ---
 

--- a/site/source/pages/examples/styling-feature-layer-points.hbs
+++ b/site/source/pages/examples/styling-feature-layer-points.hbs
@@ -1,6 +1,6 @@
 ---
 title: Styling points
-description: Custom styles on point features with <code>L.Icon</code>. More information about Feature Layers can be found in the <a href="/esri-leaflet/api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
+description: Custom styles on point features with <code>L.Icon</code>. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
 layout: example.hbs
 ---
 

--- a/site/source/pages/examples/styling-feature-layer-polygons.hbs
+++ b/site/source/pages/examples/styling-feature-layer-polygons.hbs
@@ -1,6 +1,6 @@
 ---
 title: Styling polygons
-description: Custom styling of polygons with the <code>style</code> option. More information about Feature Layers can be found in the <a href="/esri-leaflet/api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
+description: Custom styling of polygons with the <code>style</code> option. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
 layout: example.hbs
 ---
 

--- a/site/source/pages/examples/styling-feature-layer-polylines.hbs
+++ b/site/source/pages/examples/styling-feature-layer-polylines.hbs
@@ -1,6 +1,6 @@
 ---
 title: Styling lines
-description: Custom styles for line features with the <code>style</code> option. More information about Feature Layers can be found in the <a href="/esri-leaflet/api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
+description: Custom styles for line features with the <code>style</code> option. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
 layout: example.hbs
 ---
 

--- a/site/source/pages/examples/styling-heatmaps.hbs
+++ b/site/source/pages/examples/styling-heatmaps.hbs
@@ -1,6 +1,6 @@
 ---
 title: Styling heatmaps
-description: Custom styling of heatmap gradients with the <code>L.heat</code> options. More information about Feature Layers can be found in the <a href="/esri-leaflet/api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
+description: Custom styling of heatmap gradients with the <code>L.heat</code> options. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
 layout: example.hbs
 ---
 

--- a/site/source/pages/examples/visualize-points-as-a-heatmap.hbs
+++ b/site/source/pages/examples/visualize-points-as-a-heatmap.hbs
@@ -1,6 +1,6 @@
 ---
 title: Points as a heatmap
-description: Displaying point data as a heatmap using the <code>L.heat</code> plugin. More information about Feature Layers can be found in the <a href="/esri-leaflet/api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
+description: Displaying point data as a heatmap using the <code>L.heat</code> plugin. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
 layout: example.hbs
 ---
 

--- a/site/source/pages/examples/visualizing-time-with-feature-layer.hbs
+++ b/site/source/pages/examples/visualizing-time-with-feature-layer.hbs
@@ -1,6 +1,6 @@
 ---
 title: Visualizing time on a feature layer
-description: Filtering a feature layer within a certain time range. Try dates between October 2010 and August 2011. More information about Feature Layers can be found in the <a href="/esri-leaflet/api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
+description: Filtering a feature layer within a certain time range. Try dates between October 2010 and August 2011. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
 layout: example.hbs
 ---
 

--- a/site/source/pages/examples/zooming-to-all-features-1.hbs
+++ b/site/source/pages/examples/zooming-to-all-features-1.hbs
@@ -1,6 +1,6 @@
 ---
 title: Zoom to all features
-description: Fitting the map to the boundaries of all features in the layer by querying the service. More information about Feature Layers can be found in the <a href="/esri-leaflet/api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
+description: Fitting the map to the boundaries of all features in the layer by querying the service. More information about Feature Layers can be found in the <a href="../api-reference/layers/feature-layer.html">L.esri.Layers.FeatureLayer</a> documentation.
 layout: example.hbs
 ---
 

--- a/site/source/pages/examples/zooming-to-all-features-2.hbs
+++ b/site/source/pages/examples/zooming-to-all-features-2.hbs
@@ -1,0 +1,39 @@
+---
+title: Zoom to all features #2
+description: This sample creates a latLngBounds object clientside which contains the geometries fetched from the server.  An approach like this is necessary when working with older Feature Services (prior to ArcGIS Server 10.3.1) that don't support making direct requests to the server for the 'bounds' of features matching a query.
+layout: example.hbs
+---
+
+<div id="map"></div>
+
+<script>
+
+  // create a map and add Esri's Dark Gray basemap
+  var map = L.map('map').setView([40, -100], 5);
+  L.esri.basemapLayer('DarkGray').addTo(map);
+
+  // add a graphic layer composed of selected US Counties
+  var fl = L.esri.featureLayer('http://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/2', {
+    where: "NAME='Los Angeles' OR NAME='San Bernardino'"
+  }).addTo(map);
+
+  // listen for when all features have been retrieved from the server
+  fl.on("load", function(evt) {
+    // create a new empty Leaflet bounds object
+    var bounds = L.latLngBounds([]);
+    // loop through the features returned by the server
+    fl.eachFeature(function(layer) {
+      // get the bounds of an individual feature
+      var layerBounds = layer.getBounds();
+      // extend the bounds of the collection to fit the bounds of the new feature
+      bounds.extend(layerBounds);
+    });
+
+    // once we've looped through all the features, zoom the map to the extent of the collection
+    map.fitBounds(bounds);
+
+    // unwire the event listener so that it only fires once when the page is loaded
+    fl.off('load');
+  });
+
+</script>

--- a/site/source/partials/sidebar-examples.hbs
+++ b/site/source/partials/sidebar-examples.hbs
@@ -18,7 +18,8 @@
     <a href="{{assets}}examples/querying-feature-layers-2.html">Querying features #2</a>
     <a href="{{assets}}examples/spatial-queries.html">Spatial Queries</a>
     <a href="{{assets}}examples/simplifying-complex-features.html">Simplifying complex features</a>
-    <a href="{{assets}}examples/zooming-to-all-features.html">Zoom to all features</a>
+    <a href="{{assets}}examples/zooming-to-all-features-1.html">Zoom to all features #1</a>
+    <a href="{{assets}}examples/zooming-to-all-features-2.html">Zoom to all features #2</a>
     <a href="{{assets}}examples/labeling-features.html">Labeling Features</a>
     <a href="{{assets}}examples/clustering-feature-layers.html">Clustering points</a>
     <a href="{{assets}}examples/styling-clusters.html">Styling clusters</a>


### PR DESCRIPTION
* added new sample to demonstrate how to zoom to the extent of features returned by ArcGIS Server versions that don't support 'bounds' directly
* fixed typo in header
* updated hyperlink in FeatureLayer sample header info to use a relative path.  existing url was invalid locally because 'esri-leaflet' isn't present.