### PR TITLE
Use HTTPS on AJAX content (dist)

### DIFF
--- a/examples/styling-feature-layer-polygons.html
+++ b/examples/styling-feature-layer-polygons.html
@@ -178,7 +178,7 @@
   L.esri.basemapLayer('GrayLabels').addTo(map);
 
   L.esri.featureLayer({
-    url: 'http://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_Congressional_Districts/FeatureServer/0',
+    url: 'https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_Congressional_Districts/FeatureServer/0',
     simplifyFactor: 0.5,
     precision: 5,
     style: function (feature) {
@@ -223,7 +223,7 @@
   L.esri.basemapLayer(<span class="string">'GrayLabels'</span>).addTo(map);
 
   L.esri.featureLayer({
-    url: <span class="string">'http://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_Congressional_Districts/FeatureServer/0'</span>,
+    url: <span class="string">'https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_Congressional_Districts/FeatureServer/0'</span>,
     simplifyFactor: <span class="number">0.5</span>,
     precision: <span class="number">5</span>,
     style: <span class="function"><span class="keyword">function</span> <span class="params">(feature)</span> {</span>


### PR DESCRIPTION
The page currently doesn't render the map when viewed over HTTPS because it's pulling insecure content over HTTP