### PR TITLE
introduce support for geometry types other than points in IdentifyFeatures

### DIFF
--- a/spec/Layers/DynamicMapLayerSpec.js
+++ b/spec/Layers/DynamicMapLayerSpec.js
@@ -374,7 +374,8 @@ describe('L.esri.DynamicMapLayer', function () {
   });
 
   it('should bind a popup to the layer', function () {
-    server.respondWith('GET', new RegExp(/http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockMapService\/MapServer\/identify\?sr=4326&layers=visible&tolerance=3&returnGeometry=true&imageDisplay=500%2C500%2C96&mapExtent=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&geometry=-?\d+\.\d+%2C-?\d+\.\d+&geometryType=esriGeometryPoint&maxAllowableOffset=0.000171661376953125&f=json/), JSON.stringify(sampleResponse));
+    // to do: come up with a regexified geometry wildcard
+    server.respondWith('GET', new RegExp(/http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockMapService\/MapServer\/identify\?sr=4326&layers=visible&tolerance=3&returnGeometry=true&imageDisplay=500%2C500%2C96&mapExtent=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&geometry=.+&geometryType=esriGeometryPoint&maxAllowableOffset=0.000171661376953125&f=json/), JSON.stringify(sampleResponse));
 
     layer.bindPopup(function (error, featureCollection) {
       return featureCollection.features.length + ' Feature(s)';
@@ -395,7 +396,7 @@ describe('L.esri.DynamicMapLayer', function () {
   });
 
   it('should bind a popup to the layer if the layer is already on a map', function () {
-    server.respondWith('GET', new RegExp(/http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockMapService\/MapServer\/identify\?sr=4326&layers=visible&tolerance=3&returnGeometry=true&imageDisplay=500%2C500%2C96&mapExtent=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&geometry=-?\d+\.\d+%2C-?\d+\.\d+&geometryType=esriGeometryPoint&maxAllowableOffset=0.000171661376953125&f=json/), JSON.stringify(sampleResponse));
+    server.respondWith('GET', new RegExp(/http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockMapService\/MapServer\/identify\?sr=4326&layers=visible&tolerance=3&returnGeometry=true&imageDisplay=500%2C500%2C96&mapExtent=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&geometry=.+&geometryType=esriGeometryPoint&maxAllowableOffset=0.000171661376953125&f=json/), JSON.stringify(sampleResponse));
 
     layer.addTo(map);
 

--- a/spec/Layers/DynamicMapLayerSpec.js
+++ b/spec/Layers/DynamicMapLayerSpec.js
@@ -374,8 +374,11 @@ describe('L.esri.DynamicMapLayer', function () {
   });
 
   it('should bind a popup to the layer', function () {
-    // to do: come up with a regexified geometry wildcard
-    server.respondWith('GET', new RegExp(/http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockMapService\/MapServer\/identify\?sr=4326&layers=visible&tolerance=3&returnGeometry=true&imageDisplay=500%2C500%2C96&mapExtent=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&geometry=.+&geometryType=esriGeometryPoint&maxAllowableOffset=0.000171661376953125&f=json/), JSON.stringify(sampleResponse));
+    /* sample unencoded/encoded geometry parameters
+    {"x":-102.919921875,"y":36.66841891894786,"spatialReference":{"wkid":4326}}
+    %7B%22x%22%3A-102.919921875%2C%22y%22%3A36.66841891894786%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D
+    */
+    server.respondWith('GET', new RegExp(/http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockMapService\/MapServer\/identify\?sr=4326&layers=visible&tolerance=3&returnGeometry=true&imageDisplay=500%2C500%2C96&mapExtent=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&geometry=%7B%22x%22%3A-?\d+\.\d+%2C%22y%22%3A-?\d+\.\d+%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D+&geometryType=esriGeometryPoint&maxAllowableOffset=0.000171661376953125&f=json/), JSON.stringify(sampleResponse));
 
     layer.bindPopup(function (error, featureCollection) {
       return featureCollection.features.length + ' Feature(s)';

--- a/spec/Tasks/IdentifyFeaturesSpec.js
+++ b/spec/Tasks/IdentifyFeaturesSpec.js
@@ -90,7 +90,7 @@ describe('L.esri.IdentifyFeatures', function () {
     expect(request.url).to.contain('imageDisplay=500%2C500%2C96');
     expect(request.url).to.match(/mapExtent=-122\.\d+%2C45\.\d+%2C-122\.\d+%2C45\.\d+/g);
     expect(request.url).to.contain('geometryType=esriGeometryPoint');
-    expect(request.url).to.contain('geometry=-122.66%2C45.51');
+    expect(request.url).to.contain('geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D');
 
     request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });
@@ -209,7 +209,7 @@ describe('L.esri.IdentifyFeatures', function () {
     expect(request.url).to.contain('imageDisplay=500%2C500%2C96');
     expect(request.url).to.match(/mapExtent=-122\.\d+%2C45\.\d+%2C-122\.\d+%2C45\.\d+/g);
     expect(request.url).to.contain('geometryType=esriGeometryPoint');
-    expect(request.url).to.contain('geometry=-122.66%2C45.51');
+    expect(request.url).to.contain('geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D');
 
     request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });
@@ -231,7 +231,7 @@ describe('L.esri.IdentifyFeatures', function () {
     expect(request.url).to.contain('imageDisplay=500%2C500%2C96');
     expect(request.url).to.match(/mapExtent=-122\.\d+%2C45\.\d+%2C-122\.\d+%2C45\.\d+/g);
     expect(request.url).to.contain('geometryType=esriGeometryPoint');
-    expect(request.url).to.contain('geometry=-122.66%2C45.51');
+    expect(request.url).to.contain('geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D');
 
     request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });

--- a/src/Tasks/IdentifyFeatures.js
+++ b/src/Tasks/IdentifyFeatures.js
@@ -1,8 +1,8 @@
-import { Utils } from 'leaflet';
+import { latLng } from 'leaflet';
 import { Identify } from './Identify';
 import { responseToFeatureCollection,
   boundsToExtent,
-  setGeometry
+  _setGeometry
 } from '../Util';
 
 export var IdentifyFeatures = Identify.extend({
@@ -29,7 +29,11 @@ export var IdentifyFeatures = Identify.extend({
   },
 
   at: function (geometry) {
-    setGeometry(geometry);
+    // cast lat, long pairs in raw array form manually
+    if (geometry.length === 2) {
+      geometry = latLng(geometry);
+    }
+    this._setGeometryParams(geometry);
     return this;
   },
 
@@ -63,6 +67,12 @@ export var IdentifyFeatures = Identify.extend({
         callback.call(context, undefined, featureCollection, response);
       }
     });
+  },
+
+  _setGeometryParams: function (geometry) {
+    var converted = _setGeometry(geometry);
+    this.params.geometry = converted.geometry;
+    this.params.geometryType = converted.geometryType;
   }
 });
 

--- a/src/Tasks/IdentifyFeatures.js
+++ b/src/Tasks/IdentifyFeatures.js
@@ -1,6 +1,11 @@
-import { latLng } from 'leaflet';
+import { LatLngBounds, LatLng, GeoJSON } from 'leaflet';
 import { Identify } from './Identify';
-import { boundsToExtent, responseToFeatureCollection } from '../Util';
+import { warn,
+  responseToFeatureCollection,
+  boundsToExtent,
+  geojsonToArcGIS,
+  geojsonTypeToArcGIS 
+} from '../Util';
 
 export var IdentifyFeatures = Identify.extend({
   setters: {
@@ -25,10 +30,8 @@ export var IdentifyFeatures = Identify.extend({
     return this;
   },
 
-  at: function (latlng) {
-    latlng = latLng(latlng);
-    this.params.geometry = [latlng.lng, latlng.lat];
-    this.params.geometryType = 'esriGeometryPoint';
+  at: function (geometry) {
+    this._setGeometry(geometry);
     return this;
   },
 
@@ -62,6 +65,61 @@ export var IdentifyFeatures = Identify.extend({
         callback.call(context, undefined, featureCollection, response);
       }
     });
+  },
+  _setGeometry: function (geometry) {
+    this.params.inSr = 4326;
+
+    // convert bounds to extent and finish
+    if (geometry instanceof LatLngBounds) {
+      // set geometry + geometryType
+      this.params.geometry = boundsToExtent(geometry);
+      this.params.geometryType = 'esriGeometryEnvelope';
+      return;
+    }
+
+    // convert L.Marker > L.LatLng
+    if (geometry.getLatLng) {
+      geometry = geometry.getLatLng();
+    }
+
+    // convert L.LatLng to a geojson point and continue;
+    if (geometry instanceof LatLng) {
+      geometry = {
+        type: 'Point',
+        coordinates: [geometry.lng, geometry.lat]
+      };
+    }
+
+    // handle L.GeoJSON, pull out the first geometry
+    if (geometry instanceof GeoJSON) {
+      // reassign geometry to the GeoJSON value  (we are assuming that only one feature is present)
+      geometry = geometry.getLayers()[0].feature.geometry;
+      this.params.geometry = geojsonToArcGIS(geometry);
+      this.params.geometryType = geojsonTypeToArcGIS(geometry.type);
+    }
+
+    // Handle L.Polyline and L.Polygon
+    if (geometry.toGeoJSON) {
+      geometry = geometry.toGeoJSON();
+    }
+
+    // handle GeoJSON feature by pulling out the geometry
+    if (geometry.type === 'Feature') {
+      // get the geometry of the geojson feature
+      geometry = geometry.geometry;
+    }
+
+    // confirm that our GeoJSON is a point, line or polygon
+    if (geometry.type === 'Point' || geometry.type === 'LineString' || geometry.type === 'Polygon' || geometry.type === 'MultiPolygon') {
+      this.params.geometry = geojsonToArcGIS(geometry);
+      this.params.geometryType = geojsonTypeToArcGIS(geometry.type);
+      return;
+    }
+
+    // warn the user if we havn't found an appropriate object
+    warn('invalid geometry passed to spatial query. Should be L.LatLng, L.LatLngBounds, L.Marker or a GeoJSON Point, Line, Polygon or MultiPolygon object');
+
+    return;
   }
 });
 

--- a/src/Util.js
+++ b/src/Util.js
@@ -1,4 +1,4 @@
-import { latLng, latLngBounds, Util, DomUtil, LatLngBounds, LatLng, GeoJSON } from 'leaflet';
+import { latLng, latLngBounds, LatLng, LatLngBounds, Util, DomUtil, GeoJSON } from 'leaflet';
 import { jsonp } from './Request';
 import { options } from './Options';
 
@@ -190,15 +190,18 @@ export function setEsriAttribution (map) {
   }
 }
 
-export function setGeometry (geometry) {
-  this.params.inSr = 4326;
+export function _setGeometry (geometry) {
+  var params = {
+    geometry: null,
+    geometryType: null
+  };
 
   // convert bounds to extent and finish
   if (geometry instanceof LatLngBounds) {
     // set geometry + geometryType
-    this.params.geometry = boundsToExtent(geometry);
-    this.params.geometryType = 'esriGeometryEnvelope';
-    return;
+    params.geometry = boundsToExtent(geometry);
+    params.geometryType = 'esriGeometryEnvelope';
+    return params;
   }
 
   // convert L.Marker > L.LatLng
@@ -218,8 +221,8 @@ export function setGeometry (geometry) {
   if (geometry instanceof GeoJSON) {
     // reassign geometry to the GeoJSON value  (we are assuming that only one feature is present)
     geometry = geometry.getLayers()[0].feature.geometry;
-    this.params.geometry = geojsonToArcGIS(geometry);
-    this.params.geometryType = geojsonTypeToArcGIS(geometry.type);
+    params.geometry = geojsonToArcGIS(geometry);
+    params.geometryType = geojsonTypeToArcGIS(geometry.type);
   }
 
   // Handle L.Polyline and L.Polygon
@@ -235,9 +238,9 @@ export function setGeometry (geometry) {
 
   // confirm that our GeoJSON is a point, line or polygon
   if (geometry.type === 'Point' || geometry.type === 'LineString' || geometry.type === 'Polygon' || geometry.type === 'MultiPolygon') {
-    this.params.geometry = geojsonToArcGIS(geometry);
-    this.params.geometryType = geojsonTypeToArcGIS(geometry.type);
-    return;
+    params.geometry = geojsonToArcGIS(geometry);
+    params.geometryType = geojsonTypeToArcGIS(geometry.type);
+    return params;
   }
 
   // warn the user if we havn't found an appropriate object
@@ -324,7 +327,7 @@ export var EsriUtil = {
   extentToBounds: extentToBounds,
   calcAttributionWidth: calcAttributionWidth,
   setEsriAttribution: setEsriAttribution,
-  setGeometry: setGeometry,
+  _setGeometry: _setGeometry,
   _getAttributionData: _getAttributionData,
   _updateMapAttribution: _updateMapAttribution
 };

--- a/src/Util.js
+++ b/src/Util.js
@@ -1,4 +1,4 @@
-import { latLng, latLngBounds, Util, DomUtil } from 'leaflet';
+import { latLng, latLngBounds, Util, DomUtil, LatLngBounds, LatLng, GeoJSON } from 'leaflet';
 import { jsonp } from './Request';
 import { options } from './Options';
 
@@ -190,6 +190,62 @@ export function setEsriAttribution (map) {
   }
 }
 
+export function setGeometry (geometry) {
+  this.params.inSr = 4326;
+
+  // convert bounds to extent and finish
+  if (geometry instanceof LatLngBounds) {
+    // set geometry + geometryType
+    this.params.geometry = boundsToExtent(geometry);
+    this.params.geometryType = 'esriGeometryEnvelope';
+    return;
+  }
+
+  // convert L.Marker > L.LatLng
+  if (geometry.getLatLng) {
+    geometry = geometry.getLatLng();
+  }
+
+  // convert L.LatLng to a geojson point and continue;
+  if (geometry instanceof LatLng) {
+    geometry = {
+      type: 'Point',
+      coordinates: [geometry.lng, geometry.lat]
+    };
+  }
+
+  // handle L.GeoJSON, pull out the first geometry
+  if (geometry instanceof GeoJSON) {
+    // reassign geometry to the GeoJSON value  (we are assuming that only one feature is present)
+    geometry = geometry.getLayers()[0].feature.geometry;
+    this.params.geometry = geojsonToArcGIS(geometry);
+    this.params.geometryType = geojsonTypeToArcGIS(geometry.type);
+  }
+
+  // Handle L.Polyline and L.Polygon
+  if (geometry.toGeoJSON) {
+    geometry = geometry.toGeoJSON();
+  }
+
+  // handle GeoJSON feature by pulling out the geometry
+  if (geometry.type === 'Feature') {
+    // get the geometry of the geojson feature
+    geometry = geometry.geometry;
+  }
+
+  // confirm that our GeoJSON is a point, line or polygon
+  if (geometry.type === 'Point' || geometry.type === 'LineString' || geometry.type === 'Polygon' || geometry.type === 'MultiPolygon') {
+    this.params.geometry = geojsonToArcGIS(geometry);
+    this.params.geometryType = geojsonTypeToArcGIS(geometry.type);
+    return;
+  }
+
+  // warn the user if we havn't found an appropriate object
+  warn('invalid geometry passed to spatial query. Should be L.LatLng, L.LatLngBounds, L.Marker or a GeoJSON Point, Line, Polygon or MultiPolygon object');
+
+  return;
+}
+
 export function _getAttributionData (url, map) {
   jsonp(url, {}, Util.bind(function (error, attributions) {
     if (error) { return; }
@@ -268,6 +324,7 @@ export var EsriUtil = {
   extentToBounds: extentToBounds,
   calcAttributionWidth: calcAttributionWidth,
   setEsriAttribution: setEsriAttribution,
+  setGeometry: setGeometry,
   _getAttributionData: _getAttributionData,
   _updateMapAttribution: _updateMapAttribution
 };


### PR DESCRIPTION
supercedes #959, #960

to do:
- [x] add a few new unit tests in `IdentifyFeaturesSpec.js` for the new geometry types
- [x] do a little more manual testing to confirm nothing is broken
- [ ] update esri-leaflet-doc to let folks know about the new functionality (https://github.com/Esri/esri-leaflet-doc/issues/147)
- [x] bring back the regex in `DynamicMapLayerSpec.js` to simulate the more complicated geometry object syntax