### PR TITLE
Add in missing token concatenation on DynamicMapLayer image service requests.

### DIFF
--- a/src/Layers/DynamicMapLayer.js
+++ b/src/Layers/DynamicMapLayer.js
@@ -157,6 +157,9 @@ export var DynamicMapLayer = RasterLayer.extend({
     if (this.options.f === 'json') {
       this.service.request('export', params, function (error, response) {
         if (error) { return; } // we really can't do anything here but authenticate or requesterror will fire
+        if (this.options.token) {
+          response.href += ('?token=' + this.options.token);
+        }
         if (response.href) {
           this._renderImage(response.href, bounds);
         } else {


### PR DESCRIPTION
Missing token concatenation prevented token based image service requests from DynamicMapLayer.