### PR TITLE
use https explicitly for OAuth/token requests

### DIFF
--- a/site/source/pages/examples/arcgis-online-auth.hbs
+++ b/site/source/pages/examples/arcgis-online-auth.hbs
@@ -46,7 +46,7 @@ layout: example.hbs
       callback(accessToken);
     } else {
       callbacks.push(callback);
-      window.open('//www.arcgis.com/sharing/oauth2/authorize?client_id='+clientID+'&response_type=token&expiration=20160&redirect_uri=' + window.encodeURIComponent(callbackPage), 'oauth', 'height=400,width=600,menubar=no,location=yes,resizable=yes,scrollbars=yes,status=yes');
+      window.open('https://www.arcgis.com/sharing/oauth2/authorize?client_id='+clientID+'&response_type=token&expiration=20160&redirect_uri=' + window.encodeURIComponent(callbackPage), 'oauth', 'height=400,width=600,menubar=no,location=yes,resizable=yes,scrollbars=yes,status=yes');
     }
   }
 

--- a/site/source/pages/examples/arcgis-server-auth.hbs
+++ b/site/source/pages/examples/arcgis-server-auth.hbs
@@ -12,7 +12,7 @@ layout: example.hbs
   L.esri.basemapLayer('Topographic').addTo(map);
 
   function serverAuth(callback){
-    L.esri.post('//sampleserver6.arcgisonline.com/arcgis/tokens/generateToken', {
+    L.esri.post('https://sampleserver6.arcgisonline.com/arcgis/tokens/generateToken', {
       username: 'user1',
       password: 'user1',
       f: 'json',

--- a/site/source/pages/examples/premium-content.hbs
+++ b/site/source/pages/examples/premium-content.hbs
@@ -59,7 +59,7 @@ layout: example.hbs
       callback(accessToken);
     } else {
       callbacks.push(callback);
-      window.open('//www.arcgis.com/sharing/oauth2/authorize?client_id='+clientID+'&response_type=token&expiration=20160&redirect_uri=' + window.encodeURIComponent(callbackPage), 'oauth-window', 'height=400,width=600,menubar=no,location=yes,resizable=yes,scrollbars=yes,status=yes');
+      window.open('https://www.arcgis.com/sharing/oauth2/authorize?client_id='+clientID+'&response_type=token&expiration=20160&redirect_uri=' + window.encodeURIComponent(callbackPage), 'oauth-window', 'height=400,width=600,menubar=no,location=yes,resizable=yes,scrollbars=yes,status=yes');
     }
   }
 


### PR DESCRIPTION
noticed local samples demonstrating authentication are broken when running over `http` because OAuth token service smartly *requires* SSL

arcgis server token endpoint doesn't, but we should still show best practice.