### PR TITLE
Fix dynamic layer zooming issue when minZoom/maxZoom are present

### DIFF
--- a/src/Layers/RasterLayer.js
+++ b/src/Layers/RasterLayer.js
@@ -213,6 +213,7 @@ export var RasterLayer = L.Layer.extend({
     }
 
     if (zoom > this.options.maxZoom || zoom < this.options.minZoom) {
+      this._currentImage._map.removeLayer(this._currentImage);
       return;
     }
 


### PR DESCRIPTION
Fixes #744 


Edit: 
Dymanic overlay is visible only on zoom levels 10-12 in the example.

![working](https://cloud.githubusercontent.com/assets/31543/13155938/5e6e8346-d63d-11e5-85cc-c8eeba55722f.gif)
