### PR TITLE
add timeout option and keep correct count of active requests

### DIFF
--- a/spec/Layers/FeatureLayer/FeatureLayerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureLayerSpec.js
@@ -452,7 +452,7 @@ describe('L.esri.FeatureLayer', function () {
       url: 'http://gis.example.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0',
       pane: 'custom'
     });
-    expect(layer.service.options.timeout).to.equal(5000);
+    expect(layer.service.options.timeout).to.equal(0);
 
     layer.service.setTimeout(1500);
     expect(layer.service.options.timeout).to.equal(1500);

--- a/spec/Layers/FeatureLayer/FeatureLayerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureLayerSpec.js
@@ -446,4 +446,24 @@ describe('L.esri.FeatureLayer', function () {
     expect(layer._map).to.not.exist;
   });
 
+  it('should set the timeout of the service in two different ways', function(){
+    map.createPane('custom');
+    layer = L.esri.featureLayer({
+      url: 'http://gis.example.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0',
+      pane: 'custom'
+    });
+    expect(layer.service.options.timeout).to.equal(5000);
+
+    layer.service.setTimeout(1500);
+    expect(layer.service.options.timeout).to.equal(1500);
+
+    layer2 = L.esri.featureLayer({
+      url: 'http://gis.example.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0',
+      pane: 'custom',
+      timeout: 1500
+    });
+    expect(layer.service.options.timeout).to.equal(1500);
+
+  });
+
 });

--- a/spec/Layers/FeatureLayer/FeatureManagerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureManagerSpec.js
@@ -870,4 +870,51 @@ describe('L.esri.FeatureManager', function () {
 
   });
 
+  it('should keep an accurate count of active requests even when they error', function(){
+    var triggered = false;
+
+    layer.on("load", function(ev){
+      triggered = true;
+    });
+
+    var southWest = L.latLng(29.53522956294847, -98.4375),
+        northEast = L.latLng(30.14512718337613, -97.734375),
+        bounds = L.latLngBounds(southWest, northEast);
+    var point = L.point(200, 300);
+
+    server.respondWith('GET', new RegExp(/.*/), JSON.stringify({
+      fields: fields
+    }));
+
+    layer._requestFeatures(bounds, point, function(){return;});
+    
+    server.respondWith('GET', new RegExp(/.*/), JSON.stringify({
+      fields: fields
+    }));
+
+    layer._requestFeatures(bounds, point, function(){return;});
+
+    expect(layer._activeRequests).to.equal(2);
+    
+
+    server.respondWith("GET", new RegExp(/.*/),
+                [500, { "Content-Type": "application/json" },
+                 '']);
+    layer._requestFeatures(bounds, point, function(){return;})
+
+    server.respond();
+    server.respond();
+    server.respond();
+
+    expect(layer._activeRequests).to.equal(0);
+    expect(triggered).to.be.true;
+
+
+
+
+
+  })
+
+  
+
 });

--- a/spec/Layers/FeatureLayer/FeatureManagerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureManagerSpec.js
@@ -895,7 +895,6 @@ describe('L.esri.FeatureManager', function () {
     layer._requestFeatures(bounds, point, function(){return;});
 
     expect(layer._activeRequests).to.equal(2);
-    
 
     server.respondWith("GET", new RegExp(/.*/),
                 [500, { "Content-Type": "application/json" },
@@ -908,10 +907,6 @@ describe('L.esri.FeatureManager', function () {
 
     expect(layer._activeRequests).to.equal(0);
     expect(triggered).to.be.true;
-
-
-
-
 
   })
 

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -116,6 +116,10 @@ export var FeatureManager = VirtualGrid.extend({
         this._postProcessFeatures(bounds);
       }
 
+      if (error) {
+        this._postProcessFeatures(bounds);
+      }
+
       if (callback) {
         callback.call(this, error, featureCollection);
       }

--- a/src/Request.js
+++ b/src/Request.js
@@ -76,11 +76,22 @@ function createRequest (callback, context) {
     }
   };
 
+  httpRequest.ontimeout = function () {
+    this.onerror();
+  };
+
   return httpRequest;
 }
 
 function xmlHttpPost (url, params, callback, context) {
   var httpRequest = createRequest(callback, context);
+
+  if (typeof context !== 'undefined' && context !== null) {
+    if (typeof context.options !== 'undefined') {
+      httpRequest.timeout = context.options.timeout;
+    }
+  }
+
   httpRequest.open('POST', url);
   httpRequest.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
   httpRequest.send(serialize(params));
@@ -90,6 +101,12 @@ function xmlHttpPost (url, params, callback, context) {
 
 function xmlHttpGet (url, params, callback, context) {
   var httpRequest = createRequest(callback, context);
+
+  if (typeof context !== 'undefined' && context !== null) {
+    if (typeof context.options !== 'undefined') {
+      httpRequest.timeout = context.options.timeout;
+    }
+  }
 
   httpRequest.open('GET', url + '?' + serialize(params), true);
   httpRequest.send(null);
@@ -101,6 +118,13 @@ function xmlHttpGet (url, params, callback, context) {
 export function request (url, params, callback, context) {
   var paramString = serialize(params);
   var httpRequest = createRequest(callback, context);
+
+  if (typeof context !== 'undefined' && context !== null) {
+    if (typeof context.options !== 'undefined') {
+      httpRequest.timeout = context.options.timeout;
+    }
+  }
+
   var requestLength = (url + '?' + paramString).length;
 
   // request is less then 2000 characters and the browser supports CORS, make GET request with XMLHttpRequest

--- a/src/Services/Service.js
+++ b/src/Services/Service.js
@@ -8,7 +8,7 @@ export var Service = L.Evented.extend({
   options: {
     proxy: false,
     useCors: cors,
-    timeout: 5000
+    timeout: 0
   },
 
   initialize: function (options) {
@@ -40,6 +40,10 @@ export var Service = L.Evented.extend({
     this.options.token = token;
     this._runQueue();
     return this;
+  },
+
+  getTimeout: function () {
+    return this.options.timeout;
   },
 
   setTimeout: function (timeout) {

--- a/src/Services/Service.js
+++ b/src/Services/Service.js
@@ -7,7 +7,8 @@ export var Service = L.Evented.extend({
 
   options: {
     proxy: false,
-    useCors: cors
+    useCors: cors,
+    timeout: 5000
   },
 
   initialize: function (options) {
@@ -41,6 +42,10 @@ export var Service = L.Evented.extend({
     return this;
   },
 
+  setTimeout: function (timeout) {
+    this.options.timeout = timeout;
+  },
+
   _request: function (method, path, params, callback, context) {
     this.fire('requeststart', {
       url: this.options.url + path,
@@ -61,9 +66,9 @@ export var Service = L.Evented.extend({
       var url = (this.options.proxy) ? this.options.proxy + '?' + this.options.url + path : this.options.url + path;
 
       if ((method === 'get' || method === 'request') && !this.options.useCors) {
-        return Request.get.JSONP(url, params, wrappedCallback);
+        return Request.get.JSONP(url, params, wrappedCallback, context);
       } else {
-        return Request[method](url, params, wrappedCallback);
+        return Request[method](url, params, wrappedCallback, context);
       }
     }
   },


### PR DESCRIPTION
See more info at #728.

This adds a timeout option when FeatureLayer is instantiated or the possibility to setTimeout(milliseconds) on the service itself.  In addition, FeatureManager was not keeping an accurate count of activerequests, since any requests that error out would not be post-processed.  Tests were added for both cases.

The test 'keep an accurate count of active requests even when they error' in FeatureManagerSpec could also be useful for #719.