### PR TITLE
update urls and file sizes on download page

### DIFF
--- a/site/source/pages/download/index.md
+++ b/site/source/pages/download/index.md
@@ -8,7 +8,7 @@ class: no-sidebar
 
 All builds of Esri Leaflet are available for download on [GitHub](https://github.com/Esri/esri-leaflet/releases/).
 
-<a href="https://github.com/Esri/esri-leaflet/archive/v1.0.0-rc.8.zip" class="btn">Current Release</a>
+<a href="https://github.com/Esri/esri-leaflet/archive/v1.0.0.zip" class="btn">Current Release</a>
 <a href="https://github.com/Esri/esri-leaflet/releases/" class="btn">Past Releases</a>
 
 # npm
@@ -34,7 +34,7 @@ Esri Leaflet is hosted on [jsDelivr](http://www.jsdelivr.com/).
 #### Standard Build
 
 ```xml
-<script src="http://cdn.jsdelivr.net/leaflet.esri/1.0.0-rc.8/esri-leaflet.js"></script>
+<script src="http://cdn.jsdelivr.net/leaflet.esri/1.0.0/esri-leaflet.js"></script>
 
 ```
 
@@ -44,26 +44,26 @@ Esri Leaflet is also built into several smaller components and plugins for speci
 
 ```xml
 <!-- Core Build -->
-<script src="http://cdn.jsdelivr.net/leaflet.esri/1.0.0-rc.8/builds/core/esri-leaflet-core.js"></script>
+<script src="http://cdn.jsdelivr.net/leaflet.esri/1.0.0/builds/core/esri-leaflet-core.js"></script>
 
 <!-- Basemaps Only Build -->
-<script src="http://cdn.jsdelivr.net/leaflet.esri/1.0.0-rc.8/builds/basemaps/esri-leaflet-basemaps.js"></script>
+<script src="http://cdn.jsdelivr.net/leaflet.esri/1.0.0/builds/basemaps/esri-leaflet-basemaps.js"></script>
 
 <!-- Feature Layer Only Build -->
-<script src="http://cdn.jsdelivr.net/leaflet.esri/1.0.0-rc.8/builds/feature-layer/esri-leaflet-feature-layer.js"></script>
+<script src="http://cdn.jsdelivr.net/leaflet.esri/1.0.0/builds/feature-layer/esri-leaflet-feature-layer.js"></script>
 
 <!-- Map Service Only Build -->
-<script src="http://cdn.jsdelivr.net/leaflet.esri/1.0.0-rc.8/builds/map-service/esri-leaflet-map-service.js"></script>
+<script src="http://cdn.jsdelivr.net/leaflet.esri/1.0.0/builds/map-service/esri-leaflet-map-service.js"></script>
 
 <!-- Heatmap Feature Layer -->
-<script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-heatmap-feature-layer/1.0.0-rc.3/esri-leaflet-heatmap-feature-layer.js"></script>
+<script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-heatmap-feature-layer/1.0.0/esri-leaflet-heatmap-feature-layer.js"></script>
 
 <!-- Clustered Feature Layer -->
-<script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-clustered-feature-layer/1.0.0-rc.4/esri-leaflet-clustered-feature-layer.js"></script>
+<script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-clustered-feature-layer/1.0.0/esri-leaflet-clustered-feature-layer.js"></script>
 
 <!-- Geocoding Control -->
-<script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-geocoder/1.0.0-rc.4/esri-leaflet-geocoder.js"></script>
-<link rel="stylesheet" type="text/css" href="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-geocoder/1.0.0-rc.4/esri-leaflet-geocoder.css">
+<script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-geocoder/1.0.0/esri-leaflet-geocoder.js"></script>
+<link rel="stylesheet" type="text/css" href="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-geocoder/1.0.0/esri-leaflet-geocoder.css">
 
 <!-- Renderers Plugin -->
 <script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-renderers/v0.0.1-beta.2/esri-leaflet-renderers.js"></script>
@@ -79,8 +79,8 @@ A summary of what features exist in which builds.
 
 | Feature                                | Standard | Core     | MapService | ImageService | FeatureLayer | Basemaps |
 | -------------------------------------- | -------- | -------- | ---------- | ------------ | ------------ | -------- |
-| Size                                   | 52kb     | 11.6kb   | 24.3kb     | 21.6kb       | 29.6kb       | 11kb   |
-| Gzipped                                | 12.9kb   | 3.8kb    | 6.8kb      | 6.3kb        | 8.7kb        | 3.3kb    |
+| Size                                   | 57.3kb     | 11.3kb   | 26.9kb     | 22.2kb       | 32.4kb       | 11.5kb   |
+| Gzipped                                | 14.6kb   | 4kb    | 8kb      | 6.6kb        | 9.4kb        | 3.5kb    |
 | `L.esri.Request`                       | &#10003; | &#10003; | &#10003;   | &#10003;     | &#10003;     | &#10003; |
 | `L.esri.Util`                          | &#10003; | &#10003; | &#10003;   | &#10003;     | &#10003;     |          |
 | `L.esri.Services.Service`              | &#10003; | &#10003; | &#10003;   | &#10003;     | &#10003;     |          |

--- a/site/source/pages/download/index.md
+++ b/site/source/pages/download/index.md
@@ -85,7 +85,7 @@ A summary of what features exist in which builds.
 | `L.esri.Util`                          | &#10003; | &#10003; | &#10003;   | &#10003;     | &#10003;     |          |
 | `L.esri.Services.Service`              | &#10003; | &#10003; | &#10003;   | &#10003;     | &#10003;     |          |
 | `L.esri.Services.MapService`           | &#10003; |          | &#10003;   |              |              |          |
-| `L.esri.Services.FeatureLayer`         | &#10003; |          |            |              | &#10003;     |          |
+| `L.esri.Services.FeatureLayerService`         | &#10003; |          |            |              | &#10003;     |          |
 | `L.esri.Tasks.Task `                   | &#10003; | &#10003; | &#10003;   | &#10003;     | &#10003;     |          |
 | `L.esri.Tasks.Query`                   | &#10003; |          | &#10003;   | &#10003;     | &#10003;     |          |
 | `L.esri.Tasks.Find`                    | &#10003; |          | &#10003;   |              |              |          |


### PR DESCRIPTION
do we want to move the plugins that are still on s3 to jsdelivr too?