### PR TITLE
Tfl meta attrib

### DIFF
--- a/spec/Layers/TiledMapLayerSpec.js
+++ b/spec/Layers/TiledMapLayerSpec.js
@@ -1,4 +1,17 @@
 describe('L.esri.TiledMapLayer', function () {
+  function createMap(){
+    // create container
+    var container = document.createElement('div');
+
+    // give container a width/height
+    container.setAttribute('style', 'width:500px; height: 500px;');
+
+    // add contianer to body
+    document.body.appendChild(container);
+
+    return L.map(container).setView([37.75, -122.45], 12);
+  }
+
   var url = 'http://services.arcgisonline.com/ArcGIS/rest/services/USA_Topo_Maps/MapServer';
   var layer;
   var server;
@@ -8,6 +21,7 @@ describe('L.esri.TiledMapLayer', function () {
     layer = L.esri.tiledMapLayer({
       url: url
     });
+    map = createMap();
   });
 
   afterEach(function(){
@@ -102,4 +116,29 @@ describe('L.esri.TiledMapLayer', function () {
 
     expect(layer.tileUrl).to.equal('http://services.arcgisonline.com/ArcGIS/rest/services/USA_Topo_Maps/MapServer/tile/{z}/{y}/{x}?token=bar');
   });
+
+  it('should display an attribution if one was passed', function(){
+    L.esri.tiledMapLayer({
+      url: url,
+      attribution: 'Esri'
+    }).addTo(map);
+
+    expect(map.attributionControl._container.innerHTML).to.contain('Esri');
+  });
+
+  it('should display a metadata attribution if one is present and no attribution option was passed', function(){
+    var copywriteText;
+    layer = L.esri.tiledMapLayer({
+      url: url
+    }).addTo(map);
+
+    layer.on('load', function(){
+      layer.metadata(function(err, meta){
+        copywriteText = meta.copywriteText;
+        expect(map.attributionControl._container.innerHTML).to.contain(copywriteText);
+      });
+    });
+
+  });
+
 });

--- a/spec/Layers/TiledMapLayerSpec.js
+++ b/spec/Layers/TiledMapLayerSpec.js
@@ -134,8 +134,10 @@ describe('L.esri.TiledMapLayer', function () {
 
     layer.on('load', function(){
       layer.metadata(function(err, meta){
-        copywriteText = meta.copywriteText;
-        expect(map.attributionControl._container.innerHTML).to.contain(copywriteText);
+        if(meta && meta.hasOwnProperty(copywriteText)){
+          copywriteText = meta.copywriteText;
+          expect(map.attributionControl._container.innerHTML).to.contain(copywriteText);
+        }
       });
     });
 

--- a/spec/Layers/TiledMapLayerSpec.js
+++ b/spec/Layers/TiledMapLayerSpec.js
@@ -127,20 +127,19 @@ describe('L.esri.TiledMapLayer', function () {
   });
 
   it('should display a metadata attribution if one is present and no attribution option was passed', function(){
-    var copywriteText;
+    var copyrightText;
     layer = L.esri.tiledMapLayer({
       url: url
     }).addTo(map);
 
     layer.on('load', function(){
       layer.metadata(function(err, meta){
-        if(meta && meta.hasOwnProperty(copywriteText)){
-          copywriteText = meta.copywriteText;
-          expect(map.attributionControl._container.innerHTML).to.contain(copywriteText);
+        if(meta && meta.hasOwnProperty(copyrightText)){
+          copyrightText = meta.copyrightText;
+          expect(map.attributionControl._container.innerHTML).to.contain(copyrightText);
         }
       });
     });
-
   });
 
 });

--- a/src/Layers/TiledMapLayer.js
+++ b/src/Layers/TiledMapLayer.js
@@ -104,6 +104,10 @@ export var TiledMapLayer = L.TileLayer.extend({
       this.metadata(function (error, metadata) {
         if (!error && metadata.spatialReference) {
           var sr = metadata.spatialReference.latestWkid || metadata.spatialReference.wkid;
+          if (!this.options.attribution && map.attributionControl && metadata.copyrightText) {
+            this.options.attribution = metadata.copyrightText;
+            map.attributionControl.addAttribution(this.getAttribution());
+          }
           if (sr === 102100 || sr === 3857) {
             // create the zoom level data
             var arcgisLODs = metadata.tileInfo.lods;


### PR DESCRIPTION
Per #831 
Can you take a look at the test I wrote for the auto attribution. It passes if the tiledLayerServer has a _copywriteText_ property, but has not expect whatsoever if not. Is that the proper way to do it?

Cheers,
Tyler