### PR TITLE
make sure features stop drawing when layer is removed

### DIFF
--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -30,10 +30,13 @@ EsriLeaflet.Layers.FeatureLayer = EsriLeaflet.Layers.FeatureManager.extend({
     map.on('zoomstart zoomend', function(e){
       this._zooming = (e.type === 'zoomstart');
     }, this);
+    this._removed = false;
+
     return EsriLeaflet.Layers.FeatureManager.prototype.onAdd.call(this, map);
   },
 
   onRemove: function(map){
+    this._removed = true;
     for (var i in this._layers) {
       map.removeLayer(this._layers[i]);
     }

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -104,7 +104,7 @@
         }
 
         // no error, features
-        if(!error && featureCollection && featureCollection.features.length){
+        if(!error && featureCollection && featureCollection.features.length && !this._removed){
           // schedule adding features until the next animation frame
           EsriLeaflet.Util.requestAnimationFrame(L.Util.bind(function(){
             this._addFeatures(featureCollection.features, coords);


### PR DESCRIPTION
this is a fairly cheesy solution to #691, but it works fine for me.  it would be a mess trying to backport all the new and improved grid handling logic to `1.x`, 

happy to rework if you have a better idea, if not, i'll bump the internal version numbers to `1.0.2` and push the patch to github/npm.

