### PR TITLE
scope 'map' variable in Util._updateMapAttribution properly

### DIFF
--- a/src/Util.js
+++ b/src/Util.js
@@ -163,7 +163,7 @@ export function _getAttributionData (url, map) {
 }
 
 export function _updateMapAttribution (evt) {
-  map = evt.target;
+  var map = evt.target;
   var oldAttributions = map._esriAttributions;
 
   if (map && map.attributionControl && oldAttributions) {


### PR DESCRIPTION
when i refactored the dynamic attribution into `L.esri.Util` i accidentally introduced some scope leak.  i noticed the problem when I was playing around with the esri-leaflet website and tried switching to use a background map with a tiled service that had dynamic attribution.

```js
var bgMap = L.map(...);
L.esri.basemapLayer('Topographic').addTo(bgMap);

...

var map = L.map(...);

...

map = bgmap // whoops!
```

how embarrassing.  i should have caught that earlier.