### PR TITLE
default to loading a blank png when a tile request fails

### DIFF
--- a/src/Layers/TiledMapLayer.js
+++ b/src/Layers/TiledMapLayer.js
@@ -4,7 +4,8 @@ import mapService from '../Services/MapService';
 
 export var TiledMapLayer = L.TileLayer.extend({
   options: {
-    zoomOffsetAllowance: 0.1
+    zoomOffsetAllowance: 0.1,
+    errorTileUrl: 'http://downloads2.esri.com/support/TechArticles/blank256.png'
   },
 
   statics: {


### PR DESCRIPTION
resolves #759

it seems sensible to me that we just load a transparent .png by default when individual tile requests return a 404 error and easiest to just grab it directly from the Esri knowledge base article i tracked down.

Article ID:	36939
http://support.esri.com/en/knowledgebase/techarticles/detail/36939