### PR TITLE
get npm install/npm run build working on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "load-grunt-tasks": "^0.4.0",
     "mkdirp": "^0.5.1",
     "phantomjs": "^1.9.17",
-    "rollup": "^0.11.4",
+    "rollup": "^0.19.0",
     "semistandard": "^7.0.4",
     "sinon": "^1.11.1",
     "sinon-chai": "2.7.0",

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -114,7 +114,6 @@ export var FeatureLayer = FeatureManager.extend({
         if (this._visibleZoom() && (!this.options.timeField || (this.options.timeField && this._featureWithinTimeRange(geojson)))) {
           this._map.addLayer(newLayer);
         }
-
       }
     }
   },

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -385,14 +385,15 @@ export var FeatureManager = VirtualGrid.extend({
   _visibleZoom: function () {
     // check to see whether the current zoom level of the map is within the optional limit defined for the FeatureLayer
     if (!this._map) {
-      return false
+      return false;
     }
     var zoom = this._map.getZoom();
-    if (zoom > this.options.maxZoom || zoom < this.options.minZoom) { return false }
-      else { return true }
+    if (zoom > this.options.maxZoom || zoom < this.options.minZoom) {
+      return false;
+    } else { return true; }
   },
 
-  _handleZoomChange: function() {
+  _handleZoomChange: function () {
     if (!this._visibleZoom()) {
       this.removeLayers(this._currentSnapshot);
       this._currentSnapshot = [];
@@ -407,7 +408,7 @@ export var FeatureManager = VirtualGrid.extend({
         var coords = this._activeCells[i].coords;
         var key = this._cacheKey(coords);
         if (this._cache[key]) {
-          this.addLayers(self._cache[key]);
+          this.addLayers(this._cache[key]);
         }
       }
     }

--- a/src/Request.js
+++ b/src/Request.js
@@ -57,7 +57,7 @@ function createRequest (callback, context) {
     if (httpRequest.readyState === 4) {
       try {
         response = JSON.parse(httpRequest.responseText);
-      } catch(e) {
+      } catch (e) {
         response = null;
         error = {
           code: 500,

--- a/src/Util.js
+++ b/src/Util.js
@@ -35,7 +35,7 @@ export function boundsToExtent (bounds) {
 }
 
 // GeoJSON -> ArcGIS
-var g2a = GeojsonUtil.geojsonToArcGIS
+var g2a = GeojsonUtil.geojsonToArcGIS;
 export { g2a as geojsonToArcGIS };
 
 // ArcGS -> GeoJSON
@@ -97,24 +97,24 @@ export function isArcgisOnline (url) {
 export function geojsonTypeToArcGIS (geoJsonType) {
   var arcgisGeometryType;
   switch (geoJsonType) {
-  case 'Point':
-    arcgisGeometryType = 'esriGeometryPoint';
-    break;
-  case 'MultiPoint':
-    arcgisGeometryType = 'esriGeometryMultipoint';
-    break;
-  case 'LineString':
-    arcgisGeometryType = 'esriGeometryPolyline';
-    break;
-  case 'MultiLineString':
-    arcgisGeometryType = 'esriGeometryPolyline';
-    break;
-  case 'Polygon':
-    arcgisGeometryType = 'esriGeometryPolygon';
-    break;
-  case 'MultiPolygon':
-    arcgisGeometryType = 'esriGeometryPolygon';
-    break;
+    case 'Point':
+      arcgisGeometryType = 'esriGeometryPoint';
+      break;
+    case 'MultiPoint':
+      arcgisGeometryType = 'esriGeometryMultipoint';
+      break;
+    case 'LineString':
+      arcgisGeometryType = 'esriGeometryPolyline';
+      break;
+    case 'MultiLineString':
+      arcgisGeometryType = 'esriGeometryPolyline';
+      break;
+    case 'Polygon':
+      arcgisGeometryType = 'esriGeometryPolygon';
+      break;
+    case 'MultiPolygon':
+      arcgisGeometryType = 'esriGeometryPolygon';
+      break;
   }
 
   return arcgisGeometryType;


### PR DESCRIPTION
closes #722
even though we use a [`^`](https://github.com/Esri/esri-leaflet/blob/master/package.json#L63), to denote a SemVer range for rollup (that usually allows bumping the minor), we were still effectively locking the version in place at `0.11.4` because the version number is `< 1.x` (more info [here](https://github.com/npm/npm/issues/6768#issuecomment-64726706)).

i couldn't get the latest (`0.24.0`) working quickly, so this PR just bumps us up to  to `0.19.0`.  i confimed that this has the desired effect on both mac and windows.