### PR TITLE
use dynamic attribution for World Imagery

### DIFF
--- a/src/Layers/BasemapLayer.js
+++ b/src/Layers/BasemapLayer.js
@@ -104,7 +104,8 @@ export var BasemapLayer = TileLayer.extend({
           minZoom: 1,
           maxZoom: 19,
           subdomains: ['server', 'services'],
-          attribution: 'DigitalGlobe, GeoEye, i-cubed, USDA, USGS, AEX, Getmapping, Aerogrid, IGN, IGP, swisstopo, and the GIS User Community'
+          attribution: 'DigitalGlobe, GeoEye, i-cubed, USDA, USGS, AEX, Getmapping, Aerogrid, IGN, IGP, swisstopo, and the GIS User Community',
+          attributionUrl: 'https://static.arcgis.com/attribution/World_Imagery'
         }
       },
       ImageryLabels: {


### PR DESCRIPTION
i did a little snooping today and realized that we're now hosting a service to fetch metadata about imagery providers. very cool!

this will ensure that we credit lots more individual contributors to our [Community Maps](https://communitymaps.arcgis.com/newhome/index.html) program in isolated regions and keep the attribution control less cluttered at smaller scales.

![screenshot 2018-02-10 14 29 18](https://user-images.githubusercontent.com/3011734/36067299-204712ce-0e6f-11e8-88ca-7f45c1c094ae.png)

![screenshot 2018-02-10 14 30 03](https://user-images.githubusercontent.com/3011734/36067300-21aad5ba-0e6f-11e8-8bb1-4d0ec74fb973.png)
