### PR TITLE
Check if 'attributionElement' exists. Fixes #1077

### DIFF
--- a/src/Util.js
+++ b/src/Util.js
@@ -317,8 +317,9 @@ export function _getAttributionData (url, map) {
 export function _updateMapAttribution (evt) {
   var map = evt.target;
   var oldAttributions = map._esriAttributions;
+  var attributionElement = map.attributionControl._container.querySelector('.esri-dynamic-attribution');
 
-  if (map && map.attributionControl && oldAttributions) {
+  if (map && map.attributionControl && attributionElement && oldAttributions) {
     var newAttributions = '';
     var bounds = map.getBounds();
     var wrappedBounds = latLngBounds(
@@ -337,8 +338,6 @@ export function _updateMapAttribution (evt) {
     }
 
     newAttributions = newAttributions.substr(2);
-    var attributionElement = map.attributionControl._container.querySelector('.esri-dynamic-attribution');
-
     attributionElement.innerHTML = newAttributions;
     attributionElement.style.maxWidth = calcAttributionWidth(map);
 


### PR DESCRIPTION
When doing _updateMapAttribution, make sure to check if attributionElement actually exists to avoid "TypeError: Cannot set property 'innerHTML' of null". Fixes #1077