### PR TITLE
allow override of 'isModern'

### DIFF
--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -18,7 +18,8 @@ export var FeatureManager = VirtualGrid.extend({
     timeField: false,
     timeFilterMode: 'server',
     simplifyFactor: 0,
-    precision: 6
+    precision: 6,
+    isModern: true
   },
 
   /**
@@ -70,8 +71,8 @@ export var FeatureManager = VirtualGrid.extend({
     this.service.metadata(function (err, metadata) {
       if (!err) {
         var supportedFormats = metadata.supportedQueryFormats;
-        // check to see whether service can emit GeoJSON natively
-        if (supportedFormats && supportedFormats.indexOf('geoJSON') !== -1) {
+        // Unless we've been told otherwise, check to see whether service can emit GeoJSON natively
+        if (this.service.options.isModern && supportedFormats && supportedFormats.indexOf('geoJSON') !== -1) {
           this.service.options.isModern = true;
         }
         // add copyright text listed in service metadata

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -73,7 +73,7 @@ export var FeatureManager = VirtualGrid.extend({
 
         // Check if someone has requested that we don't use geoJSON, even if it's available
         var forceJsonFormat = false;
-        if (typeof this.service.options.isModern !== 'undefined' && this.service.options.isModern === false) {
+        if (this.service.options.isModern === false) {
           forceJsonFormat = true;
         }
 

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -72,8 +72,10 @@ export var FeatureManager = VirtualGrid.extend({
       if (!err) {
         var supportedFormats = metadata.supportedQueryFormats;
         // Unless we've been told otherwise, check to see whether service can emit GeoJSON natively
-        if (this.service.options.isModern && supportedFormats && supportedFormats.indexOf('geoJSON') !== -1) {
-          this.service.options.isModern = true;
+        if (supportedFormats && supportedFormats.indexOf('geoJSON') !== -1) {
+          this.service.options.isModern = true && this.service.options.isModern;
+        } else {
+          this.service.options.isModern = false;
         }
         // add copyright text listed in service metadata
         if (!this.options.attribution && map.attributionControl && metadata.copyrightText) {

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -18,8 +18,7 @@ export var FeatureManager = VirtualGrid.extend({
     timeField: false,
     timeFilterMode: 'server',
     simplifyFactor: 0,
-    precision: 6,
-    isModern: true
+    precision: 6
   },
 
   /**
@@ -71,12 +70,18 @@ export var FeatureManager = VirtualGrid.extend({
     this.service.metadata(function (err, metadata) {
       if (!err) {
         var supportedFormats = metadata.supportedQueryFormats;
-        // Unless we've been told otherwise, check to see whether service can emit GeoJSON natively
-        if (supportedFormats && supportedFormats.indexOf('geoJSON') !== -1) {
-          this.service.options.isModern = true && this.service.options.isModern;
-        } else {
-          this.service.options.isModern = false;
+
+        // Check if someone has requested that we don't use geoJSON, even if it's available
+        var forceJsonFormat = false;
+        if (typeof this.service.options.isModern !== 'undefined' && this.service.options.isModern === false) {
+          forceJsonFormat = true;
         }
+
+        // Unless we've been told otherwise, check to see whether service can emit GeoJSON natively
+        if (!forceJsonFormat && supportedFormats && supportedFormats.indexOf('geoJSON') !== -1) {
+          this.service.options.isModern = true;
+        }
+
         // add copyright text listed in service metadata
         if (!this.options.attribution && map.attributionControl && metadata.copyrightText) {
           this.options.attribution = metadata.copyrightText;


### PR DESCRIPTION
Add an option to let users decide to not use geoJSON, even if the
underlying service supports it. Occasionally handy when ArcGIS Server
has geoJSON geometry problems.