### PR TITLE
get native geojson from 10.4

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,11 +12,18 @@ module.exports = function (config) {
     frameworks: ['mocha', 'chai-sinon'],
 
     // list of files / patterns to load in the browser
+    // not sure why tests are failing when files are loaded in bulk
+    
     files: [
       'node_modules/leaflet/dist/leaflet.css',
       'node_modules/leaflet/dist/leaflet-src.js',
       'dist/esri-leaflet-debug.js',
-      'spec/**/*Spec.js'
+      // 'spec/**/*Spec.js'
+      'spec/Layers/*Spec.js',
+      'spec/Layers/FeatureLayer/*Spec.js',
+      'spec/Services/*Spec.js',
+      'spec/Tasks/*Spec.js',
+      'spec/*Spec.js'
     ],
 
     // list of files to exclude
@@ -41,7 +48,7 @@ module.exports = function (config) {
 
     // level of logging
     // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-    logLevel: config.LOG_DEBUG,
+    logLevel: config.LOG_WARN,
 
     // enable / disable watching file and executing tests whenever any file changes
     autoWatch: true,

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -64,6 +64,14 @@ export var FeatureManager = VirtualGrid.extend({
    */
 
   onAdd: function (map) {
+    // check to see whether service is 10.4 or above (and can emit GeoJSON natively)
+    this.service.metadata(function (error, metadata) {
+      var supportedFormats = metadata.supportedQueryFormats;
+      if (supportedFormats && supportedFormats.indexOf('geoJSON') !== -1) {
+        this.service.options.isModern = true;
+      }
+    }, this);
+
     map.on('zoomend', this._handleZoomChange, this);
 
     return VirtualGrid.prototype.onAdd.call(this, map);

--- a/src/Tasks/Query.js
+++ b/src/Tasks/Query.js
@@ -97,8 +97,8 @@ export var Query = Task.extend({
   run: function (callback, context) {
     this._cleanParams();
 
-    // if the service is hosted on arcgis online request geojson directly
-    if (Util.isArcgisOnline(this.options.url)) {
+    // services hosted on ArcGIS Online also support requesting geojson directly
+    if (this.options.isModern || Util.isArcgisOnline(this.options.url)) {
       this.params.f = 'geojson';
 
       return this.request(function (error, response) {
@@ -217,8 +217,7 @@ export var Query = Task.extend({
       return;
     }
 
-    // warn the user if we havn't found a
-    /* global console */
+    // warn the user if we havn't found an appropriate object
     Util.warn('invalid geometry passed to spatial query. Should be an L.LatLng, L.LatLngBounds or L.Marker or a GeoJSON Point Line or Polygon object');
 
     return;

--- a/src/Util.js
+++ b/src/Util.js
@@ -92,9 +92,7 @@ export function cleanUrl (url) {
 }
 
 export function isArcgisOnline (url) {
-  /* hosted feature services can emit geojson natively.
-  our check for 'geojson' support will need to be revisted
-  once the functionality makes its way to ArcGIS Server*/
+  /* hosted feature services can emit geojson natively. */
   return (/\.arcgis\.com.*?FeatureServer/g).test(url);
 }
 


### PR DESCRIPTION
resolves #760.

i have no idea how, but i've managed to break a bunch of `L.esri.imageMapLayer` tests with this change.  

@tomwayson, do you have time to sit down w/ me and take a look sometime soon?