### PR TITLE
add support for datum transformations

### DIFF
--- a/spec/Tasks/QuerySpec.js
+++ b/spec/Tasks/QuerySpec.js
@@ -716,6 +716,34 @@ describe('L.esri.Query', function () {
     server.respond();
   });
 
+  it('should pass through a simple datum transformation when making a query', function (done) {
+    server.respondWith('GET', mapServiceUrl + '0/query?returnGeometry=true&where=1%3D1&outSr=4326&outFields=*&datumTransformation=1234&f=json', JSON.stringify(sampleMapServiceQueryResponse));
+
+    var service = new L.esri.MapService({url: mapServiceUrl});
+
+    service.query().layer(0).transform(1234).run(function (error, featureCollection, raw) {
+      expect(featureCollection).to.deep.equal(sampleMapServiceCollection);
+      expect(raw).to.deep.equal(sampleMapServiceQueryResponse);
+      done();
+    });
+
+    server.respond();
+  });
+
+  it('should pass through a JSON datum transformation when making a query', function (done) {
+    server.respondWith('GET', mapServiceUrl + '0/query?returnGeometry=true&where=1%3D1&outSr=4326&outFields=*&datumTransformation=%7B%22wkid%22%3A1234%7D&f=json', JSON.stringify(sampleMapServiceQueryResponse));
+
+    var service = new L.esri.MapService({url: mapServiceUrl});
+
+    service.query().layer(0).transform({'wkid': 1234}).run(function (error, featureCollection, raw) {
+      expect(featureCollection).to.deep.equal(sampleMapServiceCollection);
+      expect(raw).to.deep.equal(sampleMapServiceQueryResponse);
+      done();
+    });
+
+    server.respond();
+  });
+
   it('should use a image service to query features', function (done) {
     server.respondWith('GET', imageServiceUrl + 'query?returnGeometry=true&where=1%3D1&outSr=4326&outFields=*&pixelSize=1%2C1&f=json', JSON.stringify(sampleImageServiceQueryResponse));
 

--- a/src/Tasks/Find.js
+++ b/src/Tasks/Find.js
@@ -17,6 +17,8 @@ export var Find = Task.extend({
     'returnZ': 'returnZ',
     'returnM': 'returnM',
     'gdbVersion': 'gdbVersion',
+    // skipped implementing this (for now) because the REST service implementation isnt consistent between operations
+    // 'transform': 'datumTransformations',
     'token': 'token'
   },
 

--- a/src/Tasks/IdentifyFeatures.js
+++ b/src/Tasks/IdentifyFeatures.js
@@ -10,6 +10,8 @@ export var IdentifyFeatures = Identify.extend({
     'layers': 'layers',
     'precision': 'geometryPrecision',
     'tolerance': 'tolerance',
+    // skipped implementing this (for now) because the REST service implementation isnt consistent between operations.
+    // 'transform': 'datumTransformations'
     'returnGeometry': 'returnGeometry'
   },
 

--- a/src/Tasks/Query.js
+++ b/src/Tasks/Query.js
@@ -16,6 +16,7 @@ export var Query = Task.extend({
     'precision': 'geometryPrecision',
     'featureIds': 'objectIds',
     'returnGeometry': 'returnGeometry',
+    'transform': 'datumTransformation',
     'token': 'token'
   },
 


### PR DESCRIPTION
this patch uses the shorthand 'transform' as both a setter and constructor option to allow developers to pass the argument through without internal manipulation to ArcGIS Server 10.5+ layers and tasks that support the parameter.

```js
// simple syntax
query.transform(15851);
```
```js
// JSON syntax
identifyFeatures.transform({"wkid" : 15851 });
```
```js
// Well-known text
dynamicMapLayer({
  url: modernService,
  transform: {"wkt" : "GEOGTRAN[\..."}
});
```
```js
// composite transformations
var fancy = {
  "geoTransforms": [
    {
      "wkid": "1241",
      "transformForward": false
    },
    {
      "wkid": "15851",
      "transformForward": true
    }
  ]
}
dynamicMapLayer.setTransform(fancy);
```
additional doc: http://resources.arcgis.com/en/help/arcgis-rest-api/index.html#/Project/02r3000000pv000000/

resolves #973