### PR TITLE
Convert to date on arcgis to geojson

### DIFF
--- a/spec/Layers/FeatureLayer/FeatureManagerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureManagerSpec.js
@@ -257,7 +257,7 @@ describe('L.esri.FeatureManager', function () {
           'OBJECTID': 2,
           'Name': 'Site 2',
           'Type': 'Inactive',
-          'Time': new Date('January 15 2014 GMT-0800').valueOf()
+          'Time': new Date('January 15 2014 GMT-0800')
         },
         'id': 2
       }
@@ -293,7 +293,7 @@ describe('L.esri.FeatureManager', function () {
           'OBJECTID': 2,
           'Name': 'Site 2',
           'Type': 'Inactive',
-          'Time': new Date('January 15 2014 GMT-0800').valueOf()
+          'Time': new Date('January 15 2014 GMT-0800')
         },
         'id': 2
       },
@@ -307,7 +307,7 @@ describe('L.esri.FeatureManager', function () {
           'OBJECTID': 1,
           'Name': 'Site 1',
           'Type': 'Active',
-          'Time': new Date('January 1 2014 GMT-0800').valueOf()
+          'Time': new Date('January 1 2014 GMT-0800')
         },
         'id': 1
       }
@@ -377,7 +377,7 @@ describe('L.esri.FeatureManager', function () {
         'OBJECTID': 1,
         'Name': 'Site 1',
         'Type': 'Active',
-        'Time': new Date('January 1 2014 GMT-0800').valueOf()
+        'Time': new Date('January 1 2014 GMT-0800')
       },
       'id': 1
     }]);
@@ -404,7 +404,7 @@ describe('L.esri.FeatureManager', function () {
         'OBJECTID': 2,
         'Name': 'Site 2',
         'Type': 'Inactive',
-        'Time': new Date('January 15 2014 GMT-0800').valueOf()
+        'Time': new Date('January 15 2014 GMT-0800')
       },
       'id': 2
     }]);
@@ -535,7 +535,7 @@ describe('L.esri.FeatureManager', function () {
         'OBJECTID': 1,
         'Name': 'Site 1',
         'Type': 'Active',
-        'Time': new Date('January 1 2014 GMT-0800').valueOf()
+        'Time': new Date('January 1 2014 GMT-0800')
       },
       'id': 1
     }]);
@@ -558,7 +558,7 @@ describe('L.esri.FeatureManager', function () {
         'OBJECTID': 2,
         'Name': 'Site 2',
         'Type': 'Inactive',
-        'Time': new Date('January 15 2014 GMT-0800').valueOf()
+        'Time': new Date('January 15 2014 GMT-0800')
       },
       'id': 2
     }]);

--- a/spec/UtilSpec.js
+++ b/spec/UtilSpec.js
@@ -135,4 +135,46 @@ describe('L.esri.Util', function () {
       });
     }
   });
+
+  describe('responseToFeatureCollection', function () {
+    it('should convert date fields to javascript dates', function () {
+      var data = {
+        'geometryType': 'esriGeometryPoint',
+        'fields': [
+          {
+            'name': 'oid',
+            'type': 'esriFieldTypeInteger',
+            'alias': 'oid'
+          }, {
+            'name': 'striketime',
+            'type': 'esriFieldTypeDate',
+            'alias': 'striketime',
+            'length': 16
+          }, {
+            'name': 'latitude',
+            'type': 'esriFieldTypeSingle',
+            'alias': 'latitude'
+          }],
+        'features': [
+          {
+            'attributes': {
+              'oid': 39734967,
+              'striketime': 1518434809000,
+              'latitude': 1.30747
+            },
+            'geometry': {
+              'x': 3.860490083694458,
+              'y': 1.3074699640274048
+            }
+          }
+        ]
+      };
+
+      var result = L.esri.Util.responseToFeatureCollection(data, 'oid');
+      console.log(JSON.stringify(result));
+
+      expect(result.features.length).to.equal(1);
+      expect(result.features[0].properties['striketime'] instanceof Date).to.equal(true);
+    });
+  });
 });

--- a/src/Util.js
+++ b/src/Util.js
@@ -99,11 +99,44 @@ export function responseToFeatureCollection (response, idAttribute) {
   if (count) {
     for (var i = features.length - 1; i >= 0; i--) {
       var feature = arcgisToGeoJSON(features[i], objectIdField || _findIdAttributeFromFeature(features[i]));
+      convertTimeFields(response, feature);
       featureCollection.features.push(feature);
     }
   }
 
   return featureCollection;
+}
+
+// Converts time based fields into Date objects, this could be done in the arcgisToGeoJson function
+function convertTimeFields (response, feature) {
+  if (response.fields) {
+    for (var property in feature.properties) {
+      var fieldType = getFieldType(property, response.fields);
+      if (fieldType === 'esriFieldTypeDate') {
+        var value = feature.properties[property];
+        if (value !== undefined) {
+          feature.properties[property] = new Date(value);
+        }
+      }
+    }
+  }
+}
+
+// extract field type for a geoJSON property
+function getFieldType (fieldName, fields) {
+  fields = fields || {};
+  var result;
+
+  for (var i = 0; i < fields.length; i++) {
+    var property = fields[i].name;
+
+    if (fieldName === property) {
+      result = fields[i].type;
+      break;
+    }
+  }
+
+  return result;
 }
 
   // trim url whitespace and add a trailing slash if needed


### PR DESCRIPTION
Please find attached pull request which changes the current esri-geojson functionality.

At present date fields from arcgis-server are not converted to something representing a date in the geojson (often iso8601) which is used for Feature layers. Date fields are just time since epoch and there is currently no way to get the esri field type once the conversion from esri > geojson has been done. 

This pull request changes current functionality to convert dates to javascript dates in the geo-json for features, this may or may not be the correct approach.

It is enougth to meet my requirements but may break may or may not break the filtering dates on clientside related stuff in featuremanager (I am not using this functionality), i feel that this may need a bunch of tests around both if fields are specified and not in data from arcgis-server to see what happens here.

another solution may be to append the fields property to each geojson feature and then use this to convert date fields to required type in my own code, 










