### PR TITLE
envelopeIntersects / indexIntersects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ Icon
 *.sublime-project
 .idea/*
 
+# Code
+.vscode/
+
 # SASS
 .sass-cache
 

--- a/spec/Tasks/QuerySpec.js
+++ b/spec/Tasks/QuerySpec.js
@@ -468,6 +468,18 @@ describe('L.esri.Query', function () {
     server.respond();
   });
 
+  it('should query features that have intersecting envelopes', function (done) {
+    server.respondWith('GET', featureLayerUrl + 'query?returnGeometry=true&where=1%3D1&outSr=4326&outFields=*&inSr=4326&geometry=%7B%22rings%22%3A%5B%5B%5B-97%2C39%5D%2C%5B-97%2C41%5D%2C%5B-94%2C41%5D%2C%5B-94%2C39%5D%2C%5B-97%2C39%5D%5D%5D%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryPolygon&spatialRel=esriSpatialRelEnvelopeIntersects&f=json', JSON.stringify(sampleQueryResponse));
+
+    task.bboxIntersects(geoJsonPolygon).run(function (error, featureCollection, raw) {
+      expect(featureCollection).to.deep.equal(sampleFeatureCollection);
+      expect(raw).to.deep.equal(sampleQueryResponse);
+      done();
+    });
+
+    server.respond();
+  });
+
   it('should query features with a where option', function (done) {
     server.respondWith('GET', featureLayerUrl + 'query?returnGeometry=true&where=NAME%3D\'Site\'&outSr=4326&outFields=*&f=json', JSON.stringify(sampleQueryResponse));
 

--- a/src/Tasks/Query.js
+++ b/src/Tasks/Query.js
@@ -30,43 +30,63 @@ export var Query = Task.extend({
     outFields: '*'
   },
 
+  // Returns a feature if its shape is wholly contained within the search geometry. Valid for all shape type combinations.
   within: function (geometry) {
     this._setGeometry(geometry);
-    this.params.spatialRel = 'esriSpatialRelContains'; // will make code read layer within geometry, to the api this will reads geometry contains layer
+    this.params.spatialRel = 'esriSpatialRelContains'; // to the REST api this reads geometry **contains** layer
     return this;
   },
 
+  // Returns a feature if any spatial relationship is found. Applies to all shape type combinations.
   intersects: function (geometry) {
     this._setGeometry(geometry);
     this.params.spatialRel = 'esriSpatialRelIntersects';
     return this;
   },
 
+  // Returns a feature if its shape wholly contains the search geometry. Valid for all shape type combinations.
   contains: function (geometry) {
     this._setGeometry(geometry);
-    this.params.spatialRel = 'esriSpatialRelWithin'; // will make code read layer contains geometry, to the api this will reads geometry within layer
+    this.params.spatialRel = 'esriSpatialRelWithin'; // to the REST api this reads geometry **within** layer
     return this;
   },
 
+  // Returns a feature if the intersection of the interiors of the two shapes is not empty and has a lower dimension than the maximum dimension of the two shapes. Two lines that share an endpoint in common do not cross. Valid for Line/Line, Line/Area, Multi-point/Area, and Multi-point/Line shape type combinations.
   crosses: function (geometry) {
     this._setGeometry(geometry);
     this.params.spatialRel = 'esriSpatialRelCrosses';
     return this;
   },
 
+  // Returns a feature if the two shapes share a common boundary. However, the intersection of the interiors of the two shapes must be empty. In the Point/Line case, the point may touch an endpoint only of the line. Applies to all combinations except Point/Point.
   touches: function (geometry) {
     this._setGeometry(geometry);
     this.params.spatialRel = 'esriSpatialRelTouches';
     return this;
   },
 
+  // Returns a feature if the intersection of the two shapes results in an object of the same dimension, but different from both of the shapes. Applies to Area/Area, Line/Line, and Multi-point/Multi-point shape type combinations.
   overlaps: function (geometry) {
     this._setGeometry(geometry);
     this.params.spatialRel = 'esriSpatialRelOverlaps';
     return this;
   },
 
-  // only valid for Feature Services running on ArcGIS Server 10.3 or ArcGIS Online
+  // Returns a feature if the envelope of the two shapes intersects.
+  bboxIntersects: function (geometry) {
+    this._setGeometry(geometry);
+    this.params.spatialRel = 'esriSpatialRelEnvelopeIntersects';
+    return this;
+  },
+
+  // if someone can help decipher the ArcObjects explanation and translate to plain speak, we should mention this method in the doc
+  indexIntersects: function (geometry) {
+    this._setGeometry(geometry);
+    this.params.spatialRel = 'esriSpatialRelIndexIntersects'; // Returns a feature if the envelope of the query geometry intersects the index entry for the target geometry
+    return this;
+  },
+
+  // only valid for Feature Services running on ArcGIS Server 10.3+ or ArcGIS Online
   nearby: function (latlng, radius) {
     latlng = latLng(latlng);
     this.params.geometry = [latlng.lng, latlng.lat];
@@ -105,7 +125,7 @@ export var Query = Task.extend({
   run: function (callback, context) {
     this._cleanParams();
 
-    // services hosted on ArcGIS Online also support requesting geojson directly
+    // services hosted on ArcGIS Online and ArcGIS Server 10.3.1+ support requesting geojson directly
     if (this.options.isModern || isArcgisOnline(this.options.url)) {
       this.params.f = 'geojson';
 


### PR DESCRIPTION
resolves #922 

it turns out both these operators have been around for a [long, long time](http://edndoc.esri.com/arcobjectsonline/componenthelp/esriCore/esriSpatialRelEnum.htm)...

> **esriSpatialRelEnvelopeIntersects** - Returns a feature if the envelope of the two shapes intersect~~s~~.

> **esriSpatialRelIndexIntersects** - Returns a feature if the envelope of the query geometry intersects the index entry for the target geometry.

i have a very foggy recollection of spatial index cells, but not enough to decipher the second operator explanation and translate it into language that would actually be useful to include in our doc. that means that for the time being its going to be an easter egg.