### PR TITLE
no-callback fix for jsonp with server error

### DIFF
--- a/src/Request.js
+++ b/src/Request.js
@@ -187,6 +187,20 @@ export function jsonp (url, params, callback, context) {
   script.type = 'text/javascript';
   script.src = url + '?' + serialize(params);
   script.id = callbackId;
+  script.onerror = function (error) {
+    if (error && window._EsriLeafletCallbacks[callbackId] !== true) {
+      // Can't get true error code: it can be 404, or 401, or 500
+      var err = {
+        error: {
+          code: 500,
+          message: 'Server error'
+        }
+      };
+
+      callback.call(context, err);
+      window._EsriLeafletCallbacks[callbackId] = true;
+    }
+  };
   DomUtil.addClass(script, 'esri-leaflet-jsonp');
 
   callbacks++;

--- a/src/Request.js
+++ b/src/Request.js
@@ -193,7 +193,7 @@ export function jsonp (url, params, callback, context) {
       var err = {
         error: {
           code: 500,
-          message: 'Server error'
+          message: 'An unknown error occurred'
         }
       };
 


### PR DESCRIPTION
Fix for no-callback jsonp request with server error [https://github.com/Esri/esri-leaflet/issues/1069](#1069) with onerror handler.