### PR TITLE
Fixes Issue 807 by adding token to url received from ArcGIS Server

### DIFF
--- a/src/Layers/ImageMapLayer.js
+++ b/src/Layers/ImageMapLayer.js
@@ -192,6 +192,9 @@ export var ImageMapLayer = RasterLayer.extend({
     if (this.options.f === 'json') {
       this.service.request('exportImage', params, function (error, response) {
         if (error) { return; } // we really can't do anything here but authenticate or requesterror will fire
+        if (this.options.token) { 
+          response.href += ('?token=' + this.options.token); 
+        }
         this._renderImage(response.href, bounds);
       }, this);
     } else {


### PR DESCRIPTION
Adds "&token=" + token to the imageMapLayer url so when leaflet attempts to fetch the images it includes authentication, preventing a 499 error. Resolves issue 807.