### PR TITLE
move ._map check inside requestAnimFrame

### DIFF
--- a/src/Layers/FeatureLayer/FeatureGrid.js
+++ b/src/Layers/FeatureLayer/FeatureGrid.js
@@ -21,7 +21,6 @@ export var FeatureGrid = L.Layer.extend({
 
   onRemove: function () {
     this._map.removeEventListener(this.getEvents(), this);
-    delete this._map;
     this._removeCells();
   },
 

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -161,30 +161,32 @@ export var FeatureLayer = FeatureManager.extend({
   },
 
   cellLeave: function (bounds, coords) {
-    if (!this._zooming && this._map) {
+    if (!this._zooming) {
       L.Util.requestAnimFrame(L.Util.bind(function () {
-        var cacheKey = this._cacheKey(coords);
-        var cellKey = this._cellCoordsToKey(coords);
-        var layers = this._cache[cacheKey];
-        var mapBounds = this._map.getBounds();
-        if (!this._activeCells[cellKey] && layers) {
-          var removable = true;
+        if (this._map) {
+          var cacheKey = this._cacheKey(coords);
+          var cellKey = this._cellCoordsToKey(coords);
+          var layers = this._cache[cacheKey];
+          var mapBounds = this._map.getBounds();
+          if (!this._activeCells[cellKey] && layers) {
+            var removable = true;
 
-          for (var i = 0; i < layers.length; i++) {
-            var layer = this._layers[layers[i]];
-            if (layer && layer.getBounds && mapBounds.intersects(layer.getBounds())) {
-              removable = false;
+            for (var i = 0; i < layers.length; i++) {
+              var layer = this._layers[layers[i]];
+              if (layer && layer.getBounds && mapBounds.intersects(layer.getBounds())) {
+                removable = false;
+              }
             }
-          }
 
-          if (removable) {
-            this.removeLayers(layers, !this.options.cacheLayers);
-          }
+            if (removable) {
+              this.removeLayers(layers, !this.options.cacheLayers);
+            }
 
-          if (!this.options.cacheLayers && removable) {
-            delete this._cache[cacheKey];
-            delete this._cells[cellKey];
-            delete this._activeCells[cellKey];
+            if (!this.options.cacheLayers && removable) {
+              delete this._cache[cacheKey];
+              delete this._cells[cellKey];
+              delete this._activeCells[cellKey];
+            }
           }
         }
       }, this));


### PR DESCRIPTION
i am *still* seeing intermittent problems when removing layers (mostly because i'm testing the heck out of updates to @kneemer's [comparisons](http://esri.github.io/esri-leaflet-renderers/spec/comparisons.html)).

at this point my best guess is that the intermittent errors we see within `cellLeave()` aren't being caused by the fact that `this._map` isn't being dropped correctly, but rather that we're intermittently stepping into the function while _map is still present and registering an async callback that doesn't fire until a fraction of a second later *after* its gone.

still trying to put #609 to bed.