### PR TITLE
bump/syncronize npm/bower leaflet version dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "v2.0.0-beta.6",
   "main": "dist/esri-leaflet.js",
   "dependencies": {
-    "leaflet": ">=0.7.0"
+    "leaflet": "^1.0.0-beta.2"
   },
   "ignore": [
     "**/.*",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "babelify": "^6.1.3",
     "chai": "2.3.0",
     "eslint": "^1.10.2",
-    "esperanto": "^0.7.3",
     "gh-release": "^2.0.0",
     "grunt": "^0.4.2",
     "grunt-concurrent": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "John Gravois <jgravois@esri.com> (http://johngravois.com)"
   ],
   "dependencies": {
-    "leaflet": "1.0.0-beta.2"
+    "leaflet": "^1.0.0-beta.2"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
`>=0.7.0` doesn't lay down `1.0.0-beta.x` (yet) because `0.7.7` is still tagged as *latest*.  (more info [here](https://github.com/Esri/esri-leaflet/pull/696#issuecomment-167362232)).

got rid of esperanto dependency while i was at it (to resolve an `npm install` nag)