### PR TITLE
various sample fixes

### DIFF
--- a/site/source/pages/api-reference/layers/dynamic-map-layer.md
+++ b/site/source/pages/api-reference/layers/dynamic-map-layer.md
@@ -223,12 +223,12 @@ dynamicMapLayer.bindPopup(
 
 ```js
 var map = L.map('map').setView([ 38.83,-98.5], 7);
-
 L.esri.basemapLayer('Gray').addTo(map);
 
 var url = "http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Petroleum/KGS_OilGasFields_Kansas/MapServer";
 
-L.esri.dynamicMapLayer(url, {
+L.esri.dynamicMapLayer({
+  url: url,
   opacity : 0.25
 }).addTo(map);
 

--- a/site/source/pages/examples/editing.hbs
+++ b/site/source/pages/examples/editing.hbs
@@ -13,7 +13,7 @@ layout: example.hbs
     position: absolute;
     top: 10px;
     right: 10px;
-    z-index: 10;
+    z-index: 400;
     padding: 1em;
     background: white;
     text-align: right;

--- a/site/source/pages/examples/feature-layer-popups.hbs
+++ b/site/source/pages/examples/feature-layer-popups.hbs
@@ -15,7 +15,7 @@ layout: example.hbs
     url: 'https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Heritage_Trees_Portland/FeatureServer/0'
   }).addTo(map);
 
-  trees.bindPopup(function (feature) {
-    return L.Util.template('<p>{COMMON_NAM}<br>{SCIENTIFIC}<br>{NOTES}</p>', feature.properties);
+  trees.bindPopup(function (evt) {
+    return L.Util.template('<p>{COMMON_NAM}<br>{SCIENTIFIC}<br>{NOTES}</p>', evt.feature.properties);
   });
 </script>

--- a/site/source/pages/examples/finding-features.hbs
+++ b/site/source/pages/examples/finding-features.hbs
@@ -9,7 +9,7 @@ layout: example.hbs
         position: absolute;
         top: 10px;
         right: 10px;
-        z-index: 10;
+        z-index: 400;
         background: white;
         padding: 1em;
     }

--- a/site/source/pages/examples/getting-service-metadata.hbs
+++ b/site/source/pages/examples/getting-service-metadata.hbs
@@ -9,7 +9,7 @@ layout: example.hbs
     position: absolute;
     top: 10px;
     right: 10px;
-    z-index: 10;
+    z-index: 1000;
     background: white;
     padding: 1em;
   }

--- a/site/source/pages/examples/gp-plugin.hbs
+++ b/site/source/pages/examples/gp-plugin.hbs
@@ -11,7 +11,7 @@ layout: example.hbs
     position: absolute;
     top: 10px;
     right: 10px;
-    z-index: 10;
+    z-index: 1000;
     padding: 1em;
     background: white;
   }

--- a/site/source/pages/examples/querying-feature-layers-2.hbs
+++ b/site/source/pages/examples/querying-feature-layers-2.hbs
@@ -13,12 +13,13 @@ layout: example.hbs
   var stops = L.esri.featureLayer({
     url: 'https://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/Trimet_Transit_Stops/FeatureServer/0',
     pointToLayer: function (geojson, latlng) {
-      return L.circleMarker(latlng, {
-        color: '#5B7CBA',
-        weight: 2,
-        opacity: 0.85,
-        fillOpacity: 0.5
-      });
+      return L.circleMarker(latlng);
+    },
+    style:{
+      color: '#5B7CBA',
+      weight: 2,
+      opacity: 0.85,
+      fillOpacity: 0.5
     }
   }).addTo(map);
 

--- a/site/source/pages/examples/simplifying-complex-features.hbs
+++ b/site/source/pages/examples/simplifying-complex-features.hbs
@@ -9,7 +9,7 @@ layout: example.hbs
     position: absolute;
     top: 10px;
     right: 10px;
-    z-index: 10;
+    z-index: 400;
     padding: 1em;
     background: white;
   }

--- a/site/source/pages/examples/styling-feature-layer-polylines.hbs
+++ b/site/source/pages/examples/styling-feature-layer-polylines.hbs
@@ -9,7 +9,7 @@ layout: example.hbs
     position: absolute;
     top: 10px;
     right: 10px;
-    z-index: 10;
+    z-index: 400;
     padding: 1em;
     background: white;
   }

--- a/site/source/pages/examples/switching-basemaps.hbs
+++ b/site/source/pages/examples/switching-basemaps.hbs
@@ -9,7 +9,7 @@ layout: example.hbs
     position: absolute;
     top: 10px;
     right: 10px;
-    z-index: 10;
+    z-index: 400;
     background: white;
     padding: 10px;
   }

--- a/site/source/pages/examples/tile-layer-2.hbs
+++ b/site/source/pages/examples/tile-layer-2.hbs
@@ -11,6 +11,6 @@ layout: example.hbs
 
   L.esri.tiledMapLayer({
     url: "http://services.arcgisonline.com/ArcGIS/rest/services/Specialty/World_Navigation_Charts/MapServer",
-    detectRetina: true
+    detectRetina: false
   }).addTo(map);
 </script>

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -148,7 +148,6 @@ export var FeatureLayer = FeatureManager.extend({
   },
 
   cellEnter: function (bounds, coords) {
-    console.log(this._zooming);
     if (!this._zooming) {
       L.Util.requestAnimFrame(L.Util.bind(function () {
         var cacheKey = this._cacheKey(coords);
@@ -162,7 +161,6 @@ export var FeatureLayer = FeatureManager.extend({
   },
 
   cellLeave: function (bounds, coords) {
-    console.log(this._zooming);
     if (!this._zooming) {
       L.Util.requestAnimFrame(L.Util.bind(function () {
         var cacheKey = this._cacheKey(coords);


### PR DESCRIPTION
went through and made a few fixes to the samples.  most of which are just spikes in the `z-index` value for info panes.

tbh, i'm not really sure exactly *why* L.esri.featureLayer.bindPopup() doesn't return a GeoJSON 'feature' as the callback function argument anymore.
 
tile-layer-2.html *should* work with `detectRetina` set to `true` on `L.esri.tiledMapLayer` but it doesn't, so i figured probably best to set as false until we figure out why.