### PR TITLE
fire appropriate feature events when entire featureLayer is toggled

### DIFF
--- a/spec/Layers/FeatureLayer/FeatureLayerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureLayerSpec.js
@@ -18,17 +18,17 @@ describe('L.esri.FeatureLayer', function () {
   var layer;
   var map = createMap();
   var features = [{
-        type: 'Feature',
-        id: 1,
-        geometry: {
-          type: 'LineString',
-          coordinates: [[-122, 45], [-121, 40]]
-        },
-        properties: {
-          time: new Date('January 1 2014').valueOf(),
-          type: 'good'
-        }
-      },{
+    type: 'Feature',
+    id: 1,
+    geometry: {
+      type: 'LineString',
+      coordinates: [[-122, 45], [-121, 40]]
+    },
+    properties: {
+      time: new Date('January 1 2014').valueOf(),
+      type: 'good'
+    }
+  },{
     type: 'Feature',
     id: 2,
     geometry: {
@@ -145,6 +145,25 @@ describe('L.esri.FeatureLayer', function () {
     layer.removeLayers([1]);
   });
 
+  it('should fire a removefeature event when the featureLayer is removed from the map', function(done){
+    layer = L.esri.featureLayer({
+      url: 'http://gis.example.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0',
+      timeField: 'time',
+      pointToLayer: function(feature, latlng){
+        return L.circleMarker(latlng);
+      }
+    }).addTo(map);
+
+    layer.createLayers(features);
+
+    layer.on('removefeature', function(e){
+      expect(e.feature.id).to.equal(2);
+      done();
+    });
+
+    map.removeLayer(layer);
+  });
+
   it('should add features back to a map', function(){
     layer.removeLayers([1]);
     layer.addLayers([1]);
@@ -158,6 +177,27 @@ describe('L.esri.FeatureLayer', function () {
     });
     layer.removeLayers([1]);
     layer.addLayers([1]);
+  });
+
+  it('should fire an addfeature event when a featureLayer is readded to the map', function(done){
+    layer = L.esri.featureLayer({
+      url: 'http://gis.example.com/mock/arcgis/rest/services/MockService/MockFeatureServer/0',
+      timeField: 'time',
+      pointToLayer: function(feature, latlng){
+        return L.circleMarker(latlng);
+      }
+    }).addTo(map);
+
+    layer.createLayers(features);
+    map.removeLayer(layer);
+
+    layer.on('addfeature', function(e){
+      expect(e.feature.id).to.equal(2);
+      done();
+    });
+
+    map.addLayer(layer);
+    layer.createLayers(features);
   });
 
   it('should not add features outside the time range', function(){

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -23,6 +23,11 @@ export var FeatureLayer = FeatureManager.extend({
   onRemove: function (map) {
     for (var i in this._layers) {
       map.removeLayer(this._layers[i]);
+      // trigger the event when the entire featureLayer is removed from the map
+      this.fire('removefeature', {
+        feature: this._layers[i].feature,
+        permanent: false
+      }, true);
     }
 
     return FeatureManager.prototype.onRemove.call(this, map);
@@ -82,6 +87,9 @@ export var FeatureLayer = FeatureManager.extend({
 
       if (this._visibleZoom() && layer && !this._map.hasLayer(layer)) {
         this._map.addLayer(layer);
+        this.fire('addfeature', {
+          feature: layer.feature
+        }, true);
       }
 
       // update geometry if necessary
@@ -112,6 +120,9 @@ export var FeatureLayer = FeatureManager.extend({
 
         // add the layer if the current zoom level is inside the range defined for the layer, it is within the current time bounds or our layer is not time enabled
         if (this._visibleZoom() && (!this.options.timeField || (this.options.timeField && this._featureWithinTimeRange(geojson)))) {
+          this.fire('addfeature', {
+            feature: newLayer.feature
+          }, true);
           this._map.addLayer(newLayer);
         }
       }


### PR DESCRIPTION
resolves #788

previously the `addfeature` and `removefeature` events were specific to situations in which an individual feature was appended or dropped from the collection associated with a layer that was currently being drawn (typically because of panning and zooming).

this change extends the logic to fire `removefeature` events for individual features when the entire layer is removed from the map.
for consistency, i also ensured that `addfeature` fires both when a featureLayer is added to the map initially, and again after it is toggled back on.

cc/ @denydias