### PR TITLE
dont query outside FeatureLayer visible scale

### DIFF
--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -102,7 +102,10 @@ export var FeatureManager = VirtualGrid.extend({
    */
 
   createCell: function (bounds, coords) {
-    this._requestFeatures(bounds, coords);
+    // dont fetch features outside the scale range defined for the layer
+    if (this._visibleZoom()) {
+      this._requestFeatures(bounds, coords);
+    }
   },
 
   _requestFeatures: function (bounds, coords, callback) {


### PR DESCRIPTION
resolves #926 

implementing @keithpower's suggestion to make sure queries aren't fired outside a FeatureLayer's visible scale range.