### PR TITLE
Fix esri logo removal check condition

### DIFF
--- a/dist/esri-leaflet-src.js
+++ b/dist/esri-leaflet-src.js
@@ -1642,7 +1642,7 @@ EsriLeaflet.Tasks.identifyFeatures = function(params){
     },
     onRemove: function(map){
       // check to make sure the logo hasn't already been removed
-      if(!map._hasEsriLogo && this._logo && this._logo._container){
+      if(map._hasEsriLogo && !!(this._logo && this._logo._container)){
         map.removeControl(this._logo);
         map._hasEsriLogo = false;
       }


### PR DESCRIPTION
Why `!map._hasEsriLogo`? It causes to return false when there is esri logo in the map. Proposed changed remove the `!` and also return a boolean from the div references. Maybe only `map._hasEsriLogo` is enough.