### PR TITLE
remove unused shallowClone function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,14 @@
 {
   "name": "esri-leaflet",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@esri/arcgis-to-geojson-utils": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-to-geojson-utils/-/arcgis-to-geojson-utils-1.0.4.tgz",
+      "integrity": "sha512-+8qR95frMscZNn2sK/1v8vmwgviu2JERAs9rNUNzsZpP2jZymKij1l13YA5qxo1wVsKJ/7k6dBT32tcw8+Ei+w=="
+    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -125,11 +130,6 @@
       "resolved": "https://registry.npmjs.org/application-config-path/-/application-config-path-0.1.0.tgz",
       "integrity": "sha1-GTxfCoZUGkxm+6Hi3DhYM2LqXo8=",
       "dev": true
-    },
-    "arcgis-to-geojson-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arcgis-to-geojson-utils/-/arcgis-to-geojson-utils-1.0.1.tgz",
-      "integrity": "sha1-4CyU00MEw7O3t4rhi+tZKIthVa0="
     },
     "argparse": {
       "version": "1.0.9",
@@ -3000,15 +3000,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3018,6 +3009,15 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -6582,15 +6582,6 @@
         "duplexer": "0.1.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -6611,6 +6602,15 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.7.0",
         "function-bind": "1.1.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "John Gravois <jgravois@esri.com> (http://johngravois.com)"
   ],
   "dependencies": {
-    "arcgis-to-geojson-utils": "^1.0.1",
+    "@esri/arcgis-to-geojson-utils": "^1.0.4",
     "leaflet-virtual-grid": "^1.0.3",
     "tiny-binary-search": "^1.0.2"
   },

--- a/spec/Tasks/IdentifyFeaturesSpec.js
+++ b/spec/Tasks/IdentifyFeaturesSpec.js
@@ -62,19 +62,21 @@ describe('L.esri.IdentifyFeatures', function () {
   // use 'objectid' instead of 'OBJECTID' to trap irregular casing
   var sampleFeatureCollection = {
     'type': 'FeatureCollection',
-    'features': [{
-      'type': 'Feature',
-      'geometry': {
-        'type': 'Point',
-        'coordinates': [-122.81, 45.48]
-      },
-      'properties': {
-        'objectid': 1,
-        'Name': 'Site'
-      },
-      'id': 1,
-      'layerId': 0
-    }]
+    'features': [
+      {
+        'type': 'Feature',
+        'geometry': {
+          'type': 'Point',
+          'coordinates': [-122.81, 45.48]
+        },
+        'properties': {
+          'objectid': 1,
+          'Name': 'Site'
+        },
+        'id': 1,
+        'layerId': 0
+      }
+    ]
   };
 
   beforeEach(function () {

--- a/src/Util.js
+++ b/src/Util.js
@@ -5,7 +5,7 @@ import { options } from './Options';
 import {
   geojsonToArcGIS as g2a,
   arcgisToGeoJSON as a2g
-} from 'arcgis-to-geojson-utils';
+} from '@esri/arcgis-to-geojson-utils';
 
 export function geojsonToArcGIS (geojson, idAttr) {
   return g2a(geojson, idAttr);

--- a/src/Util.js
+++ b/src/Util.js
@@ -15,18 +15,6 @@ export function arcgisToGeoJSON (arcgis, idAttr) {
   return a2g(arcgis, idAttr);
 }
 
-// shallow object clone for feature properties and attributes
-// from http://jsperf.com/cloning-an-object/2
-export function shallowClone (obj) {
-  var target = {};
-  for (var i in obj) {
-    if (obj.hasOwnProperty(i)) {
-      target[i] = obj[i];
-    }
-  }
-  return target;
-}
-
 // convert an extent (ArcGIS) to LatLngBounds (Leaflet)
 export function extentToBounds (extent) {
   // "NaN" coordinates from ArcGIS Server indicate a null geometry
@@ -338,7 +326,6 @@ export function _updateMapAttribution (evt) {
 }
 
 export var EsriUtil = {
-  shallowClone: shallowClone,
   warn: warn,
   cleanUrl: cleanUrl,
   isArcgisOnline: isArcgisOnline,


### PR DESCRIPTION
when we migrated to using [`@esri/arcgis-to-geojson-utils`](https://www.npmjs.com/package/@esri/arcgis-to-geojson-utils) as a dependency for converting ArcGIS JSON into GeoJSON we forgot to get rid of one of its internal methods.

🔴  > 🍏  👍
