### PR TITLE
make max-width of attribution control configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ coverage
 # Debugging Files
 working
 debug/*.html
+debug/archive/
 !debug/sample.html
 
 # Docs Build

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "scripts": {
     "build": "rollup -c profiles/debug.js & rollup -c profiles/production.js",
-    "lint": "semistandard src/**/*.js | snazzy",
+    "lint": "semistandard \"src/**\" \"src/**/*.js\" | snazzy",
     "prebuild": "mkdirp dist",
     "prepublish": "npm run build",
     "pretest": "npm run build",

--- a/src/EsriLeaflet.js
+++ b/src/EsriLeaflet.js
@@ -3,6 +3,7 @@ export {version as VERSION} from '../package.json';
 
 // import base
 export { Support } from './Support';
+export { Options } from './Options';
 export { Util } from './Util';
 export { get, post, request } from './Request';
 

--- a/src/Options.js
+++ b/src/Options.js
@@ -1,0 +1,5 @@
+export var Options = {
+  attributionWidthOffset: 55
+};
+
+export default Options;

--- a/src/Util.js
+++ b/src/Util.js
@@ -130,8 +130,8 @@ export function warn () {
 }
 
 export function calcAttributionWidth (map) {
-  // slightly less than the width of the map
-  return (map.getSize().x - 20) + 'px';
+  // either crop at 55px or user defined buffer
+  return (map.getSize().x - ((map.options.constrainAttributionWidth) ? map.options.constrainAttributionWidth : 55)) + 'px';
 }
 
 export function setEsriAttribution (map) {

--- a/src/Util.js
+++ b/src/Util.js
@@ -160,7 +160,7 @@ export function setEsriAttribution (map) {
       'display: inline-block;' +
       'transition: 0s white-space;' +
       'transition-delay: 1s;' +
-      'max-width: ' + calcAttributionWidth(map); +';';
+      'max-width: ' + calcAttributionWidth(map) + ';' +
     '}';
 
     document.getElementsByTagName('head')[0].appendChild(attributionStyle);

--- a/src/Util.js
+++ b/src/Util.js
@@ -143,7 +143,7 @@ export function setEsriAttribution (map) {
     var hoverAttributionStyle = document.createElement('style');
     hoverAttributionStyle.type = 'text/css';
     hoverAttributionStyle.innerHTML = '.esri-truncated-attribution:hover {' +
-      'white-space: normal;';
+      'white-space: normal;' +
     '}';
 
     document.getElementsByTagName('head')[0].appendChild(hoverAttributionStyle);
@@ -160,7 +160,7 @@ export function setEsriAttribution (map) {
       'display: inline-block;' +
       'transition: 0s white-space;' +
       'transition-delay: 1s;' +
-      'max-width:' + calcAttributionWidth(map) +';'
+      'max-width: ' + calcAttributionWidth(map); +';';
     '}';
 
     document.getElementsByTagName('head')[0].appendChild(attributionStyle);

--- a/src/Util.js
+++ b/src/Util.js
@@ -1,5 +1,7 @@
 import L from 'leaflet';
 import { jsonp } from './Request';
+import { Options } from './Options';
+
 import {
   geojsonToArcGIS as g2a,
   arcgisToGeoJSON as a2g
@@ -131,7 +133,7 @@ export function warn () {
 
 export function calcAttributionWidth (map) {
   // either crop at 55px or user defined buffer
-  return (map.getSize().x - ((map.options.constrainAttributionWidth) ? map.options.constrainAttributionWidth : 55)) + 'px';
+  return (map.getSize().x - Options.attributionWidthOffset) + 'px';
 }
 
 export function setEsriAttribution (map) {
@@ -141,7 +143,7 @@ export function setEsriAttribution (map) {
     var hoverAttributionStyle = document.createElement('style');
     hoverAttributionStyle.type = 'text/css';
     hoverAttributionStyle.innerHTML = '.esri-truncated-attribution:hover {' +
-      'white-space: normal;'
+      'white-space: normal;';
     '}';
 
     document.getElementsByTagName('head')[0].appendChild(hoverAttributionStyle);
@@ -158,7 +160,7 @@ export function setEsriAttribution (map) {
       'display: inline-block;' +
       'transition: 0s white-space;' +
       'transition-delay: 1s;' +
-      'max-width:' + L.esri.Util.calcAttributionWidth(map) +';'
+      'max-width:' + L.esri.Util.calcAttributionWidth(map) + ';';
     '}';
 
     document.getElementsByTagName('head')[0].appendChild(attributionStyle);


### PR DESCRIPTION
in the majority of applications it makes sense to leverage as much horizontal space as possible to display attribution, primarily because of small form factor devices, but `55px` is a little safer default because it accommodates a bottom oriented zoom control automatically.

since other possibly bottom aligned controls like L.Control.Scale and L.Controls.Layers don't have a static predictable width our best bet is to just expose a mechanism to let developers indicate just how much space should be reserved.

~~i ***think*** its kosher to just tack on a new `L.Map` control constructor option and introspect for it ourselves later. if so, we'll need to find a new location in our own API reference to document it.~~