### PR TITLE
Use HTTPS on AJAX content (src)

### DIFF
--- a/site/source/pages/examples/styling-feature-layer-polygons.hbs
+++ b/site/source/pages/examples/styling-feature-layer-polygons.hbs
@@ -14,7 +14,7 @@ layout: example.hbs
   L.esri.basemapLayer('GrayLabels').addTo(map);
 
   L.esri.featureLayer({
-    url: 'http://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_Congressional_Districts/FeatureServer/0',
+    url: 'https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_Congressional_Districts/FeatureServer/0',
     simplifyFactor: 0.5,
     precision: 5,
     style: function (feature) {

--- a/site/source/pages/examples/styling-feature-layer-polylines.hbs
+++ b/site/source/pages/examples/styling-feature-layer-polylines.hbs
@@ -24,7 +24,7 @@ layout: example.hbs
   L.esri.basemapLayer('Streets').addTo(map);
 
   var bikePaths = L.esri.featureLayer({
-    url: 'http://services.arcgis.com/uCXeTVveQzP4IIcx/ArcGIS/rest/services/Bike_Routes/FeatureServer/0',
+    url: 'https://services.arcgis.com/uCXeTVveQzP4IIcx/ArcGIS/rest/services/Bike_Routes/FeatureServer/0',
     style: function (feature) {
       var c,o = 0.75;
       switch (feature.properties.BIKEMODE) {


### PR DESCRIPTION
Revision of #679 
The page currently doesn't render the map when viewed over HTTPS because it's pulling insecure content over HTTP