### PR TITLE
2.0.7 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,27 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Upcoming changes][unreleased]
+## [Unreleased][unreleased]
 
-## [2.0.6]
-* `withCredentials` is no longer set for CORS requests.  [#890](https://github.com/Esri/esri-leaflet/pull/890)
+## [2.0.7]
 
 ### Fixed
+
+* its now possible to call setOpacity() immediately after instantiating a `RasterLayer` [#909](https://github.com/Esri/esri-leaflet/pull/909) (thank you[@Saulzi](https://github.com/Saulzi)!)
+* `L.TileLayer` maxNativeZoom is now honored by `tiledMapLayer` [#904](https://github.com/Esri/esri-leaflet/pull/904)
+* `addfeature` is no longer emitted twice when `FeatureLayer.setWhere()` is called [#893](https://github.com/Esri/esri-leaflet/pull/893)
+
+### Changed
+
+* `RasterLayer` now exposes a public `redraw()` method [#905](https://github.com/Esri/esri-leaflet/pull/905)
+* an inline base64 encoded transparent image is now substituted for missing tiles [#902](https://github.com/Esri/esri-leaflet/pull/902)
+* the `addfeature` event is no longer triggered when features are fetched and drawn for the very first time [#893](https://github.com/Esri/esri-leaflet/pull/893)
+
+## [2.0.6]
+
+### Fixed
+
+* `withCredentials` is no longer set for CORS requests [#890](https://github.com/Esri/esri-leaflet/pull/890)
 
 ## [2.0.5] - deprecated
 
@@ -490,7 +505,8 @@ None
 * Add DarkGray and DarkGrayLabels to BasemapLayer. #190
 * An attributionControl on maps is now required when using BasemapLayer. #159
 
-[unreleased]: https://github.com/esri/esri-leaflet/compare/v2.0.6...HEAD
+[unreleased]: https://github.com/esri/esri-leaflet/compare/v2.0.7...HEAD
+[2.0.6]: https://github.com/esri/esri-leaflet/compare/v2.0.6...v2.0.7
 [2.0.6]: https://github.com/esri/esri-leaflet/compare/v2.0.5...v2.0.6
 [2.0.5]: https://github.com/esri/esri-leaflet/compare/v2.0.4...v2.0.5
 [2.0.4]: https://github.com/esri/esri-leaflet/compare/v2.0.3...v2.0.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * its now possible to call setOpacity() immediately after instantiating a `RasterLayer` [#909](https://github.com/Esri/esri-leaflet/pull/909) (thank you[@Saulzi](https://github.com/Saulzi)!)
 * `L.TileLayer` maxNativeZoom is now honored by `tiledMapLayer` [#904](https://github.com/Esri/esri-leaflet/pull/904)
+* an error is no longer thrown when a `RasterLayer` is added to the map at a zoom level outside its own custom restraint [#903](https://github.com/Esri/esri-leaflet/pull/903)
 * `addfeature` is no longer emitted twice when `FeatureLayer.setWhere()` is called [#893](https://github.com/Esri/esri-leaflet/pull/893)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The easiest way to get started is to load Esri Leaflet via [CDN](https://unpkg.c
     <script src="https://unpkg.com/leaflet@1.0.1/dist/leaflet-src.js"></script>
 
     <!-- Load Esri Leaflet locally, after cloning this repository -->
-    <script src="https://unpkg.com/esri-leaflet@2.0.6"></script>
+    <script src="https://unpkg.com/esri-leaflet@2.0.7"></script>
 
     <style>
       html, body, #map {
@@ -154,10 +154,10 @@ If you'd like to inspect and modify the source of Esri Leaflet, follow the instr
 * Esri Leaflet [1.x](https://github.com/Esri/esri-leaflet/releases/tag/v1.0.3) (available on [CDN](https://cdn.jsdelivr.net/leaflet.esri/1.0.4/esri-leaflet.js)) can be used in apps alongside:
   *  [Leaflet](http://leafletjs.com) version 0.7.x.
 
-* Esri Leaflet [2.x](https://github.com/Esri/esri-leaflet/releases/tag/v2.0.6) (available on [CDN](https://unpkg.com/esri-leaflet@2.0.5)) can be used in apps alongside:
+* Esri Leaflet [2.x](https://github.com/Esri/esri-leaflet/releases/tag/v2.0.7) (available on [CDN](https://unpkg.com/esri-leaflet@2.0.7)) can be used in apps alongside:
   *  [Leaflet](http://leafletjs.com) version 1.x.
 
-The `master` branch of this repository is only compatible with Leaflet 1.x.
+The `master` branch of this repository is *only* compatible with Leaflet 1.x.
 
 ### Versioning
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "esri-leaflet",
   "description": "Leaflet plugins for consuming ArcGIS Online and ArcGIS Server services.",
+  "license": "Apache-2.0",
   "main": "dist/esri-leaflet.js",
   "dependencies": {
     "arcgis-to-geojson-utils": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esri-leaflet",
   "description": "Leaflet plugins for consuming ArcGIS Online and ArcGIS Server services.",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "author": "Patrick Arlt <parlt@esri.com> (http://patrickarlt.com)",
   "browser": "dist/esri-leaflet-debug.js",
   "bugs": {


### PR DESCRIPTION
closes #910 

diff for release below
https://github.com/esri/esri-leaflet/compare/v2.0.6...HEAD