### PR TITLE
revert #884, withCredentials can be problematic for non IWA services

### DIFF
--- a/spec/RequestSpec.js
+++ b/spec/RequestSpec.js
@@ -100,7 +100,7 @@ describe('L.esri request helpers', function () {
     });
 
     expect(requests[0].url).to.contain('token=foo');
-    expect(requests[0].withCredentials).to.equal(true);
+    expect(requests[0].withCredentials).to.equal(false);
     requests[0].respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });
 

--- a/src/Layers/DynamicMapLayer.js
+++ b/src/Layers/DynamicMapLayer.js
@@ -162,6 +162,7 @@ export var DynamicMapLayer = RasterLayer.extend({
     if (this.options.f === 'json') {
       this.service.request('export', params, function (error, response) {
         if (error) { return; } // we really can't do anything here but authenticate or requesterror will fire
+
         if (this.options.token) {
           response.href += ('?token=' + this.options.token);
         }

--- a/src/Request.js
+++ b/src/Request.js
@@ -118,7 +118,7 @@ export function request (url, params, callback, context) {
   var httpRequest = createRequest(callback, context);
   var requestLength = (url + '?' + paramString).length;
 
-  // get around ie10/11 bug which requires that the request be opened before a timeout is applied
+  // ie10/11 require the request be opened before a timeout is applied
   if (requestLength <= 2000 && Support.cors) {
     httpRequest.open('GET', url + '?' + paramString);
   } else if (requestLength > 2000 && Support.cors) {
@@ -132,18 +132,15 @@ export function request (url, params, callback, context) {
     }
   }
 
-  // request is less then 2000 characters and the browser supports CORS, make GET request with XMLHttpRequest
+  // request is less than 2000 characters and the browser supports CORS, make GET request with XMLHttpRequest
   if (requestLength <= 2000 && Support.cors) {
-    // ensure cookies are passed through in cross-site Access-Control requests
-    httpRequest.withCredentials = true;
     httpRequest.send(null);
 
-  // request is less more then 2000 characters and the browser supports CORS, make POST request with XMLHttpRequest
+  // request is more than 2000 characters and the browser supports CORS, make POST request with XMLHttpRequest
   } else if (requestLength > 2000 && Support.cors) {
-    httpRequest.withCredentials = true;
     httpRequest.send(paramString);
 
-  // request is less more then 2000 characters and the browser does not support CORS, make a JSONP request
+  // request is less  than 2000 characters and the browser does not support CORS, make a JSONP request
   } else if (requestLength <= 2000 && !Support.cors) {
     return jsonp(url, params, callback, context);
 


### PR DESCRIPTION
after tagging `v2.0.5` i realized that one of the bug fixes resulted in errors when attempting to use CORS to fetch data from non secure ArcGIS Online feature services.

http://jsbin.com/wudoxe/edit?html,output

after tracking down a dependable test machine i also learned that the change wasn't even sufficient to get IWA secure dynamic map service images to draw anyway, because setting the `L.imageOverlay` constructor option crossOrigin to true still stripped identifying cookies and resulted in a 401 error from the server.