### PR TITLE
delete featurelayer._map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-[Upcoming changes][unreleased]
+### [Upcoming changes][unreleased]
 
 ### Fixed
 
 * Improved NationalGeographic and Gray attribution #612
+* Fixed removing of `FeatureLayer` from maps (again)
 
 ## [2.0.0-beta.5](v2.0.0-beta.5)
 
@@ -343,7 +344,8 @@ None
 * Add DarkGray and DarkGrayLabels to BasemapLayer. #190
 * An attributionControl on maps is now required when using BasemapLayer. #159
 
-[unreleased]: https://github.com/esri/esri-leaflet/compare/v2.0.0-beta.4...HEAD
+[unreleased]: https://github.com/esri/esri-leaflet/compare/v2.0.0-beta.5...HEAD
+[v2.0.0-beta.5]: https://github.com/esri/esri-leaflet/compare/v2.0.0-beta.4...v2.0.0-beta.5
 [v2.0.0-beta.4]: https://github.com/esri/esri-leaflet/compare/v2.0.0-beta.3...v2.0.0-beta.4
 [v2.0.0-beta.3]: https://github.com/esri/esri-leaflet/compare/v2.0.0-beta.2...v2.0.0-beta.3
 [v2.0.0-beta.2]: https://github.com/esri/esri-leaflet/compare/v2.0.0-beta.1...v2.0.0-beta.2

--- a/spec/Layers/FeatureLayer/FeatureLayerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureLayerSpec.js
@@ -431,4 +431,19 @@ describe('L.esri.FeatureLayer', function () {
 
     expect(layer.getFeature(1).options.pane).to.equal('custom');
   });
+
+  it('should not throw uncaught errors when a feature layer is removed from the map', function(){
+    map.createPane('custom');
+    layer = L.esri.featureLayer({
+      url: 'http://gis.example.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0',
+      pane: 'custom'
+    }).addTo(map);
+
+    layer.createLayers(features);
+    expect(layer._map).to.equal(map);
+
+    map.removeLayer(layer);
+    expect(layer._map).to.not.exist;
+  });
+
 });

--- a/src/Layers/FeatureLayer/FeatureGrid.js
+++ b/src/Layers/FeatureLayer/FeatureGrid.js
@@ -21,6 +21,7 @@ export var FeatureGrid = L.Layer.extend({
 
   onRemove: function () {
     this._map.removeEventListener(this.getEvents(), this);
+    delete this._map;
     this._removeCells();
   },
 


### PR DESCRIPTION
i was still seeing some flaky behavior (ie: code was intermittently stepping into the block where we check for the presence of this._map) when removing feature layers so i dropped in an actual `delete` and wrote a test which confirms that the property is no longer set.

closes #609 

i'd like to tag/bump to 2.0.0 and drop the betas altogether right before i merge the new website changes in.