### PR TITLE
no 'rollup-plugin-npm', only node-resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "rollup": "^0.25.4",
     "rollup-plugin-json": "^2.0.0",
     "rollup-plugin-node-resolve": "^1.4.0",
-    "rollup-plugin-npm": "^1.2.1",
     "rollup-plugin-uglify": "^0.1.0",
     "semistandard": "^7.0.5",
     "sinon": "^1.11.1",


### PR DESCRIPTION
just pulling out the `rollup-plugin-npm` package dependency to resolve an install nag.
its now called `rollup-plugin-node-resolve` (and was already included).