### PR TITLE
replace blank tile remote url with base64 encoded version

### DIFF
--- a/src/Layers/TiledMapLayer.js
+++ b/src/Layers/TiledMapLayer.js
@@ -5,7 +5,7 @@ import mapService from '../Services/MapService';
 export var TiledMapLayer = L.TileLayer.extend({
   options: {
     zoomOffsetAllowance: 0.1,
-    errorTileUrl: 'http://downloads2.esri.com/support/TechArticles/blank256.png'
+    errorTileUrl: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEABAMAAACuXLVVAAAAA1BMVEUzNDVszlHHAAAAAXRSTlMAQObYZgAAAAlwSFlzAAAAAAAAAAAB6mUWpAAAADZJREFUeJztwQEBAAAAgiD/r25IQAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA7waBAAABw08RwAAAAABJRU5ErkJggg=='
   },
 
   statics: {


### PR DESCRIPTION
in #784 @blq made a good suggestion to replace the default blank tile we use currently with a base64 encoded image.  

this will help us avoid an unnecessary web request and also function correctly in https applications.