### PR TITLE
satisfies eslint peer dependecy requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     ]
   },
   "devDependencies": {
+    "eslint": "^0.24.1",
     "assemble": "^0.4.37",
     "babelify": "^6.1.3",
     "chai": "2.3.0",


### PR DESCRIPTION
@patrickarlt When I delete my node_modules directory and try npm install I get the following error: 
```
npm ERR! peerinvalid The package eslint does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer eslint-config-semistandard@4.0.0 wants eslint@0.x
npm ERR! peerinvalid Peer eslint-config-standard@3.4.1 wants eslint@0.x
npm ERR! peerinvalid Peer eslint-config-standard-react@1.0.4 wants eslint@>=0.24.1
npm ERR! peerinvalid Peer eslint-plugin-react@2.7.1 wants eslint@>=0.8.0 || ~1.0.0-rc-0
```

Does not happen on a fresh clone so it isn't critical but this commit resolves the issue I was seeing.