### PR TITLE
reverse simplification scale and ensure bindPopup simplifies output geometry

### DIFF
--- a/spec/Layers/DynamicMapLayerSpec.js
+++ b/spec/Layers/DynamicMapLayerSpec.js
@@ -374,7 +374,7 @@ describe('L.esri.DynamicMapLayer', function () {
   });
 
   it('should bind a popup to the layer', function () {
-    server.respondWith('GET', new RegExp(/http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockMapService\/MapServer\/identify\?sr=4326&layers=visible&tolerance=3&returnGeometry=true&imageDisplay=500%2C500%2C96&mapExtent=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&geometry=-?\d+\.\d+%2C-?\d+\.\d+&geometryType=esriGeometryPoint&f=json/), JSON.stringify(sampleResponse));
+    server.respondWith('GET', new RegExp(/http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockMapService\/MapServer\/identify\?sr=4326&layers=visible&tolerance=3&returnGeometry=true&imageDisplay=500%2C500%2C96&mapExtent=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&geometry=-?\d+\.\d+%2C-?\d+\.\d+&geometryType=esriGeometryPoint&maxAllowableOffset=0.000171661376953125&f=json/), JSON.stringify(sampleResponse));
 
     layer.bindPopup(function (error, featureCollection) {
       return featureCollection.features.length + ' Feature(s)';
@@ -395,7 +395,7 @@ describe('L.esri.DynamicMapLayer', function () {
   });
 
   it('should bind a popup to the layer if the layer is already on a map', function () {
-    server.respondWith('GET', new RegExp(/http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockMapService\/MapServer\/identify\?sr=4326&layers=visible&tolerance=3&returnGeometry=true&imageDisplay=500%2C500%2C96&mapExtent=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&geometry=-?\d+\.\d+%2C-?\d+\.\d+&geometryType=esriGeometryPoint&f=json/), JSON.stringify(sampleResponse));
+    server.respondWith('GET', new RegExp(/http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockMapService\/MapServer\/identify\?sr=4326&layers=visible&tolerance=3&returnGeometry=true&imageDisplay=500%2C500%2C96&mapExtent=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&geometry=-?\d+\.\d+%2C-?\d+\.\d+&geometryType=esriGeometryPoint&maxAllowableOffset=0.000171661376953125&f=json/), JSON.stringify(sampleResponse));
 
     layer.addTo(map);
 

--- a/src/Layers/DynamicMapLayer.js
+++ b/src/Layers/DynamicMapLayer.js
@@ -89,6 +89,9 @@ export var DynamicMapLayer = RasterLayer.extend({
 
     var identifyRequest = this.identify().on(this._map).at(e.latlng);
 
+    // remove extraneous vertices from response features
+    identifyRequest.simplify(this._map, 0.5);
+
     if (this.options.layers) {
       identifyRequest.layers('visible:' + this.options.layers.join(','));
     } else {

--- a/src/Tasks/IdentifyFeatures.js
+++ b/src/Tasks/IdentifyFeatures.js
@@ -40,7 +40,7 @@ export var IdentifyFeatures = Identify.extend({
 
   simplify: function (map, factor) {
     var mapWidth = Math.abs(map.getBounds().getWest() - map.getBounds().getEast());
-    this.params.maxAllowableOffset = (mapWidth / map.getSize().y) * (1 - factor);
+    this.params.maxAllowableOffset = (mapWidth / map.getSize().y) * factor;
     return this;
   },
 


### PR DESCRIPTION
resolves #919 (partially anyway)

this patch applies a simplification factor of 0.5 to output geometries in dynamicMapLayer.bindPopup using the current scale of the map to ensure that no more vertices than necessary are retrieved from the server.

for the test case provided by the user, this reduced the payload from `213kb/600ms` to `922b/150ms` when zoomed out pretty far on a complex feature.

![screenshot 2017-01-31 12 21 28](https://cloud.githubusercontent.com/assets/3011734/22482895/d1a10eb8-e7af-11e6-8246-f8571d16241a.png)

i think this is a sensible default so that we can ensure in more cases that the map click interaction is snappy.