### PR TITLE
Removes RasterLayer link

### DIFF
--- a/site/source/pages/api-reference/index.hbs
+++ b/site/source/pages/api-reference/index.hbs
@@ -12,7 +12,7 @@ Layers provide visualization capabilities for data hosted in Feature Services, M
 * [`L.esri.Layers.BasemapLayer`]({{assets}}api-reference/layers/basemap-layer.html)
 * [`L.esri.Layers.DynamicMapLayer`]({{assets}}api-reference/layers/dynamic-map-layer.html)
 * [`L.esri.Layers.ImageMapLayer`]({{assets}}api-reference/layers/image-map-layer.html)
-* [`L.esri.Layers.RasterLayer`]({{assets}}api-reference/layers/raster-layer.html)
+* `L.esri.Layers.RasterLayer`
 * [`L.esri.Layers.TiledMapLayer`]({{assets}}api-reference/layers/tiled-map-layer.html)
 * [`L.esri.Layers.FeatureLayer`]({{assets}}api-reference/layers/feature-layer.html)
 * [`L.esri.Layers.ClusteredFeatureLayer`]({{assets}}api-reference/layers/clustered-feature-layer.html)


### PR DESCRIPTION
Documentation for RasterLayer isn't available, so it probably shouldn't be linked.