### PR TITLE
make check for custom CRS smarterer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,9 @@ cache:
     - node_modules
 before_script:
   - npm prune
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
+script:
+  - npm run test:ci
 before_install:
   - npm i -g npm@latest
-  - google-chrome-stable --headless --disable-gpu
 addons:
   chrome: stable

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -69,7 +69,7 @@ module.exports = function (config) {
 
     customLaunchers: {
       Chrome_travis_ci: {
-        base: 'Chrome',
+        base: 'ChromeHeadless',
         flags: ['--no-sandbox']
       }
     },

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "start-watch": "watch \"npm run build\" src",
     "start": "run-p start-watch serve",
     "serve": "http-server -p 5000 -c-1 -o",
-    "test": "npm run lint && karma start"
+    "test": "npm run lint && karma start",
+    "test:ci": "npm run lint && karma start --browsers Chrome_travis_ci"
   },
   "semistandard": {
     "globals": [


### PR DESCRIPTION
resolves #1019 

took a look at this today and realized that the problem @theashyster reported also causes an unnecessary console error _outside_ of webpack when a simple WGS84 tile service is added to a map.

```js
var map = L.map('map',{crs: L.CRS.EPSG4326}).setView([45,-125], 3);

L.esri.tiledMapLayer({
  url: 'http://services.arcgisonline.com/arcgis/rest/services/ESRI_Imagery_World_2D/MapServer'
}).addTo(map);
```
instead of checking to see whether a) the map and tiled service are both web mercator and b) if `proj4` is available we can instrospect the CRS defined for the map and make sure the supplied code is the same one the service is using.