### PR TITLE
insert copyright info into leaflet attribution control for all layers automatically

### DIFF
--- a/src/Layers/BasemapLayer.js
+++ b/src/Layers/BasemapLayer.js
@@ -1,7 +1,6 @@
 import L from 'leaflet';
 import { pointerEvents } from '../Support';
 import {
-  calcAttributionWidth,
   setEsriAttribution,
   _getAttributionData,
   _updateMapAttribution
@@ -234,7 +233,7 @@ export var BasemapLayer = L.TileLayer.extend({
 
   getAttribution: function () {
     if (this.options.attribution) {
-      var attribution = '<span class="esri-attributions" style="line-height:14px; vertical-align: -3px; text-overflow:ellipsis; white-space:nowrap; overflow:hidden; display:inline-block; max-width:' + calcAttributionWidth(this._map) + ';">' + this.options.attribution + '</span>';
+      var attribution = '<span class="esri-dynamic-attribution">' + this.options.attribution + '</span>';
     }
     return attribution;
   }

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -67,11 +67,18 @@ export var FeatureManager = VirtualGrid.extend({
     // include 'Powered by Esri' in map attribution
     setEsriAttribution(map);
 
-    // check to see whether service is 10.4 or above (and can emit GeoJSON natively)
-    this.service.metadata(function (error, metadata) {
-      var supportedFormats = metadata.supportedQueryFormats;
-      if (!error && supportedFormats && supportedFormats.indexOf('geoJSON') !== -1) {
-        this.service.options.isModern = true;
+    this.service.metadata(function (err, metadata) {
+      if (!err) {
+        var supportedFormats = metadata.supportedQueryFormats;
+        // check to see whether service can emit GeoJSON natively
+        if (supportedFormats && supportedFormats.indexOf('geoJSON') !== -1) {
+          this.service.options.isModern = true;
+        }
+        // add copyright text listed in service metadata
+        if (!this.options.attribution && map.attributionControl && metadata.copyrightText) {
+          this.options.attribution = metadata.copyrightText;
+          map.attributionControl.addAttribution(this.getAttribution());
+        }
       }
     }, this);
 

--- a/src/Layers/RasterLayer.js
+++ b/src/Layers/RasterLayer.js
@@ -51,6 +51,14 @@ export var RasterLayer = L.Layer.extend({
       this._map.on('click', this._getPopupData, this);
       this._map.on('dblclick', this._resetPopupState, this);
     }
+
+    // add copyright text listed in service metadata
+    this.metadata(function (err, metadata) {
+      if (!err && !this.options.attribution && map.attributionControl && metadata.copyrightText) {
+        this.options.attribution = metadata.copyrightText;
+        map.attributionControl.addAttribution(this.getAttribution());
+      }
+    }, this);
   },
 
   onRemove: function (map) {


### PR DESCRIPTION
closes #837, #840

* interrogate `dynamicMapLayer`, `imageMapLayer`, and `featureLayer` for copyright text in service and add it to the control automatically (unless custom attribution is supplied)
* trim attribution to slightly less than the width of the map (and update when the map is resized) using an ellipsis to denote overflow
* make the attribution expandable (and collapsible) when the user hovers over the control.

~~this includes commits from #841.  i'm planning on a rebase/squash after that one lands.~~