### PR TITLE
force redirect users to http [needs discussion]

### DIFF
--- a/site/source/partials/header.hbs
+++ b/site/source/partials/header.hbs
@@ -47,6 +47,13 @@
     <script src="//cdn.jsdelivr.net/jsdelivr-rum/latest/jsdelivr-rum.min.js"></script>
   {{/if}}
 
+  <script>
+  // force redirect everyone to http to avoid mixed content errors from sample services that dont support https
+  var host = "esri.github.io";
+  if ((host == window.location.host) && (window.location.protocol != "http:"))
+      window.location.protocol = "http";
+  </script>
+
   <!-- Google Analytics -->
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
we get a fairly substantial number of reports from people experiencing one of two categories of problems

1. they are using `https` to access our documentation and a sample misbehaves because the service itself doesn't support `https`
2. they are using `https` to access our documentation and a sample misbehaves because we use `http` explicitly when we load the service (even though it **does** support SSL)

i'm happy to go on nipping problems of category 2 in the bud and attempting to root out services that don't support https, but it occurred to me that we can also just force redirect everyone to http since we never gather any personally identifying information.

i'm curious to hear other's thoughts, as i know there are some ardent supporters of *https everywhere* out there.