### PR TITLE
bower.json doesn't need to specify a version number.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "esri-leaflet",
-  "version": "v2.0.2",
+  "description": "Leaflet plugins for consuming ArcGIS Online and ArcGIS Server services.",
   "main": "dist/esri-leaflet.js",
   "dependencies": {
     "leaflet": "^1.0.0-rc.2"


### PR DESCRIPTION
i just noticed that leaflet's [`bower.json`](https://github.com/Leaflet/Leaflet/blob/master/bower.json) doesn't specify a version number.

since bower can fetch SemVer releases from GitHub tags [just fine](http://stackoverflow.com/questions/26571739/bower-install-no-versions-available).  this means we can remove the version number in our `bower.json` entirely too (and stop keeping it *in sync* manually).

calling `bower install` with the app bower.json below lays down 'leaflet 1.0.0-rc.3'
```js
{
  "name": "dummy project",
  "dependencies": {
    "leaflet": "^1.0.0-rc.1"
  }
}
```
