### PR TITLE
Fix content type for ImageMapLayer

### DIFF
--- a/src/Layers/ImageMapLayer.js
+++ b/src/Layers/ImageMapLayer.js
@@ -9,7 +9,7 @@ export var ImageMapLayer = RasterLayer.extend({
     updateInterval: 150,
     format: 'jpgpng',
     transparent: true,
-    f: 'json'
+    f: 'image'
   },
 
   query: function () {


### PR DESCRIPTION
The default server response content type per the [docs](http://esri.github.io/esri-leaflet/api-reference/layers/image-map-layer.html#options) for an `imageMapLayer` should be `image`, not `json`.