### PR TITLE
make it possible to query for unique attribute values`

### DIFF
--- a/spec/Tasks/QuerySpec.js
+++ b/spec/Tasks/QuerySpec.js
@@ -744,9 +744,9 @@ describe('L.esri.Query', function () {
   });
 
   it('should query distinct', function (done) {
-    server.respondWith('GET', featureLayerUrl + 'query?returnGeometry=false&returnDistinctValues=true&where=1%3D1&outSr=4326&outFields=*&f=json', JSON.stringify(sampleDistinctFeatureCollection));
+    server.respondWith('GET', featureLayerUrl + 'query?returnGeometry=false&where=1%3D1&outSr=4326&outFields=*&returnDistinctValues=true&f=json', JSON.stringify(sampleDistinctQueryResponse));
 
-    var request = task.distinct(function (error, featureCollection, raw) {
+    var request = task.distinct(true).run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleDistinctFeatureCollection);
       expect(raw).to.deep.equal(sampleDistinctQueryResponse);
       done();

--- a/spec/Tasks/QuerySpec.js
+++ b/spec/Tasks/QuerySpec.js
@@ -223,9 +223,51 @@ describe('L.esri.Query', function () {
     }]
   };
 
+  var sampleDistinctFeatureCollection = {
+    'type': 'FeatureCollection',
+    'features': [{
+      'type': 'Feature',
+      'geometry': null,
+      'properties': {
+        'FID': 1,
+        'Name': 'Site'
+      },
+      'id': 1
+    }]
+  };
+
   var sampleIdsResponse = {
     'objectIdFieldName': 'FID',
     'objectIds': [1, 2]
+  };
+
+  var sampleDistinctQueryResponse = {
+    'objectIdFieldName': 'FID',
+    'fields': [{
+      'name': 'stop_desc',
+      'type': 'esriFieldTypeString',
+      'alias': 'stop_desc',
+      'sqlType': 'sqlTypeNVarchar',
+      'length': 256,
+      'domain': null,
+      'defaultValue': null
+    }, {
+      'name': 'FID',
+      'type': 'esriFieldTypeInteger',
+      'alias': 'FID',
+      'sqlType': 'sqlTypeInteger',
+      'domain': null,
+      'defaultValue': null
+    }],
+    'features': [
+      {
+        'attributes': {
+          'FID': 1,
+          'Name': 'Site'
+        },
+        'geometry': null
+      }
+    ]
   };
 
   beforeEach(function () {
@@ -693,6 +735,20 @@ describe('L.esri.Query', function () {
     var request = task.ids(function (error, ids, raw) {
       expect(ids).to.deep.equal([1, 2]);
       expect(raw).to.deep.equal(sampleIdsResponse);
+      done();
+    });
+
+    expect(request).to.be.an.instanceof(XMLHttpRequest);
+
+    server.respond();
+  });
+
+  it('should query distinct', function (done) {
+    server.respondWith('GET', featureLayerUrl + 'query?returnGeometry=false&returnDistinctValues=true&where=1%3D1&outSr=4326&outFields=*&f=json', JSON.stringify(sampleDistinctFeatureCollection));
+
+    var request = task.distinct(function (error, featureCollection, raw) {
+      expect(featureCollection).to.deep.equal(sampleDistinctFeatureCollection);
+      expect(raw).to.deep.equal(sampleDistinctQueryResponse);
       done();
     });
 

--- a/src/Tasks/Query.js
+++ b/src/Tasks/Query.js
@@ -175,6 +175,16 @@ export var Query = Task.extend({
     }, context);
   },
 
+  // geometry must be omitted for queries requesting distinct values
+  distinct: function (callback, context) {
+    this._cleanParams();
+    this.params.returnGeometry = false;
+    this.params.returnDistinctValues = true;
+    return this.request(function (error, response) {
+      callback.call(this, error, (response), response);
+    }, context);
+  },
+
   // only valid for image services
   pixelSize: function (rawPoint) {
     var castPoint = point(rawPoint);

--- a/src/Tasks/Query.js
+++ b/src/Tasks/Query.js
@@ -175,14 +175,11 @@ export var Query = Task.extend({
     }, context);
   },
 
-  // geometry must be omitted for queries requesting distinct values
-  distinct: function (callback, context) {
-    this._cleanParams();
+  distinct: function () {
+    // geometry must be omitted for queries requesting distinct values
     this.params.returnGeometry = false;
     this.params.returnDistinctValues = true;
-    return this.request(function (error, response) {
-      callback.call(this, error, (response), response);
-    }, context);
+    return this;
   },
 
   // only valid for image services


### PR DESCRIPTION
resolves #1026, supercedes #1027 

made a few small tweaks on top of @joelondon's work to get tests passing and ensure that calling `distinct()` doesn't trigger a request to the server all on its own.