### PR TITLE
fix broken link for feature layer service

### DIFF
--- a/site/source/pages/api-reference/layers/feature-layer.md
+++ b/site/source/pages/api-reference/layers/feature-layer.md
@@ -166,7 +166,7 @@ You can create a new empty feature service with a single layer on the [ArcGIS fo
 | `removefeature` | [<`RemoveFeatureEvent`>]({{assets}}api-reference/events.html#feature-remove) | Fired when a feature on the layer is removed from the map. |
 | `addfeature` | [<`AddFeatureEvent`>]({{assets}}api-reference/events.html#feature-add) | Fired when a previously removed feature is added back to the map. |
 
-`L.esri.FeatureLayer` also fires all  [`L.esri.Services.FeatureLayer`]({{assets}}api-reference/services/feature-layer.html) events.
+`L.esri.FeatureLayer` also fires all  [`L.esri.Services.FeatureLayer`]({{assets}}api-reference/services/feature-layer-service.html) events.
 
 In addition to the events above, `L.esri.FeatureLayer` also fires the following [Mouse Events](http://leafletjs.com/reference.html#event-objects) `click`, `dblclick`, `mouseover`, `mouseout`, `mousemove`, and `contextmenu` and the following the [Popup Events](http://leafletjs.com/reference.html#event-objects) `popupopen` and `popupclose`
 

--- a/site/source/partials/sidebar-documentation.hbs
+++ b/site/source/partials/sidebar-documentation.hbs
@@ -30,7 +30,7 @@
   <h5>Base Classes</h5>
   <nav>
     <a href="{{assets}}api-reference/services/image-service.html">ImageService</a>
-    <a href="{{assets}}api-reference/services/feature-layer.html">FeatureLayerService</a>
+    <a href="{{assets}}api-reference/services/feature-layer-service.html">FeatureLayerService</a>
     <a href="{{assets}}api-reference/services/map-service.html">MapService</a>
     <a href="{{assets}}api-reference/services/service.html">Service</a>
   </nav>


### PR DESCRIPTION
I see the site has been broken out into https://github.com/jgravois/esri-leaflet-website - the 'edit this page' still links to esri-leaflet - not sure if this is the right place. 

cc @jgravois 