### PR TITLE
dont remap custom web mercator LODs

### DIFF
--- a/src/Layers/TiledMapLayer.js
+++ b/src/Layers/TiledMapLayer.js
@@ -118,7 +118,7 @@ export var TiledMapLayer = TileLayer.extend({
             this.options.attribution = metadata.copyrightText;
             map.attributionControl.addAttribution(this.getAttribution());
           }
-          if (map.options.crs === L.CRS.EPSG3857 && sr === 102100 || sr === 3857) {
+          if (map.options.crs === L.CRS.EPSG3857 && (sr === 102100 || sr === 3857)) {
             this._lodMap = {};
             // create the zoom level data
             var arcgisLODs = metadata.tileInfo.lods;


### PR DESCRIPTION
STR:
right now we are inappropriately blowing away custom LODs when we encounter a `wkid:3857` tile cache with a modified `origin`.

```js
var crs = new L.Proj.CRS("EPSG:3857","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs", {
  origin: [-20037700, 30241100], // custom 
  resolutions: [
    611.4962262813797, // only a subset
    305.74811314055756,
    152.87405657041106,
    76.43702828507324,
    38.21851414253662 
  ]
});

var map = L.map('map', {
  crs: crs
}).setView([32.2217, -110.926], 2);

// The min/maxZoom values provided should match the actual cache thats been published. This information can be retrieved from the service endpoint directly.
L.esri.tiledMapLayer({
  url: 'https://maps2.tucsonaz.gov/arcgis/rest/services/BaseMaps/gisBaseMap_Topo/MapServer',
  useCors: false
}).addTo(map);
```
the service above probably  _should_ have been published using a custom projection (or better yet, the default), but we still can and should correct the logic in our conditional block so that we don't massage LODs when they are passed through in code.

ref: https://community.esri.com/message/739516-leaflet-basemap-issue
  