### PR TITLE
Add check for layer visibility when cellEnter is called.

### DIFF
--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -153,7 +153,7 @@ export var FeatureLayer = FeatureManager.extend({
   },
 
   cellEnter: function (bounds, coords) {
-    if (!this._zooming && this._map) {
+    if (this._visibleZoom() && !this._zooming && this._map) {
       L.Util.requestAnimFrame(L.Util.bind(function () {
         var cacheKey = this._cacheKey(coords);
         var cellKey = this._cellCoordsToKey(coords);


### PR DESCRIPTION
If you have a layer that is visible at say zoom 16 - 20 and then zoom out to 15 the layer will not be visible (as expected).  If you then pan out of the current virtual grid bounds and then pan back to your original position the layer becomes visible even though you are still at zoom 15.

This is fixed by checking for visibleZoom within cellEnter so features are only added to the map if in a visible zoom.