### PR TITLE
RasterLayer.getEvents deleted

### DIFF
--- a/src/Layers/RasterLayer.js
+++ b/src/Layers/RasterLayer.js
@@ -62,12 +62,6 @@ export var RasterLayer = L.Layer.extend({
     this._map.off('moveend', this._update, this);
   },
 
-  getEvents: function () {
-    return {
-      moveend: this._update
-    };
-  },
-
   bindPopup: function (fn, popupOptions) {
     this._shouldRenderPopup = false;
     this._lastClick = false;


### PR DESCRIPTION
Because in ‘onAdd’ function ‘update’ function already binded to
‘moveend’ event. If ‘getEvents’ exists, ‘update’ is calling two times