### PR TITLE
update all tests with fetch-mock library -wip

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,6 +14,7 @@ module.exports = function (config) {
     // list of files / patterns to load in the browser
     // not sure why tests are failing when files are loaded in bulk
     files: [
+      'node_modules/fetch-mock/es5/client-bundle.js',
       'node_modules/leaflet/dist/leaflet.css',
       'node_modules/leaflet/dist/leaflet-src.js',
       'dist/esri-leaflet-debug.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,17 +5,17 @@
   "requires": true,
   "dependencies": {
     "@esri/arcgis-rest-request": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-1.0.2.tgz",
-      "integrity": "sha512-P44FP5Tf6GAOzN+H3UjuSwBJRwux4JxoiEc6BIvDnI2hTO0REl/ie89MESilR74Gv+9PlPEuAuF+ojEKGg0q2g==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-1.1.1.tgz",
+      "integrity": "sha1-euh2kB9t5Dq9xx79jFiUqZbiCWc=",
       "requires": {
         "tslib": "1.9.0"
       }
     },
     "@esri/arcgis-to-geojson-utils": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-to-geojson-utils/-/arcgis-to-geojson-utils-1.0.5.tgz",
-      "integrity": "sha512-vG4Ih7WyRuwWSuu6HzjDgj8lnVQ0IZK2JjF1bn+HpdNHc1KN/WLsLjGu7A/hdsShVsiWTPdKVa0mDYVrUOXbhw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-to-geojson-utils/-/arcgis-to-geojson-utils-1.1.0.tgz",
+      "integrity": "sha512-PG8PtPcMuHcZn+YoPYuw6R6I+9XYuNmW56pQmq+1mdHvBrYws9eHEXoQDKao6pwUqsseZxiFTAiSTR144wsZ8w=="
     },
     "abbrev": {
       "version": "1.0.9",
@@ -1946,6 +1946,19 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+<<<<<<< HEAD
+    "fetch-mock": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-6.0.1.tgz",
+      "integrity": "sha512-KhDT75LHyyd+a3kVQprxl9PIcD8DAMVTbW+1QgnsBpX/cxwY/qv56+vc4Zx35qTxFBH+WoqoMcsrKnSMfPcqBg==",
+      "dev": true,
+      "requires": {
+        "glob-to-regexp": "0.3.0",
+        "path-to-regexp": "2.1.0"
+      }
+    },
+=======
+>>>>>>> 51940752bd3feee6ad53eb146d9cc2ae030d77d6
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -3135,6 +3148,12 @@
       "requires": {
         "is-glob": "2.0.1"
       }
+    },
+    "glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "dev": true
     },
     "globals": {
       "version": "9.18.0",
@@ -5076,6 +5095,12 @@
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.1.0.tgz",
+      "integrity": "sha512-dZY7QPCPp5r9cnNuQ955mOv4ZFVDXY/yvqeV7Y1W2PJA3PEFcuow9xKFfJxbBj1pIjOAP+M2B4/7xubmykLrXw==",
+      "dev": true
+    },
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
@@ -5624,9 +5649,15 @@
       }
     },
     "rollup": {
+<<<<<<< HEAD
+      "version": "0.56.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.56.4.tgz",
+      "integrity": "sha512-Ja1ph+tZSE9sY5/WURJCuhaU2+2LTKKmhvxG7Smunn37s7aESLDFUj5XMnSYMypytwxeTvpy8ZzFfEeFiYMyug==",
+=======
       "version": "0.56.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.56.0.tgz",
       "integrity": "sha512-/VSCYZl0Tn4f7e+Jlwzmx9cEMrDcQbHTHowPVnunzhmLW0fisG1LYovuR2sSVGOO5/+Esb1KUzJlyS4n1HcOsA==",
+>>>>>>> 51940752bd3feee6ad53eb146d9cc2ae030d77d6
       "dev": true
     },
     "rollup-plugin-json": {

--- a/package.json
+++ b/package.json
@@ -12,13 +12,14 @@
     "John Gravois <jgravois@esri.com> (http://johngravois.com)"
   ],
   "dependencies": {
-    "@esri/arcgis-rest-request": "^1.0.2",
-    "@esri/arcgis-to-geojson-utils": "^1.0.5",
+    "@esri/arcgis-rest-request": "^1.1.1",
+    "@esri/arcgis-to-geojson-utils": "^1.1.0",
     "leaflet-virtual-grid": "^1.0.5",
     "tiny-binary-search": "^1.0.2"
   },
   "devDependencies": {
     "chai": "3.5.0",
+    "fetch-mock": "^6.0.1",
     "gh-release": "^2.0.0",
     "highlight.js": "^8.0.0",
     "http-server": "^0.10.0",
@@ -35,7 +36,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^3.4.2",
     "npm-run-all": "^4.0.2",
-    "rollup": "^0.56.0",
+    "rollup": "^0.56.4",
     "rollup-plugin-json": "^2.3.0",
     "rollup-plugin-node-resolve": "^3.0.3",
     "rollup-plugin-uglify": "^3.0.0",
@@ -84,6 +85,7 @@
     "start": "run-p start-watch serve",
     "serve": "http-server -p 5000 -c-1 -o",
     "test": "npm run lint && karma start",
+    "test-watch": "karma start --browsers=Chrome --single-run=false --auto-watch",
     "test:ci": "npm run lint && karma start --browsers Chrome_travis_ci"
   },
   "semistandard": {
@@ -92,6 +94,7 @@
       "L",
       "XMLHttpRequest",
       "sinon",
+      "fetchMock",
       "xhr",
       "proj4"
     ]

--- a/spec/Layers/BasemapLayerSpec.js
+++ b/spec/Layers/BasemapLayerSpec.js
@@ -14,7 +14,6 @@ describe('L.esri.BasemapLayer', function () {
   }
 
   var map;
-  var server;
   var clock;
   var mockAttributions = {
     'contributors': [
@@ -45,14 +44,15 @@ describe('L.esri.BasemapLayer', function () {
 
   beforeEach(function () {
     clock = sinon.useFakeTimers();
-    server = sinon.fakeServer.create();
-    server.respondWith('GET', new RegExp(/.*/), JSON.stringify(mockAttributions));
+    fetchMock.config.overwriteRoutes = true;
+    fetchMock.config.fallbackToNetwork = true;
+    fetchMock.get(new RegExp(/.*/), JSON.stringify(mockAttributions));
     map = createMap();
   });
 
   afterEach(function () {
     clock.restore();
-    server.restore();
+    fetchMock.restore();
     map.remove();
   });
 

--- a/spec/Tasks/FindSpec.js
+++ b/spec/Tasks/FindSpec.js
@@ -1,7 +1,6 @@
 /* eslint-env mocha */
 /* eslint-disable handle-callback-err */
 describe('L.esri.Find', function () {
-  var server;
   var task;
 
   // create map
@@ -99,114 +98,117 @@ describe('L.esri.Find', function () {
   };
 
   beforeEach(function () {
-    server = sinon.fakeServer.create();
     task = L.esri.find({url: mapServiceUrl});
   });
 
   afterEach(function () {
-    server.restore();
+    fetchMock.restore();
   });
 
   it('should find features with provided layer id and search text', function (done) {
-    server.respondWith('GET', mapServiceUrl + 'find?sr=4326&contains=true&returnGeometry=true&returnZ=true&returnM=false&layers=0&searchText=Site&f=json', JSON.stringify(sampleResponse));
-
-    var request = task.layers('0').text('Site').run(function (error, featureCollection, raw) {
+    fetchMock.getOnce(
+      mapServiceUrl + 'find?f=json&sr=4326&contains=true&returnGeometry=true&returnZ=true&returnM=false&layers=0&searchText=Site',
+      JSON.stringify(sampleResponse)
+    );
+    task.layers('0').text('Site').run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
-    });
-
-    expect(request).to.be.an.instanceof(XMLHttpRequest);
-
-    server.respond();
+    }, this);
+    // Test for Promise ?
+    // expect(this.request).to.be.an.instanceof(XMLHttpRequest);
   });
 
   it('should find features by specified search field', function (done) {
-    server.respondWith('GET', mapServiceUrl + 'find?sr=4326&contains=true&returnGeometry=true&returnZ=true&returnM=false&layers=0&searchText=Site&searchFields=Field&f=json', JSON.stringify(sampleResponseWithSearchFields));
+    fetchMock.getOnce(
+      mapServiceUrl + 'find?f=json&sr=4326&contains=true&returnGeometry=true&returnZ=true&returnM=false&layers=0&searchText=Site&searchFields=Field',
+      JSON.stringify(sampleResponseWithSearchFields)
+    );
 
     task.layers('0').text('Site').fields('Field').run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponseWithSearchFields);
       done();
     });
-
-    server.respond();
   });
 
   it('should find an exact match for the search text', function (done) {
-    server.respondWith('GET', mapServiceUrl + 'find?sr=4326&contains=false&returnGeometry=true&returnZ=true&returnM=false&layers=0&searchText=Site&f=json', JSON.stringify(sampleResponse));
+    fetchMock.getOnce(
+      mapServiceUrl + 'find?f=json&sr=4326&contains=false&returnGeometry=true&returnZ=true&returnM=false&layers=0&searchText=Site',
+      JSON.stringify(sampleResponse)
+    );
 
     task.layers('0').text('Site').contains(false).run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    server.respond();
   });
 
   it('should fetch unformatted results from 10.5+', function (done) {
-    server.respondWith('GET', mapServiceUrl + 'find?sr=4326&contains=true&returnGeometry=true&returnZ=true&returnM=false&layers=0&searchText=Site&returnUnformattedValues=true&f=json', JSON.stringify(sampleResponse));
+    fetchMock.getOnce(
+      mapServiceUrl + 'find?f=json&sr=4326&contains=true&returnGeometry=true&returnZ=true&returnM=false&layers=0&searchText=Site&returnUnformattedValues=true',
+      JSON.stringify(sampleResponse)
+    );
 
     task.layers('0').text('Site').format(false).run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    server.respond();
   });
 
   it('should find features and limit geometries to a given precision', function (done) {
-    server.respondWith('GET', mapServiceUrl + 'find?sr=4326&contains=true&returnGeometry=true&returnZ=true&returnM=false&layers=0&searchText=Site&geometryPrecision=4&f=json', JSON.stringify(sampleResponse));
+    fetchMock.getOnce(
+      mapServiceUrl + 'find?f=json&sr=4326&contains=true&returnGeometry=true&returnZ=true&returnM=false&layers=0&searchText=Site&geometryPrecision=4',
+      JSON.stringify(sampleResponse)
+    );
 
     task.layers('0').text('Site').precision(4).run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    server.respond();
   });
 
   it('should find features without geometry', function (done) {
-    server.respondWith('GET', mapServiceUrl + 'find?sr=4326&contains=true&returnGeometry=false&returnZ=true&returnM=false&layers=0&searchText=Site&f=json', JSON.stringify(sampleResponseWithoutGeometry));
-
+    fetchMock.getOnce(
+      mapServiceUrl + 'find?f=json&sr=4326&contains=true&returnGeometry=false&returnZ=true&returnM=false&layers=0&searchText=Site',
+      JSON.stringify(sampleResponseWithoutGeometry)
+    );
     task.layers('0').text('Site').returnGeometry(false).run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollectionWithoutGeometry);
       expect(raw).to.deep.equal(sampleResponseWithoutGeometry);
       done();
     });
-
-    server.respond();
   });
 
   it('should identify features with a token', function (done) {
-    server.respondWith('GET', mapServiceUrl + 'find?sr=4326&contains=true&returnGeometry=true&returnZ=true&returnM=false&layers=0&searchText=Site&token=foo&f=json', JSON.stringify(sampleResponse));
-
+    fetchMock.getOnce(
+      mapServiceUrl + 'find?f=json&sr=4326&contains=true&returnGeometry=true&returnZ=true&returnM=false&layers=0&searchText=Site&token=foo',
+      JSON.stringify(sampleResponse)
+    );
     task.layers('0').text('Site').token('foo').run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    server.respond();
   });
 
   it('should use a service to execute the find task', function (done) {
     var service = L.esri.mapService({url: mapServiceUrl});
 
-    server.respondWith('GET', mapServiceUrl + 'find?sr=4326&contains=true&returnGeometry=true&returnZ=true&returnM=false&layers=0&searchText=Site&f=json', JSON.stringify(sampleResponse));
-
-    var request = service.find().layers('0').text('Site').run(function (error, featureCollection, raw) {
+    fetchMock.getOnce(
+      mapServiceUrl + 'find?f=json&sr=4326&contains=true&returnGeometry=true&returnZ=true&returnM=false&layers=0&searchText=Site',
+      JSON.stringify(sampleResponse)
+    );
+    service.find().layers('0').text('Site').run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    expect(request).to.be.an.instanceof(XMLHttpRequest);
-
-    server.respond();
+    // Test for Promise ?
+    // expect(request).to.be.an.instanceof(XMLHttpRequest);
   });
 
   it('should use JSONP to execute without a service', function (done) {
@@ -232,19 +234,17 @@ describe('L.esri.Find', function () {
       }
     });
 
-    server.respondWith('GET', mapServiceUrl + 'find?sr=4326&contains=true&returnGeometry=true&returnZ=true&returnM=false&layers=0&searchText=Site&foo=bar&f=json', JSON.stringify(sampleResponse));
-
-    var request = myTask.layers('0').text('Site').run(function (error, featureCollection, raw) {
+    fetchMock.getOnce(
+      mapServiceUrl + 'find?f=json&sr=4326&contains=true&returnGeometry=true&returnZ=true&returnM=false&layers=0&searchText=Site&foo=bar',
+      JSON.stringify(sampleResponse)
+    );
+    myTask.layers('0').text('Site').run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    console.log(request.url);
-
-    expect(request).to.be.an.instanceof(XMLHttpRequest);
-
-    server.respond();
+    // Test for Promise ?
+    // expect(request).to.be.an.instanceof(XMLHttpRequest);
   });
 });
 /* eslint-enable handle-callback-err */

--- a/spec/Tasks/IdentifyFeaturesSpec.js
+++ b/spec/Tasks/IdentifyFeaturesSpec.js
@@ -13,8 +13,6 @@ describe('L.esri.IdentifyFeatures', function () {
 
     return L.map(container).setView([45.51, -122.66], 16);
   }
-
-  var server;
   var task;
 
   // create map
@@ -80,245 +78,262 @@ describe('L.esri.IdentifyFeatures', function () {
   };
 
   beforeEach(function () {
-    server = sinon.fakeServer.create();
+    fetchMock.config.warnOnFallback = false;
     task = L.esri.identifyFeatures({url: mapServiceUrl}).on(map).at(latlng);
   });
 
   afterEach(function () {
-    server.restore();
+    fetchMock.restore();
   });
 
   it('should identify features', function (done) {
-    var request = task.run(function (error, featureCollection, raw) {
+    fetchMock.catch(function (responseUrl, responseOpts) {
+      expect(responseUrl).to.contain(mapServiceUrl + 'identify');
+      expect(responseUrl).to.contain('sr=4326');
+      expect(responseUrl).to.contain('layers=all');
+      expect(responseUrl).to.contain('tolerance=3');
+      expect(responseUrl).to.contain('returnGeometry=true');
+      expect(responseUrl).to.contain('imageDisplay=500%2C500%2C96');
+      expect(responseUrl).to.match(/mapExtent=-122\.\d+%2C45\.\d+%2C-122\.\d+%2C45\.\d+/g);
+      expect(responseUrl).to.contain('geometryType=esriGeometryPoint');
+      expect(responseUrl).to.contain('geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D');
+      return sampleResponse;
+    });
+    task.run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    expect(request.url).to.contain(mapServiceUrl + 'identify');
-    expect(request.url).to.contain('sr=4326');
-    expect(request.url).to.contain('layers=all');
-    expect(request.url).to.contain('tolerance=3');
-    expect(request.url).to.contain('returnGeometry=true');
-    expect(request.url).to.contain('imageDisplay=500%2C500%2C96');
-    expect(request.url).to.match(/mapExtent=-122\.\d+%2C45\.\d+%2C-122\.\d+%2C45\.\d+/g);
-    expect(request.url).to.contain('geometryType=esriGeometryPoint');
-    expect(request.url).to.contain('geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D');
-
-    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });
 
   it('should identify features with a layer definition', function (done) {
-    var request = task.layerDef(0, 'NAME=Oregon').run(function (error, featureCollection, raw) {
+    fetchMock.catch(function (responseUrl, responseOpts) {
+      expect(responseUrl).to.contain('layerDefs=0%3ANAME%3DOregon');
+      return sampleResponse;
+    });
+
+    task.layerDef(0, 'NAME=Oregon').run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    expect(request.url).to.contain('layerDefs=0%3ANAME%3DOregon');
-
-    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });
 
   it('should identify features with 2 layer definitions', function (done) {
-    var request = task.layerDef(0, 'NAME=Oregon').layerDef(1, 'NAME=Multnomah').run(function (error, featureCollection, raw) {
+    fetchMock.catch(function (responseUrl, responseOpts) {
+      expect(responseUrl).to.contain('layerDefs=0%3ANAME%3DOregon%3B1%3ANAME%3DMultnomah');
+      return sampleResponse;
+    });
+
+    task.layerDef(0, 'NAME=Oregon').layerDef(1, 'NAME=Multnomah').run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    expect(request.url).to.contain('layerDefs=0%3ANAME%3DOregon%3B1%3ANAME%3DMultnomah');
-
-    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });
 
   it('should identify features in a given time range', function (done) {
     var start = new Date('January 1 2013 GMT-0800');
     var end = new Date('January 1 2014 GMT-0800');
 
-    var request = task.between(start, end).run(function (error, featureCollection, raw) {
+    fetchMock.catch(function (responseUrl, responseOpts) {
+      expect(responseUrl).to.contain('time=1357027200000%2C1388563200000');
+      return sampleResponse;
+    });
+
+    task.between(start, end).run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    expect(request.url).to.contain('time=1357027200000%2C1388563200000');
-
-    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });
 
   it('should restrict identification to specific layers', function (done) {
-    var request = task.layers('top').run(function (error, featureCollection, raw) {
+    fetchMock.catch(function (responseUrl, responseOpts) {
+      return sampleResponse;
+    });
+
+    task.layers('top').run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });
 
   it('should identify features and limit geometries to a given precision', function (done) {
-    var request = task.precision(4).run(function (error, featureCollection, raw) {
+    fetchMock.catch(function (responseUrl, responseOpts) {
+      expect(responseUrl).to.contain('geometryPrecision=4');
+      return sampleResponse;
+    });
+
+    task.precision(4).run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    expect(request.url).to.contain('geometryPrecision=4');
-
-    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });
 
   it('should identify features and simplify geometries', function (done) {
-    var request = task.simplify(map, 0.5).run(function (error, featureCollection, raw) {
+    fetchMock.catch(function (responseUrl, responseOpts) {
+      expect(responseUrl).to.contain('maxAllowableOffset=0.000010728836059570312');
+      return sampleResponse;
+    });
+
+    task.simplify(map, 0.5).run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    expect(request.url).to.contain('maxAllowableOffset=0.000010728836059570312');
-
-    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });
 
   it('should identify features with a token', function (done) {
-    var request = task.token('foo').run(function (error, featureCollection, raw) {
+    fetchMock.catch(function (responseUrl, responseOpts) {
+      expect(responseUrl).to.contain('token=foo');
+      return sampleResponse;
+    });
+
+    task.token('foo').run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    expect(request.url).to.contain('token=foo');
-
-    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });
 
   it('should identify features within a certain pixel tolerance', function (done) {
-    var request = task.tolerance(4).run(function (error, featureCollection, raw) {
+    fetchMock.catch(function (responseUrl, responseOpts) {
+      expect(responseUrl).to.contain('tolerance=4');
+      return sampleResponse;
+    });
+
+    task.tolerance(4).run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    expect(request.url).to.contain('tolerance=4');
-
-    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });
 
   it('should fetch unformatted results from 10.5+', function (done) {
-    var request = task.format(false).run(function (error, featureCollection, raw) {
+    fetchMock.catch(function (responseUrl, responseOpts) {
+      expect(responseUrl).to.contain('returnUnformattedValues=true');
+      return sampleResponse;
+    });
+
+    task.format(false).run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    expect(request.url).to.contain('returnUnformattedValues=true');
-
-    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });
 
   it('should use a service to execute the request', function (done) {
     var service = L.esri.mapService({url: mapServiceUrl});
 
-    var request = service.identify().on(map).at(latlng).run(function (error, featureCollection, raw) {
+    fetchMock.catch(function (responseUrl, responseOpts) {
+      expect(responseUrl).to.contain(mapServiceUrl + 'identify');
+      expect(responseUrl).to.contain('sr=4326');
+      expect(responseUrl).to.contain('layers=all');
+      expect(responseUrl).to.contain('tolerance=3');
+      expect(responseUrl).to.contain('returnGeometry=true');
+      expect(responseUrl).to.contain('imageDisplay=500%2C500%2C96');
+      expect(responseUrl).to.match(/mapExtent=-122\.\d+%2C45\.\d+%2C-122\.\d+%2C45\.\d+/g);
+      expect(responseUrl).to.contain('geometryType=esriGeometryPoint');
+      expect(responseUrl).to.contain('geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D');
+      return sampleResponse;
+    });
+
+    service.identify().on(map).at(latlng).run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    expect(request.url).to.contain(mapServiceUrl + 'identify');
-    expect(request.url).to.contain('sr=4326');
-    expect(request.url).to.contain('layers=all');
-    expect(request.url).to.contain('tolerance=3');
-    expect(request.url).to.contain('returnGeometry=true');
-    expect(request.url).to.contain('imageDisplay=500%2C500%2C96');
-    expect(request.url).to.match(/mapExtent=-122\.\d+%2C45\.\d+%2C-122\.\d+%2C45\.\d+/g);
-    expect(request.url).to.contain('geometryType=esriGeometryPoint');
-    expect(request.url).to.contain('geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D');
-
-    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });
 
   it('should use a service to execute the request with simple LatLng', function (done) {
     var service = L.esri.mapService({url: mapServiceUrl});
 
-    var request = service.identify().on(map).at(rawLatlng).run(function (error, featureCollection, raw) {
+    fetchMock.catch(function (responseUrl, responseOpts) {
+      expect(responseUrl).to.contain(mapServiceUrl + 'identify');
+      expect(responseUrl).to.contain('sr=4326');
+      expect(responseUrl).to.contain('layers=all');
+      expect(responseUrl).to.contain('tolerance=3');
+      expect(responseUrl).to.contain('returnGeometry=true');
+      expect(responseUrl).to.contain('imageDisplay=500%2C500%2C96');
+      expect(responseUrl).to.match(/mapExtent=-122\.\d+%2C45\.\d+%2C-122\.\d+%2C45\.\d+/g);
+      expect(responseUrl).to.contain('geometryType=esriGeometryPoint');
+      expect(responseUrl).to.contain('geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D');
+      return sampleResponse;
+    });
+
+    service.identify().on(map).at(rawLatlng).run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    expect(request.url).to.contain(mapServiceUrl + 'identify');
-    expect(request.url).to.contain('sr=4326');
-    expect(request.url).to.contain('layers=all');
-    expect(request.url).to.contain('tolerance=3');
-    expect(request.url).to.contain('returnGeometry=true');
-    expect(request.url).to.contain('imageDisplay=500%2C500%2C96');
-    expect(request.url).to.match(/mapExtent=-122\.\d+%2C45\.\d+%2C-122\.\d+%2C45\.\d+/g);
-    expect(request.url).to.contain('geometryType=esriGeometryPoint');
-    expect(request.url).to.contain('geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D');
-
-    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });
 
   it('should return layerId of features in response', function (done) {
     var service = L.esri.mapService({url: mapServiceUrl});
 
-    var request = service.identify().on(map).at(rawLatlng).run(function (error, featureCollection, raw) {
+    fetchMock.catch(function (responseUrl, responseOpts) {
+      return sampleResponse;
+    });
+
+    service.identify().on(map).at(rawLatlng).run(function (error, featureCollection, raw) {
       expect(featureCollection.features[0].layerId).to.deep.equal(0);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });
 
   it('should identify features with an input extent', function (done) {
     var extentTask = L.esri.identifyFeatures({url: mapServiceUrl}).on(map).at(bounds);
 
-    var request = extentTask.run(function (error, featureCollection, raw) {
+    fetchMock.catch(function (responseUrl, responseOpts) {
+      expect(responseUrl).to.contain('geometry=%7B%22xmin%22%3A-122.66%2C%22ymin%22%3A45.5%2C%22xmax%22%3A-122.65%2C%22ymax%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D');
+      expect(responseUrl).to.contain('geometryType=esriGeometryEnvelope');
+      expect(responseUrl).to.contain('sr=4326');
+      return sampleResponse;
+    });
+
+    extentTask.run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    expect(request.url).to.contain('geometry=%7B%22xmin%22%3A-122.66%2C%22ymin%22%3A45.5%2C%22xmax%22%3A-122.65%2C%22ymax%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D');
-    expect(request.url).to.contain('geometryType=esriGeometryEnvelope');
-    expect(request.url).to.contain('sr=4326');
-
-    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });
 
   it('should identify features with raw geojson input', function (done) {
     var rawTask = L.esri.identifyFeatures({url: mapServiceUrl}).on(map).at(rawGeoJsonPolygon);
 
-    var request = rawTask.run(function (error, featureCollection, raw) {
+    fetchMock.catch(function (responseUrl, responseOpts) {
+      expect(responseUrl).to.contain('geometry=%7B%22rings%22%3A%5B%5B%5B-97%2C39%5D%2C%5B-97%2C41%5D%2C%5B-94%2C41%5D%2C%5B-94%2C39%5D%2C%5B-97%2C39%5D%5D%5D%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D');
+      expect(responseUrl).to.contain('geometryType=esriGeometryPolygon');
+      expect(responseUrl).to.contain('sr=4326');
+      return sampleResponse;
+    });
+
+    rawTask.run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    expect(request.url).to.contain('geometry=%7B%22rings%22%3A%5B%5B%5B-97%2C39%5D%2C%5B-97%2C41%5D%2C%5B-94%2C41%5D%2C%5B-94%2C39%5D%2C%5B-97%2C39%5D%5D%5D%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D');
-    expect(request.url).to.contain('geometryType=esriGeometryPolygon');
-    expect(request.url).to.contain('sr=4326');
-
-    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });
 
   it('should identify features with geojson input', function (done) {
     var polygonTask = L.esri.identifyFeatures({url: mapServiceUrl}).on(map).at(geoJsonPolygon);
 
-    var request = polygonTask.run(function (error, featureCollection, raw) {
+    fetchMock.catch(function (responseUrl, responseOpts) {
+      expect(responseUrl).to.contain('geometry=%7B%22rings%22%3A%5B%5B%5B-97%2C39%5D%2C%5B-97%2C41%5D%2C%5B-94%2C41%5D%2C%5B-94%2C39%5D%2C%5B-97%2C39%5D%5D%5D%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D');
+      expect(responseUrl).to.contain('geometryType=esriGeometryPolygon');
+      expect(responseUrl).to.contain('sr=4326');
+      return sampleResponse;
+    });
+
+    polygonTask.run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    expect(request.url).to.contain('geometry=%7B%22rings%22%3A%5B%5B%5B-97%2C39%5D%2C%5B-97%2C41%5D%2C%5B-94%2C41%5D%2C%5B-94%2C39%5D%2C%5B-97%2C39%5D%5D%5D%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D');
-    expect(request.url).to.contain('geometryType=esriGeometryPolygon');
-    expect(request.url).to.contain('sr=4326');
-
-    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });
 
   it('should identify features passing through arbitrary request parameters', function (done) {
@@ -329,18 +344,19 @@ describe('L.esri.IdentifyFeatures', function () {
       }
     }).on(map).at(geoJsonPolygon);
 
-    var request = polygonTask.run(function (error, featureCollection, raw) {
+    fetchMock.catch(function (responseUrl, responseOpts) {
+      expect(responseUrl).to.contain('geometry=%7B%22rings%22%3A%5B%5B%5B-97%2C39%5D%2C%5B-97%2C41%5D%2C%5B-94%2C41%5D%2C%5B-94%2C39%5D%2C%5B-97%2C39%5D%5D%5D%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D');
+      expect(responseUrl).to.contain('geometryType=esriGeometryPolygon');
+      expect(responseUrl).to.contain('sr=4326');
+      expect(responseUrl).to.contain('foo=bar');
+      return sampleResponse;
+    });
+
+    polygonTask.run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    expect(request.url).to.contain('geometry=%7B%22rings%22%3A%5B%5B%5B-97%2C39%5D%2C%5B-97%2C41%5D%2C%5B-94%2C41%5D%2C%5B-94%2C39%5D%2C%5B-97%2C39%5D%5D%5D%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D');
-    expect(request.url).to.contain('geometryType=esriGeometryPolygon');
-    expect(request.url).to.contain('sr=4326');
-    expect(request.url).to.contain('foo=bar');
-
-    request.respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
   });
 });
 /* eslint-enable handle-callback-err */

--- a/spec/Tasks/IdentifyImageSpec.js
+++ b/spec/Tasks/IdentifyImageSpec.js
@@ -18,7 +18,6 @@ describe('L.esri.IdentifyImage', function () {
     return L.map(container).setView([45.51, -122.66], 16);
   }
 
-  var server;
   var task;
 
   // create map
@@ -341,45 +340,48 @@ describe('L.esri.IdentifyImage', function () {
   };
 
   beforeEach(function () {
-    server = sinon.fakeServer.create();
     task = L.esri.identifyImage({url: imageServiceUrl}).at(latlng);
   });
 
   afterEach(function () {
-    server.restore();
+    fetchMock.restore();
   });
 
   it('should identify a pixel value at location', function (done) {
-    server.respondWith('GET', imageServiceUrl + 'identify?returnGeometry=false&geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryPoint&f=json', JSON.stringify(sampleResponse));
-
-    var request = task.run(function (error, results, raw) {
+    fetchMock.getOnce(
+      imageServiceUrl + 'identify?f=json&returnGeometry=false&geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryPoint',
+      JSON.stringify(sampleResponse)
+    );
+    task.run(function (error, results, raw) {
       expect(results).to.deep.equal(sampleResults);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    expect(request).to.be.an.instanceof(XMLHttpRequest);
-
-    server.respond();
+    // Test for Promise ?
+    // expect(request).to.be.an.instanceof(XMLHttpRequest);
   });
 
   it('should identify a pixel value at location with simple LatLng', function (done) {
-    server.respondWith('GET', imageServiceUrl + 'identify?returnGeometry=false&geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryPoint&f=json', JSON.stringify(sampleResponse));
-
-    var request = task.at(rawLatlng).run(function (error, results, raw) {
+    fetchMock.getOnce(
+      imageServiceUrl + 'identify?f=json&returnGeometry=false&geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryPoint',
+      JSON.stringify(sampleResponse)
+    );
+    task.at(rawLatlng).run(function (error, results, raw) {
       expect(results).to.deep.equal(sampleResults);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
 
-    expect(request).to.be.an.instanceof(XMLHttpRequest);
-
-    server.respond();
+    // Test for Promise ?
+    // expect(request).to.be.an.instanceof(XMLHttpRequest);
   });
 
   it('should identify a pixel value with mosaic rule', function (done) {
     var mosaicRule = {mosaicMethod: 'esriMosaicLockRaster', 'lockRasterIds': [8]};
-    server.respondWith('GET', imageServiceUrl + 'identify?returnGeometry=false&geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryPoint&mosaicRule=%7B%22mosaicMethod%22%3A%22esriMosaicLockRaster%22%2C%22lockRasterIds%22%3A%5B8%5D%7D&f=json', JSON.stringify(sampleResponse));
+    fetchMock.getOnce(
+      imageServiceUrl + 'identify?f=json&returnGeometry=false&geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryPoint&mosaicRule=%7B%22mosaicMethod%22%3A%22esriMosaicLockRaster%22%2C%22lockRasterIds%22%3A%5B8%5D%7D',
+      JSON.stringify(sampleResponse)
+    );
 
     task.setMosaicRule(mosaicRule);
     expect(task.getMosaicRule()).to.deep.equal(mosaicRule);
@@ -389,14 +391,14 @@ describe('L.esri.IdentifyImage', function () {
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    server.respond();
   });
 
   it('should identify a pixel value with rendering rule', function (done) {
     var renderingRule = {rasterFunction: 'RFTAspectColor'};
-    server.respondWith('GET', imageServiceUrl + 'identify?returnGeometry=false&geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryPoint&renderingRule=%7B%22rasterFunction%22%3A%22RFTAspectColor%22%7D&f=json', JSON.stringify(sampleResponse));
-
+    fetchMock.getOnce(
+      imageServiceUrl + 'identify?f=json&returnGeometry=false&geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryPoint&renderingRule=%7B%22rasterFunction%22%3A%22RFTAspectColor%22%7D',
+      JSON.stringify(sampleResponse)
+    );
     task.setRenderingRule(renderingRule);
     expect(task.getRenderingRule()).to.deep.equal(renderingRule);
 
@@ -405,15 +407,14 @@ describe('L.esri.IdentifyImage', function () {
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    server.respond();
   });
 
   it('should identify a pixel value with a pixel size array', function (done) {
     var pixelSize = [15, 15];
-
-    server.respondWith('GET', imageServiceUrl + 'identify?returnGeometry=false&geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryPoint&pixelSize=15%2C15&f=json', JSON.stringify(sampleResponse));
-
+    fetchMock.getOnce(
+      imageServiceUrl + 'identify?f=json&returnGeometry=false&geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryPoint&pixelSize=15%2C15',
+      JSON.stringify(sampleResponse)
+    );
     task.setPixelSize(pixelSize);
 
     expect(task.getPixelSize()).to.equal(pixelSize);
@@ -423,14 +424,15 @@ describe('L.esri.IdentifyImage', function () {
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    server.respond();
   });
 
   it('should identify a pixel value with a pixel size string', function (done) {
     var pixelSize = '1,1';
 
-    server.respondWith('GET', imageServiceUrl + 'identify?returnGeometry=false&geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryPoint&pixelSize=1%2C1&f=json', JSON.stringify(sampleResponse));
+    fetchMock.getOnce(
+      imageServiceUrl + 'identify?f=json&returnGeometry=false&geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryPoint&pixelSize=1%2C1',
+      JSON.stringify(sampleResponse)
+    );
 
     task.setPixelSize(pixelSize);
     expect(task.getPixelSize()).to.equal(pixelSize);
@@ -440,12 +442,13 @@ describe('L.esri.IdentifyImage', function () {
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    server.respond();
   });
 
   it('should return catalog items', function (done) {
-    server.respondWith('GET', imageServiceUrl + 'identify?returnGeometry=true&geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryPoint&returnCatalogItems=true&f=json', JSON.stringify(sampleResponseWithCatalogItems));
+    fetchMock.getOnce(
+      imageServiceUrl + 'identify?f=json&returnGeometry=true&geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryPoint&returnCatalogItems=true',
+      JSON.stringify(sampleResponseWithCatalogItems)
+    );
 
     task.returnGeometry(true).returnCatalogItems(true);
     task.run(function (error, results, raw) {
@@ -453,8 +456,6 @@ describe('L.esri.IdentifyImage', function () {
       expect(raw).to.deep.equal(sampleResponseWithCatalogItems);
       done();
     });
-
-    server.respond();
   });
 
   it('should return catalog items w/o geometry', function (done) {
@@ -464,7 +465,10 @@ describe('L.esri.IdentifyImage', function () {
       delete (sampleResponseWithCatalogItemsNoGeometry.catalogItems.features[i].geometry);
       sampleResultsWithCatalogItemsNoGeomerty.catalogItems.features[i].geometry = null;
     }
-    server.respondWith('GET', imageServiceUrl + 'identify?returnGeometry=false&geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryPoint&returnCatalogItems=true&f=json', JSON.stringify(sampleResponseWithCatalogItemsNoGeometry));
+    fetchMock.getOnce(
+      imageServiceUrl + 'identify?f=json&returnGeometry=false&geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryPoint&returnCatalogItems=true',
+      JSON.stringify(sampleResponseWithCatalogItemsNoGeometry)
+    );
 
     task.returnCatalogItems(true);
     task.run(function (error, results, raw) {
@@ -472,8 +476,6 @@ describe('L.esri.IdentifyImage', function () {
       expect(raw).to.deep.equal(sampleResponseWithCatalogItemsNoGeometry);
       done();
     });
-
-    server.respond();
   });
 
   it('should pass through arbitrary parameters', function (done) {
@@ -484,15 +486,16 @@ describe('L.esri.IdentifyImage', function () {
       }
     }).at(latlng);
 
-    server.respondWith('GET', imageServiceUrl + 'identify?returnGeometry=false&geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryPoint&foo=bar&f=json', JSON.stringify(sampleResponse));
+    fetchMock.getOnce(
+      imageServiceUrl + 'identify?f=json&returnGeometry=false&geometry=%7B%22x%22%3A-122.66%2C%22y%22%3A45.51%2C%22spatialReference%22%3A%7B%22wkid%22%3A4326%7D%7D&geometryType=esriGeometryPoint&foo=bar',
+      JSON.stringify(sampleResponse)
+    );
 
     customTask.run(function (error, results, raw) {
       expect(results).to.deep.equal(sampleResults);
       expect(raw).to.deep.equal(sampleResponse);
       done();
     });
-
-    server.respond();
   });
 });
 /* eslint-enable handle-callback-err */


### PR DESCRIPTION
Update tests with [fetch-mock](https://www.npmjs.com/package/fetch-mock) library.
Still some tests are failing:

- **DynamicMapLayer, ImageMapLayer:**
3 tests failing because of a problem popup related:
•	Can’t find a way to do the test when the popup has rendered
•	fetchMock.flush() does not help : promise has resolved does not mean that callback has been executed

- **DynamicMapLayer, ImageMapLayer, TiledMapSpec:** 
Test "_should propagate events from the service_" failing:
Don't know how to handle spy on requestend because as the event is triggered after the metadata callback has been called, I can’t find a way to « hook » the test: `expect(requestendSpy.callCount).to.be.above(0);`

- **FindSpec, IdentifyImageSpec, QuerySpec:**
Part of the tests testing for xhr type are commented : should the promise be returned ? So far it is not the case.
`expect(this.request).to.be.an.instanceof(XMLHttpRequest);`

- **RequestSpec:**
2 tests testing for error failing : failed not managed yet [code]https://github.com/Esri/esri-leaflet/blob/51940752bd3feee6ad53eb146d9cc2ae030d77d6/src/Request.js#L8)

- [ ] L.esri.FeatureManager test TODO.
@jgravois I wanted to have your opinion so far on the issues above before going ahead as at a first look it seemed trickier for FeatureManager 
