### PR TITLE
make sure XMLHttpRequest.open is called first

### DIFF
--- a/src/Request.js
+++ b/src/Request.js
@@ -118,6 +118,16 @@ function xmlHttpGet (url, params, callback, context) {
 export function request (url, params, callback, context) {
   var paramString = serialize(params);
   var httpRequest = createRequest(callback, context);
+  var requestLength = (url + '?' + paramString).length;
+
+  // get around ie10/11 bug which requires that the request be opened before a timeout is applied
+  if (requestLength <= 2000 && Support.cors) {
+    httpRequest.open('GET', url + '?' + paramString);
+
+  } else if (requestLength > 2000 && Support.cors) {
+    httpRequest.open('POST', url);
+    httpRequest.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+  }
 
   if (typeof context !== 'undefined' && context !== null) {
     if (typeof context.options !== 'undefined') {
@@ -125,17 +135,12 @@ export function request (url, params, callback, context) {
     }
   }
 
-  var requestLength = (url + '?' + paramString).length;
-
   // request is less then 2000 characters and the browser supports CORS, make GET request with XMLHttpRequest
   if (requestLength <= 2000 && Support.cors) {
-    httpRequest.open('GET', url + '?' + paramString);
     httpRequest.send(null);
 
   // request is less more then 2000 characters and the browser supports CORS, make POST request with XMLHttpRequest
   } else if (requestLength > 2000 && Support.cors) {
-    httpRequest.open('POST', url);
-    httpRequest.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
     httpRequest.send(paramString);
 
   // request is less more then 2000 characters and the browser does not support CORS, make a JSONP request


### PR DESCRIPTION
this is a fix to workaround an ie10/11 bug that a customer pointed out in [GIS.SE](http://gis.stackexchange.com/questions/188964/invalidstateerror-in-ie-for-esri-leaflet) that causes the `L.esri.featureLayer` in our [own sample](http://esri.github.io/esri-leaflet/) to fail to draw entirely in those versions of the browser.

the change ensures that we call methods on `XMLHttpRequest` in the following sequence:
1. `open()`
2. `whatever()`
3. `send()`

more or less lifted from google/tracing-framework#407

cc/ @patrickarlt
