### PR TITLE
less esri in attribution

### DIFF
--- a/src/Layers/BasemapLayer.js
+++ b/src/Layers/BasemapLayer.js
@@ -14,7 +14,7 @@ export var BasemapLayer = L.TileLayer.extend({
           minZoom: 1,
           maxZoom: 19,
           subdomains: ['server', 'services'],
-          attribution: 'Esri'
+          attribution: ''
         }
       },
       Topographic: {
@@ -24,7 +24,7 @@ export var BasemapLayer = L.TileLayer.extend({
           minZoom: 1,
           maxZoom: 19,
           subdomains: ['server', 'services'],
-          attribution: 'Esri'
+          attribution: ''
         }
       },
       Oceans: {
@@ -34,7 +34,7 @@ export var BasemapLayer = L.TileLayer.extend({
           minZoom: 1,
           maxZoom: 16,
           subdomains: ['server', 'services'],
-          attribution: 'Esri'
+          attribution: ''
         }
       },
       OceansLabels: {


### PR DESCRIPTION
now that we skip displaying a logo and just add *&copy;Esri* to Leaflet's attribution control, we need to make sure the text isn't duplicated in edge cases where additional credits can't be fetched.

for example:
```js
var map = L.map('map').setView([45, 1080], 5);
L.esri.basemapLayer('Topographic').addTo(map);
```