### PR TITLE
ensure FeatureLayer max/minZoom are always respected

### DIFF
--- a/spec/Layers/FeatureLayer/FeatureManagerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureManagerSpec.js
@@ -815,7 +815,7 @@ describe('L.esri.FeatureManager', function () {
     expect(requestendSpy.callCount).to.be.above(0);
   });
 
-  it('should NOT create layers when the zoom level is outside allowed range', function (done) {
+  it('should NOT draw layers when the zoom level is outside allowed range', function (done) {
 
     map.setZoom(14);
 
@@ -831,39 +831,43 @@ describe('L.esri.FeatureManager', function () {
 
       server.respond();
 
-      expect(layer.createLayers).not.to.have.been.called;
+      expect(layer._visibleZoom()).to.be.false;
+      expect(layer._currentSnapshot.length).to.equal(0);
       done();
     });
 
     map.setZoom(17);
-
-
   });
 
   // this test needs reworked
-  // it('should create layers when the zoom level is inside allowed range', function (done) {
+  it('should create layers when the zoom level is inside allowed range', function (done) {
 
-  //   map.setZoom(14);
+    map.setZoom(14);
 
-  //   server.respondWith('GET', 'http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0/query?returnGeometry=true&where=1%3D1&outSr=4326&outFields=*&inSr=4326&geometry=%7B%22xmin%22%3A-122.6953125%2C%22ymin%22%3A45.521743896993634%2C%22xmax%22%3A-122.6513671875%2C%22ymax%22%3A45.55252525134013%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryEnvelope&spatialRel=esriSpatialRelIntersects&geometryPrecision=6&f=json', JSON.stringify({
-  //     fields: fields,
-  //     features: [feature1, feature2],
-  //     objectIdFieldName: 'OBJECTID'
-  //   }));
+    server.respondWith('GET', 'http://services.arcgis.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0/query?returnGeometry=true&where=1%3D1&outSr=4326&outFields=*&inSr=4326&geometry=%7B%22xmin%22%3A-122.6953125%2C%22ymin%22%3A45.521743896993634%2C%22xmax%22%3A-122.6513671875%2C%22ymax%22%3A45.55252525134013%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryEnvelope&spatialRel=esriSpatialRelIntersects&geometryPrecision=6&f=json', JSON.stringify({
+      fields: fields,
+      features: [feature1, feature2],
+      objectIdFieldName: 'OBJECTID'
+    }));
 
-  //   layer.addTo(map);
+    layer.addTo(map);
 
-  //   map.once('zoomend', function () {
+    map.once('zoomend', function () {
 
-  //     server.respond();
+      server.respond();
 
-  //     expect(layer.createLayers).to.have.been.called;
-  //     done();
-  //   });
+      expect(layer._visibleZoom()).to.be.true;
 
-  //   map.setZoom(11);
+      // var requestSpy = sinon.spy();
+      // layer.on('addfeature', requestSpy);
+      // expect(requestSpy.callCount).to.be.above(0);
+      done();
+
+    });
+
+    map.setZoom(11);
 
 
-  // });
+  });
 
 });

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -80,11 +80,11 @@ export var FeatureLayer = FeatureManager.extend({
       var layer = this._layers[geojson.id];
       var newLayer;
 
-      if (layer && !this._map.hasLayer(layer)) {
+      if (this._visibleZoom() && layer && !this._map.hasLayer(layer)) {
         this._map.addLayer(layer);
       }
 
-      // update geometry if neccessary
+      // update geometry if necessary
       if (layer && this.options.simplifyFactor > 0 && (layer.setLatLngs || layer.setLatLng)) {
         this._updateLayer(layer, geojson);
       }
@@ -110,10 +110,11 @@ export var FeatureLayer = FeatureManager.extend({
           feature: newLayer.feature
         }, true);
 
-        // add the layer if it is within the time bounds or our layer is not time enabled
-        if (!this.options.timeField || (this.options.timeField && this._featureWithinTimeRange(geojson))) {
+        // add the layer if the current zoom level is inside the range defined for the layer, it is within the current time bounds or our layer is not time enabled
+        if (this._visibleZoom() && (!this.options.timeField || (this.options.timeField && this._featureWithinTimeRange(geojson)))) {
           this._map.addLayer(newLayer);
         }
+
       }
     }
   },

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -63,6 +63,31 @@ export var FeatureManager = VirtualGrid.extend({
    */
 
   onAdd: function (map) {
+    /*
+    not sure if this the best way to maintain a reference to FeatureManager
+    within the event listener?
+    */
+    var self = this;
+
+    map.on('zoomend', function(e) {
+      var zoom = map.getZoom();
+      if (zoom > self.service.options.maxZoom || zoom < self.service.options.minZoom) {
+        console.log('dont draw!');
+        // self.removeLayers(self._currentSnapshot);
+        // self._currentSnapshot = [];
+      }
+      else {
+        console.log('draw!');
+        /* For every cell in this._activeCells:
+
+        1. Get the cache key for the coords of the cell ` var key = this._cacheKey(coords);
+        2. If this._cache[key] exists it will be an array of feature IDs.
+        3. Call this.addLayers(this._cache[key]) to instruct the feature layer to add the layers back.
+
+        */
+      }
+    });
+
     return VirtualGrid.prototype.onAdd.call(this, map);
   },
 
@@ -147,11 +172,14 @@ export var FeatureManager = VirtualGrid.extend({
       this._buildTimeIndexes(features);
     }
 
-    var zoom = this._map.getZoom();
+    // remove this logic entirely once the new stuff is hooked up
+    // var zoom = this._map.getZoom();
 
-    if (zoom > this.options.maxZoom ||
-        zoom < this.options.minZoom) { return; }
+    // if (zoom > this.options.maxZoom ||
+    //     zoom < this.options.minZoom) { return; }
 
+    // will have to rip out the stuff below too once the new stuff is working
+    // https://github.com/patrickarlt/leaflet-virtual-grid/blob/master/src/virtual-grid.js#L100-L102
     this.createLayers(features);
   },
 

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -94,6 +94,9 @@ export var FeatureManager = VirtualGrid.extend({
 
   _visibleZoom: function () {
     // check to see whether the current zoom level of the map is within the optional limit defined for the FeatureLayer
+    if (!this._map) {
+      return false
+    }
     var zoom = this._map.getZoom();
     if (zoom > this.options.maxZoom || zoom < this.options.minZoom) { return false }
       else { return true }


### PR DESCRIPTION
resolves #643 (in favor of #660), based on direction provided by @patrickarlt [here](https://github.com/Esri/esri-leaflet/pull/660#issuecomment-151680624).  the tests are still pretty crap for this, but they're a little better than they were before.

testing manually everything looked good to me when:
* no min/maxZoom are declared in the constructor
* both are declared
* each are provided singularly
* when panning/zooming the map manually
* when calling methods like `map.setZoom()`
* when the initial map zoom level should draw the layer
* when it shouldn't

i'm not positive, but this might resolve the problem reported in JRHutson/Food-Resource-Map#37 as well.