### PR TITLE
Added missing attribution option

### DIFF
--- a/src/Layers/BasemapLayer.js
+++ b/src/Layers/BasemapLayer.js
@@ -47,7 +47,8 @@ export var BasemapLayer = TileLayer.extend({
           minZoom: 1,
           maxZoom: 16,
           subdomains: ['server', 'services'],
-          pane: (pointerEvents) ? 'esri-labels' : 'tilePane'
+          pane: (pointerEvents) ? 'esri-labels' : 'tilePane',
+          attribution: ''
         }
       },
       NationalGeographic: {
@@ -124,7 +125,8 @@ export var BasemapLayer = TileLayer.extend({
           minZoom: 1,
           maxZoom: 19,
           subdomains: ['server', 'services'],
-          pane: (pointerEvents) ? 'esri-labels' : 'tilePane'
+          pane: (pointerEvents) ? 'esri-labels' : 'tilePane',
+          attribution: ''
         }
       },
       ShadedRelief: {


### PR DESCRIPTION
Added missing attribtion option to OceansLabels and ImageryTransportation basemaps. 
Because of null attribution following error was happening: 
Uncaught TypeError: Cannot set property 'innerHTML' of null
    at _updateMapAttribution (Util.js:342)
    at Util.js:313