### PR TITLE
bump geocoder and fix layer constructor snippets

### DIFF
--- a/site/source/pages/api-reference/layers/image-map-layer.md
+++ b/site/source/pages/api-reference/layers/image-map-layer.md
@@ -229,7 +229,7 @@ var map = L.map('map').setView([43.50, -120.23], 7);
 
 L.esri.basemapLayer('Imagery').addTo(map);
 
-L.esri.imageMapLayer('http://imagery.oregonexplorer.info/arcgis/rest/services/NAIP_2011/NAIP_2011_Dynamic/ImageServer')
+L.esri.imageMapLayer({url: 'http://imagery.oregonexplorer.info/arcgis/rest/services/NAIP_2011/NAIP_2011_Dynamic/ImageServer'})
       .setBandIds('3,0,1')
       .addTo(map);
 ```

--- a/site/source/pages/api-reference/layers/tiled-map-layer.md
+++ b/site/source/pages/api-reference/layers/tiled-map-layer.md
@@ -95,7 +95,8 @@ Is you have Feature Services published in ArcGIS Online you can create a static 
 ```js
 var map = L.map('map').setView([37.7614, -122.3911], 12);
 
-L.esri.tiledMapLayer("http://services.arcgisonline.com/ArcGIS/rest/services/USA_Topo_Maps/MapServer", {
+L.esri.tiledMapLayer({
+  url: 'http://services.arcgisonline.com/ArcGIS/rest/services/USA_Topo_Maps/MapServer',
   maxZoom: 15
 }).addTo(map);
 ```

--- a/site/source/pages/examples/center-map-on-address.hbs
+++ b/site/source/pages/examples/center-map-on-address.hbs
@@ -4,8 +4,8 @@ description: Geocode an address and then center the map on it automatically. Thi
 layout: example.hbs
 ---
 
-<script src="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-geocoder/1.0.0-rc.4/esri-leaflet-geocoder.js"></script>
-<link rel="stylesheet" type="text/css" href="http://cdn-geoweb.s3.amazonaws.com/esri-leaflet-geocoder/1.0.0-rc.4/esri-leaflet-geocoder.css">
+<link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/leaflet.esri.geocoder/1.0.2/esri-leaflet-geocoder.css">
+<script src="//cdn.jsdelivr.net/leaflet.esri.geocoder/1.0.2/esri-leaflet-geocoder.js"></script>
 
 <div id="map"></div>
 

--- a/site/source/pages/examples/geocoding-control.hbs
+++ b/site/source/pages/examples/geocoding-control.hbs
@@ -4,8 +4,8 @@ description: Using the geocoding control to search for addresses and center the 
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="//cdn.jsdelivr.net/leaflet.esri.geocoder/1.0.1/esri-leaflet-geocoder.css">
-<script src="//cdn.jsdelivr.net/leaflet.esri.geocoder/1.0.1/esri-leaflet-geocoder.js"></script>
+<link rel="stylesheet" href="//cdn.jsdelivr.net/leaflet.esri.geocoder/1.0.2/esri-leaflet-geocoder.css">
+<script src="//cdn.jsdelivr.net/leaflet.esri.geocoder/1.0.2/esri-leaflet-geocoder.js"></script>
 
 <div id="map"></div>
 

--- a/site/source/pages/examples/reverse-geocoding.hbs
+++ b/site/source/pages/examples/reverse-geocoding.hbs
@@ -4,8 +4,8 @@ description: Query the closest address to a given point with the Esri Leaflet Ge
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="//cdn.jsdelivr.net/leaflet.esri.geocoder/1.0.1/esri-leaflet-geocoder.css">
-<script src="//cdn.jsdelivr.net/leaflet.esri.geocoder/1.0.1/esri-leaflet-geocoder.js"></script>
+<link rel="stylesheet" href="//cdn.jsdelivr.net/leaflet.esri.geocoder/1.0.2/esri-leaflet-geocoder.css">
+<script src="//cdn.jsdelivr.net/leaflet.esri.geocoder/1.0.2/esri-leaflet-geocoder.js"></script>
 
 <div id="map"></div>
 

--- a/site/source/pages/examples/search-feature-layer.hbs
+++ b/site/source/pages/examples/search-feature-layer.hbs
@@ -4,8 +4,8 @@ description: Searches features layers for matching text in addition to geocoding
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="//cdn.jsdelivr.net/leaflet.esri.geocoder/1.0.1/esri-leaflet-geocoder.css">
-<script src="//cdn.jsdelivr.net/leaflet.esri.geocoder/1.0.1/esri-leaflet-geocoder.js"></script>
+<link rel="stylesheet" href="//cdn.jsdelivr.net/leaflet.esri.geocoder/1.0.2/esri-leaflet-geocoder.css">
+<script src="//cdn.jsdelivr.net/leaflet.esri.geocoder/1.0.2/esri-leaflet-geocoder.js"></script>
 
 <div id="map"></div>
 

--- a/site/source/pages/examples/search-map-service.hbs
+++ b/site/source/pages/examples/search-map-service.hbs
@@ -4,8 +4,8 @@ description: Searches map services for matching text in addition to geocoding. T
 layout: example.hbs
 ---
 
-<link rel="stylesheet" href="//cdn.jsdelivr.net/leaflet.esri.geocoder/1.0.1/esri-leaflet-geocoder.css">
-<script src="//cdn.jsdelivr.net/leaflet.esri.geocoder/1.0.1/esri-leaflet-geocoder.js"></script>
+<link rel="stylesheet" href="//cdn.jsdelivr.net/leaflet.esri.geocoder/1.0.2/esri-leaflet-geocoder.css">
+<script src="//cdn.jsdelivr.net/leaflet.esri.geocoder/1.0.2/esri-leaflet-geocoder.js"></script>
 
 <div id="map"></div>
 


### PR DESCRIPTION
bumped geocoder to 1.0.2 in samples and fixed a few outdated layer constructor snippets in the API reference.

will rebuild site after merging.