### PR TITLE
update NatGeo, Gray and DarkGray basemap attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 [Upcoming changes][unreleased]
 
+### Fixed
+
+* Improved NationalGeographic and Gray attribution #612
+
 ## [2.0.0-beta.5](v2.0.0-beta.5)
 
 ### Fixed

--- a/src/Layers/BasemapLayer.js
+++ b/src/Layers/BasemapLayer.js
@@ -63,7 +63,7 @@ export var BasemapLayer = L.TileLayer.extend({
           minZoom: 1,
           maxZoom: 16,
           subdomains: ['server', 'services'],
-          attribution: 'Esri'
+          attribution: 'National Geographic, Esri, DeLorme, HERE, UNEP-WCMC, USGS, NASA, ESA, METI, NRCAN, GEBCO, NOAA, increment P Corp.'
         }
       },
       DarkGray: {
@@ -74,7 +74,7 @@ export var BasemapLayer = L.TileLayer.extend({
           minZoom: 1,
           maxZoom: 16,
           subdomains: ['server', 'services'],
-          attribution: 'Esri, DeLorme, HERE'
+          attribution: 'Esri, HERE, DeLorme, MapmyIndia, © OpenStreetMap contributors'
         }
       },
       DarkGrayLabels: {
@@ -96,7 +96,7 @@ export var BasemapLayer = L.TileLayer.extend({
           minZoom: 1,
           maxZoom: 16,
           subdomains: ['server', 'services'],
-          attribution: 'Esri, NAVTEQ, DeLorme'
+          attribution: 'Esri, HERE, DeLorme, MapmyIndia, © OpenStreetMap contributors'
         }
       },
       GrayLabels: {
@@ -151,7 +151,7 @@ export var BasemapLayer = L.TileLayer.extend({
           minZoom: 1,
           maxZoom: 13,
           subdomains: ['server', 'services'],
-          attribution: 'Esri, NAVTEQ, DeLorme'
+          attribution: 'Esri, USGS'
         }
       },
       ShadedReliefLabels: {


### PR DESCRIPTION
improves the attribution for various tiled map services that don't have a static attribution url to include.