### PR TITLE
stop caching the node_modules directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ notifications:
   email: false
 node_js:
   - "4"
-cache:
-  directories:
-    - node_modules
 before_script:
   - npm prune
 before_install:


### PR DESCRIPTION
following a recommendation from @BanzaiMan to try and track down the cause of unexpected sporadic errors.