### PR TITLE
RasterLayer shouldnt remove non-existent images outside constrained zoom levels

### DIFF
--- a/src/Layers/RasterLayer.js
+++ b/src/Layers/RasterLayer.js
@@ -229,7 +229,9 @@ export var RasterLayer = L.Layer.extend({
     }
 
     if (zoom > this.options.maxZoom || zoom < this.options.minZoom) {
-      this._currentImage._map.removeLayer(this._currentImage);
+      if (this._currentImage) {
+        this._currentImage._map.removeLayer(this._currentImage);
+      }
       return;
     }
 


### PR DESCRIPTION
in e8a395dde1aaf73a1fd1552e43641916f80ab6ff @greenkarmic pointed out that a console error is encountered when a RasterLayer is added to a map whose current zoom level is outside the min/maxZoom defined for the layer.

this patch ensures that we check for the existence of a previous image before we attempt to remove it.