### PR TITLE
bump virtual grid dep to 1.0.2 explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   ],
   "dependencies": {
     "arcgis-to-geojson-utils": "^1.0.0",
-    "leaflet-virtual-grid": "^1.0.0",
-    "leaflet": "1.0.0-beta.2"
+    "leaflet-virtual-grid": "^1.0.2",
+    "leaflet": "^1.0.0-beta.2"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
while this isn't *technically* required, it seems useful to me document in the repo that our next release wouldn't behave correctly with leaflet-virtual-grid `1.0.0`

@ngoldman, do you have opinions about this sort of thing?

