### PR TITLE
export a flat ES build [wip]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ debug/*.js
 debug/*.json
 debug/archive/
 !debug/sample.html
+!debug/esm.html
 
 # Docs Build
 site/build

--- a/debug/esm.html
+++ b/debug/esm.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+  <html>
+  <head>
+    <meta charset=utf-8 />
+    <title>Esri Leaflet Debugging Sample</title>
+    <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+
+    <!-- Load Leaflet -->
+    <link rel="stylesheet" href="../node_modules/leaflet/dist/leaflet.css" />
+
+    <style>
+      body {
+        margin:0;
+        padding:0;
+      }
+
+      #map {
+        position: absolute;
+        top:0;
+        bottom:0;
+        right:0;left:0;
+      }
+
+      #info-pane {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        z-index: 1000;
+        padding: 1em;
+        background: white;
+      }
+    </style>
+  </head>
+  <body>
+
+  <div id="map"></div>
+  <div id="info-pane" class="leaflet-bar">
+    <label>
+    sample application for debugging
+    </label>
+  </div>
+  <!--// ;-->
+  <script type='module'>
+    import * as leaflet from '/node_modules/leaflet/dist/leaflet-src.esm.js';
+    import * as esri from '/dist/esri-leaflet.esm.js';
+  
+    let map = leaflet.map('map', {
+      center: [51.505, -0.09],
+      zoom: 13
+    });
+    
+    // look ma, no build step!
+    esri.basemapLayer('Topographic').addTo(map);
+  </script>
+
+  </body>
+  </html>

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   ],
   "dependencies": {
     "@esri/arcgis-to-geojson-utils": "^1.1.1",
-    "leaflet-virtual-grid": "^1.0.5",
-    "tiny-binary-search": "^1.0.2"
+    "leaflet-virtual-grid": "^1.0.6",
+    "tiny-binary-search": "^1.0.3"
   },
   "devDependencies": {
     "chai": "3.5.0",
@@ -46,8 +46,7 @@
     "watch": "^0.17.1"
   },
   "homepage": "http://esri.github.io/esri-leaflet",
-  "module": "src/EsriLeaflet.js",
-  "jsnext:main": "src/EsriLeaflet.js",
+  "module": "dist/esri-leaflet.esm.js",
   "jspm": {
     "registry": "npm",
     "format": "es6",
@@ -72,7 +71,7 @@
     "url": "git@github.com:Esri/esri-leaflet.git"
   },
   "scripts": {
-    "build": "rollup -c profiles/debug.js & rollup -c profiles/production.js",
+    "build": "rollup -c profiles/es_module.js & rollup -c profiles/debug.js & rollup -c profiles/production.js",
     "lint": "semistandard | snazzy",
     "prebuild": "mkdirp dist",
     "prepublish": "npm run build",

--- a/profiles/base.js
+++ b/profiles/base.js
@@ -1,29 +1,26 @@
 import json from 'rollup-plugin-json';
-import nodeResolve from 'rollup-plugin-node-resolve';
+import resolve from 'rollup-plugin-node-resolve';
+import pkg from '../package.json';
 
-var pkg = require('../package.json');
-var copyright = '/* ' + pkg.name + ' - v' + pkg.version + ' - ' + new Date().toString() + '\n' +
-                ' * Copyright (c) ' + new Date().getFullYear() + ' Environmental Systems Research Institute, Inc.\n' +
-                ' * ' + pkg.license + ' */';
+const copyright = `/* @preserve
+ * ${pkg.name} - v${pkg.version} - ${new Date().toString()}
+ * Copyright (c) ${new Date().getFullYear()} Environmental Systems Research Institute, Inc.
+ * ${pkg.license}
+ */
+`;
 
 export default {
   input: 'src/EsriLeaflet.js',
-
   external: ['leaflet', 'esri-leaflet'],
   plugins: [
-    nodeResolve({
-      jsnext: true,
-      main: false,
-      browser: false,
-      extensions: [ '.js', '.json' ]
-    }),
+    resolve(),
     json()
   ],
-
   output: {
     banner: copyright,
     format: 'umd',
     name: 'L.esri',
+    sourcemap: true,
     globals: {
       'leaflet': 'L',
       'esri-leaflet': 'L.esri'

--- a/profiles/es_module.js
+++ b/profiles/es_module.js
@@ -1,6 +1,7 @@
 import pkg from '../package.json';
 import config from './base.js';
 
-config.output.file = pkg.main;
+config.output.file = pkg.module;
+config.output.format = 'es';
 
 export default config;

--- a/profiles/production.js
+++ b/profiles/production.js
@@ -1,10 +1,7 @@
-import uglify from 'rollup-plugin-uglify';
 import config from './base.js';
+import uglify from 'rollup-plugin-uglify';
 
 config.output.file = 'dist/esri-leaflet.js';
-config.output.sourcemap = 'dist/esri-leaflet.js.map';
-
-// use a Regex to preserve copyright text
-config.plugins.push(uglify({ output: {comments: /Institute, Inc/} }));
+config.plugins.push(uglify());
 
 export default config;


### PR DESCRIPTION
still need to figure out how to appropriately reference `leaflet` as a module _without_ knowing its physical location.

```
import { TileLayer, Util } from 'leaflet';

> Uncaught TypeError: Failed to resolve module specifier "leaflet". Relative references must start with either "/", "./", or "../".
```