### PR TITLE
add cluster layer to api reference

### DIFF
--- a/site/source/pages/api-reference/layers/clustered-feature-layer.md
+++ b/site/source/pages/api-reference/layers/clustered-feature-layer.md
@@ -1,11 +1,11 @@
 ---
-title: L.esri.ClusteredFeatureLayer
+title: L.esri.Cluster.ClusteredFeatureLayer
 layout: documentation.hbs
 ---
 
 # {{page.data.title}}
 
-`L.esri.ClusteredFeatureLayer` provides integration for Feature Layers with the [Leaflet.markercluster plugin](https://github.com/Leaflet/Leaflet.markercluster). Because of the extra dependency on Leaflet.markercluster we do not include `L.esri.ClusteredFeatureLayer` in the default build of Esri Leaflet. It lives in /dist/extras/clustered-feature-layer.js. You will also need to include your own copy of the [Leaflet.markercluster plugin](https://github.com/Leaflet/Leaflet.markercluster).
+`L.esri.Cluster.ClusteredFeatureLayer` provides integration for Feature Layers with the [Leaflet.markercluster plugin](https://github.com/Leaflet/Leaflet.markercluster). Because of the extra dependency on Leaflet.markercluster we do not include `L.esri.Cluster.ClusteredFeatureLayer` in the default build of Esri Leaflet.  You will also need to include your own copy of the [Leaflet.markercluster plugin](https://github.com/Leaflet/Leaflet.markercluster).
 
 More information about Feature Layers can be found in the [`L.esri.FeatureLayer` documentation]({{assets}}api-reference/layers/feature-layer.html).
 
@@ -20,7 +20,7 @@ More information about Feature Layers can be found in the [`L.esri.FeatureLayer`
     </thead>
     <tbody>
         <tr>
-            <td><code class="nobr">L.esri.clusteredFeatureLayer({{{param 'Object' 'options'}}})</code></td>
+            <td><code class="nobr">L.esri.Cluster.clusteredFeatureLayer({{{param 'Object' 'options'}}})</code></td>
             <td>You must pass a <code>url</code> to a [Feature Layer](http://resources.arcgis.com/en/help/arcgis-rest-api/#/Layer/02r3000000w6000000/) in your <code>options</code></td>
         </tr>
     </tbody>
@@ -287,13 +287,12 @@ L.esri.basemapLayer("Streets").addTo(map);
 
 var url = "http://services.arcgis.com/rOo16HdIMeOBI4Mb/arcgis/rest/services/stops/FeatureServer/0";
 
-var busStops = new L.esri.ClusteredFeatureLayer({
+var busStops = L.esri.Cluster.clusteredFeatureLayer({
   url: url,
   // Cluster Options
   polygonOptions: {
     color: "#2d84c8"
   },
-
   // Feature Layer Options
   pointToLayer: function (geojson, latlng) {
     return L.circleMarker(latlng, 10, {

--- a/site/source/pages/api-reference/layers/coming-soon.md
+++ b/site/source/pages/api-reference/layers/coming-soon.md
@@ -1,9 +1,0 @@
----
-layout: documentation.hbs
----
-
-# L.esri.ClusteredFeatureLayer
-
-This plugin relies on [Leaflet.markercluster](https://github.com/Leaflet/Leaflet.markercluster), which is not yet compatible with [Leaflet 1.0 beta 1](http://leafletjs.com/2015/07/15/leaflet-1.0-beta1-released.html).
-
-Please check out our own Clustered Feature Layer [repository](https://github.com/Esri/esri-leaflet-clustered-feature-layer) in Github for documentation and examples for using the plugin in applications built on top of Leaflet 0.7.3.

--- a/site/source/partials/sidebar-documentation.hbs
+++ b/site/source/partials/sidebar-documentation.hbs
@@ -7,7 +7,7 @@
     <a href="{{assets}}api-reference/layers/dynamic-map-layer.html">Dynamic Map Layer</a>
     <a href="{{assets}}api-reference/layers/image-map-layer.html">Image Map Layer</a>
     <a class="plugin" href="{{assets}}api-reference/layers/heatmap-feature-layer.html">Heatmap Feature Layer</a>
-    <a class="plugin" href="{{assets}}api-reference/layers/coming-soon.html">Clustered Feature Layer</a>
+    <a class="plugin" href="{{assets}}api-reference/layers/clustered-feature-layer.html">Clustered Feature Layer</a>
   </nav>
 
   <h5>Controls</h5>


### PR DESCRIPTION
just realized i never forgot to get rid of the placeholder for `clusteredFeatureLayer` i stuck in awhile back.