### PR TITLE
2.0.6 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Upcoming changes][unreleased]
 
-## [2.0.5]
+## [2.0.6]
+* `withCredentials` is no longer set for CORS requests.  [#890](https://github.com/Esri/esri-leaflet/pull/890)
+
+### Fixed
+
+## [2.0.5] - deprecated
 
 ### Fixed
 * DynamicMapLayer image overlays now utilize a proxy when appropriate [#862](https://github.com/Esri/esri-leaflet/issues/862)
@@ -485,7 +490,8 @@ None
 * Add DarkGray and DarkGrayLabels to BasemapLayer. #190
 * An attributionControl on maps is now required when using BasemapLayer. #159
 
-[unreleased]: https://github.com/esri/esri-leaflet/compare/v2.0.5...HEAD
+[unreleased]: https://github.com/esri/esri-leaflet/compare/v2.0.6...HEAD
+[2.0.6]: https://github.com/esri/esri-leaflet/compare/v2.0.5...v2.0.6
 [2.0.5]: https://github.com/esri/esri-leaflet/compare/v2.0.4...v2.0.5
 [2.0.4]: https://github.com/esri/esri-leaflet/compare/v2.0.3...v2.0.4
 [2.0.3]: https://github.com/esri/esri-leaflet/compare/v2.0.2...v2.0.3

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The easiest way to get started is to load Esri Leaflet via [CDN](https://unpkg.c
     <script src="https://unpkg.com/leaflet@1.0.1/dist/leaflet-src.js"></script>
 
     <!-- Load Esri Leaflet locally, after cloning this repository -->
-    <script src="https://unpkg.com/esri-leaflet@2.0.5"></script>
+    <script src="https://unpkg.com/esri-leaflet@2.0.6"></script>
 
     <style>
       html, body, #map {
@@ -154,7 +154,7 @@ If you'd like to inspect and modify the source of Esri Leaflet, follow the instr
 * Esri Leaflet [1.x](https://github.com/Esri/esri-leaflet/releases/tag/v1.0.3) (available on [CDN](https://cdn.jsdelivr.net/leaflet.esri/1.0.4/esri-leaflet.js)) can be used in apps alongside:
   *  [Leaflet](http://leafletjs.com) version 0.7.x.
 
-* Esri Leaflet [2.x](https://github.com/Esri/esri-leaflet/releases/tag/v2.0.5) (available on [CDN](https://unpkg.com/esri-leaflet@2.0.5)) can be used in apps alongside:
+* Esri Leaflet [2.x](https://github.com/Esri/esri-leaflet/releases/tag/v2.0.6) (available on [CDN](https://unpkg.com/esri-leaflet@2.0.5)) can be used in apps alongside:
   *  [Leaflet](http://leafletjs.com) version 1.x.
 
 The `master` branch of this repository is only compatible with Leaflet 1.x.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esri-leaflet",
   "description": "Leaflet plugins for consuming ArcGIS Online and ArcGIS Server services.",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "author": "Patrick Arlt <parlt@esri.com> (http://patrickarlt.com)",
   "browser": "dist/esri-leaflet-debug.js",
   "bugs": {


### PR DESCRIPTION
`2.0.5` has been deprecated on npm.