### PR TITLE
make sure logo href opens in a new tab and TiledMapLayer regex fix

### DIFF
--- a/spec/Layers/TiledMapLayerSpec.js
+++ b/spec/Layers/TiledMapLayerSpec.js
@@ -18,11 +18,19 @@ describe('L.esri.TiledMapLayer', function () {
     expect(layer.tileUrl).to.equal('http://services.arcgisonline.com/ArcGIS/rest/services/USA_Topo_Maps/MapServer/tile/{z}/{y}/{x}');
   });
 
-  it('will modify url for tiles.arcgis.com services', function () {
+  it('will modify url for old tiles.arcgisonline.com services', function () {
     var layer = L.esri.tiledMapLayer({
       url: 'http://tiles.arcgisonline.com/ArcGIS/rest/services/USA_Topo_Maps/MapServer'
     });
     expect(layer.tileUrl).to.equal('http://tiles{s}.arcgisonline.com/ArcGIS/rest/services/USA_Topo_Maps/MapServer/tile/{z}/{y}/{x}');
+    expect(layer.options.subdomains).to.deep.equal(['1','2','3','4']);
+  });
+
+  it('will modify url for new tiles.arcgis.com services', function () {
+    var layer = L.esri.tiledMapLayer({
+      url: 'http://tiles.arcgis.com/ArcGIS/rest/services/USA_Topo_Maps/MapServer'
+    });
+    expect(layer.tileUrl).to.equal('http://tiles{s}.arcgis.com/ArcGIS/rest/services/USA_Topo_Maps/MapServer/tile/{z}/{y}/{x}');
     expect(layer.options.subdomains).to.deep.equal(['1','2','3','4']);
   });
 

--- a/src/Controls/Logo.js
+++ b/src/Controls/Logo.js
@@ -15,21 +15,9 @@ export var Logo = L.Control.extend({
     div.style.marginLeft = this.options.marginLeft;
     div.style.marginBottom = this.options.marginBottom;
     div.style.marginRight = this.options.marginRight;
-    div.innerHTML = this._adjustLogo(this._map._size);
-
-    this._map.on('resize', function (e) {
-      div.innerHTML = this._adjustLogo(e.newSize);
-    }, this);
+    div.innerHTML = '<a href="http://www.esri.com" target="_blank" style="border: none;"><img src="https://js.arcgis.com/3.13/esri/images/map/logo-sm.png" alt="Powered by Esri" style="border: none;"></a>';
 
     return div;
-  },
-
-  _adjustLogo: function (mapSize) {
-    if (mapSize.x <= 600 || mapSize.y <= 600) {
-      return '<a href="https://developers.arcgis.com" style="border: none;"><img src="https://js.arcgis.com/3.13/esri/images/map/logo-sm.png" alt="Powered by Esri" style="border: none;"></a>';
-    } else {
-      return '<a href="https://developers.arcgis.com" style="border: none;"><img src="https://js.arcgis.com/3.13/esri/images/map/logo-med.png" alt="Powered by Esri" style="border: none;"></a>';
-    }
   }
 });
 

--- a/src/Layers/TiledMapLayer.js
+++ b/src/Layers/TiledMapLayer.js
@@ -46,7 +46,8 @@ export var TiledMapLayer = L.TileLayer.extend({
     this.service = mapService(options);
     this.service.addEventParent(this);
 
-    if (arcgisonline.test(/tiles.arcgis(online)?\.com/g) {
+    var arcgisonline = new RegExp(/tiles.arcgis(online)?\.com/g);
+    if (arcgisonline.test(options.url)) {
       this.tileUrl = this.tileUrl.replace('://tiles', '://tiles{s}');
       options.subdomains = ['1', '2', '3', '4'];
     }


### PR DESCRIPTION
resolves #615 (despite the opinions of stalwarts like @swingley)

i noticed that the changes introduced in #614 were breaking tests (because `arcgisonline` wasn't defined and we were missing a closing parenthesis) so i included a fix for that as well.

lastly, i decided to use the small logo all the time to match the prominence of [Google's](https://developers.google.com/maps/documentation/javascript/) in version 3 of their JS API and to link to www.esri.com instead of the developers site.