### PR TITLE
eachActiveFeature() to return only layers currently in view

### DIFF
--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -243,6 +243,19 @@ export var FeatureLayer = FeatureManager.extend({
    * Utility Methods
    */
 
+  eachActiveFeature: function (fn, context) {
+    // figure out roughly which layers are in view
+    if (this._map) {
+      var activeBounds = this._map.getBounds();
+      for (var i in this._layers) {
+        if (activeBounds.intersects(this._layers[i].getBounds())) {
+          fn.call(context, this._layers[i]);
+        }
+      }
+    }
+    return this;
+  },
+
   eachFeature: function (fn, context) {
     for (var i in this._layers) {
       fn.call(context, this._layers[i]);

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -244,11 +244,11 @@ export var FeatureLayer = FeatureManager.extend({
    */
 
   eachActiveFeature: function (fn, context) {
-    // figure out roughly which layers are in view
+    // figure out (roughly) which layers are in view
     if (this._map) {
       var activeBounds = this._map.getBounds();
       for (var i in this._layers) {
-        if (activeBounds.intersects(this._layers[i].getBounds())) {
+        if (activeBounds.intersects(this._layers[i].getBounds()) && this._currentSnapshot.indexOf(this._layers[i].feature.id) !== -1) {
           fn.call(context, this._layers[i]);
         }
       }

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -148,7 +148,7 @@ export var FeatureManager = VirtualGrid.extend({
   },
 
   _postProcessFeatures: function (bounds) {
-    // deincriment the request counter now that we have processed features
+    // deincrement the request counter now that we have processed features
     this._activeRequests--;
 
     // if there are no more active requests fire a load event for this view
@@ -169,16 +169,15 @@ export var FeatureManager = VirtualGrid.extend({
 
     for (var i = features.length - 1; i >= 0; i--) {
       var id = features[i].id;
-      this._currentSnapshot.push(id);
+      if (!this._currentSnapshot[id]) {
+        this._currentSnapshot.push(id);
+      }
       this._cache[key].push(id);
     }
 
     if (this.options.timeField) {
       this._buildTimeIndexes(features);
     }
-
-    // need to PR removal of the logic below too...
-    // https://github.com/patrickarlt/leaflet-virtual-grid/blob/master/src/virtual-grid.js#L100-L102
 
     this.createLayers(features);
   },

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -169,10 +169,13 @@ export var FeatureManager = VirtualGrid.extend({
 
     for (var i = features.length - 1; i >= 0; i--) {
       var id = features[i].id;
-      if (!this._currentSnapshot[id]) {
+
+      if (this._currentSnapshot.indexOf(id) === -1) {
         this._currentSnapshot.push(id);
       }
-      this._cache[key].push(id);
+      if (this._cache[key].indexOf(id) === -1) {
+        this._cache[key].push(id);
+      }
     }
 
     if (this.options.timeField) {


### PR DESCRIPTION
resolves #933.

not only did `_currentSnapshot` not already isolate features currently in view, i found that it just was just growing in size as duplicate keys were appended throughout the browser session.

@keithpower i'd be curious to see how the approach i'm proposing here compares to your own technique if you can spare the time to take a look.