### PR TITLE
Add setZIndex function

### DIFF
--- a/src/Layers/RasterLayer.js
+++ b/src/Layers/RasterLayer.js
@@ -228,7 +228,7 @@ export var RasterLayer = Layer.extend({
 
             if (this.options.position === 'front') {
               this.bringToFront();
-            } else {
+            } else if (this.options.position === 'back') {
               this.bringToBack();
             }
             

--- a/src/Layers/RasterLayer.js
+++ b/src/Layers/RasterLayer.js
@@ -30,7 +30,11 @@ export var RasterLayer = Layer.extend({
   onAdd: function (map) {
     // include 'Powered by Esri' in map attribution
     setEsriAttribution(map);
-
+    
+    if (this.options.zIndex) {
+      this.options.position = null;
+    }
+    
     this._update = Util.throttle(this._update, this.options.updateInterval, this);
 
     map.on('moveend', this._update, this);
@@ -99,6 +103,7 @@ export var RasterLayer = Layer.extend({
     this.options.position = 'front';
     if (this._currentImage) {
       this._currentImage.bringToFront();
+      this._setAutoZIndex(Math.max)
     }
     return this;
   },
@@ -107,9 +112,42 @@ export var RasterLayer = Layer.extend({
     this.options.position = 'back';
     if (this._currentImage) {
       this._currentImage.bringToBack();
+      this._setAutoZIndex(Math.min)
     }
     return this;
   },
+  
+  setZIndex: function (value) {
+    this.options.zIndex = value;
+    if (this._currentImage) {
+      this._currentImage.setZIndex(value);
+    }
+    return this;
+  },
+  
+  _setAutoZIndex: function (compare) {
+		// go through all other layers of the same pane, set zIndex to max + 1 (front) or min - 1 (back)
+    if (!this._currentImage) {
+      return;
+    }
+    
+		var layers = this._currentImage.getPane().children,
+		    edgeZIndex = -compare(-Infinity, Infinity); // -Infinity for max, Infinity for min
+
+		for (var i = 0, len = layers.length, zIndex; i < len; i++) {
+
+			zIndex = layers[i].style.zIndex;
+
+			if (layers[i] !== this._currentImage._image && zIndex) {
+				edgeZIndex = compare(edgeZIndex, +zIndex);
+			}
+		}
+
+		if (isFinite(edgeZIndex)) {
+			this.options.zIndex = edgeZIndex + compare(-1, 1);
+			this.setZIndex(this.options.zIndex);
+		}
+	},
 
   getAttribution: function () {
     return this.options.attribution;
@@ -192,6 +230,10 @@ export var RasterLayer = Layer.extend({
               this.bringToFront();
             } else {
               this.bringToBack();
+            }
+            
+            if (this.options.zIndex) {
+              this.setZIndex(this.options.zIndex);
             }
 
             if (this._map && this._currentImage._map) {

--- a/src/Layers/RasterLayer.js
+++ b/src/Layers/RasterLayer.js
@@ -30,11 +30,11 @@ export var RasterLayer = Layer.extend({
   onAdd: function (map) {
     // include 'Powered by Esri' in map attribution
     setEsriAttribution(map);
-    
+
     if (this.options.zIndex) {
       this.options.position = null;
     }
-    
+
     this._update = Util.throttle(this._update, this.options.updateInterval, this);
 
     map.on('moveend', this._update, this);
@@ -103,7 +103,7 @@ export var RasterLayer = Layer.extend({
     this.options.position = 'front';
     if (this._currentImage) {
       this._currentImage.bringToFront();
-      this._setAutoZIndex(Math.max)
+      this._setAutoZIndex(Math.max);
     }
     return this;
   },
@@ -112,11 +112,11 @@ export var RasterLayer = Layer.extend({
     this.options.position = 'back';
     if (this._currentImage) {
       this._currentImage.bringToBack();
-      this._setAutoZIndex(Math.min)
+      this._setAutoZIndex(Math.min);
     }
     return this;
   },
-  
+
   setZIndex: function (value) {
     this.options.zIndex = value;
     if (this._currentImage) {
@@ -124,7 +124,7 @@ export var RasterLayer = Layer.extend({
     }
     return this;
   },
-  
+
   _setAutoZIndex: function (compare) {
     // go through all other layers of the same pane, set zIndex to max + 1 (front) or min - 1 (back)
     if (!this._currentImage) {
@@ -227,7 +227,7 @@ export var RasterLayer = Layer.extend({
             } else if (this.options.position === 'back') {
               this.bringToBack();
             }
-            
+
             if (this.options.zIndex) {
               this.setZIndex(this.options.zIndex);
             }

--- a/src/Layers/RasterLayer.js
+++ b/src/Layers/RasterLayer.js
@@ -126,28 +126,24 @@ export var RasterLayer = Layer.extend({
   },
   
   _setAutoZIndex: function (compare) {
-		// go through all other layers of the same pane, set zIndex to max + 1 (front) or min - 1 (back)
+    // go through all other layers of the same pane, set zIndex to max + 1 (front) or min - 1 (back)
     if (!this._currentImage) {
       return;
     }
-    
-		var layers = this._currentImage.getPane().children,
-		    edgeZIndex = -compare(-Infinity, Infinity); // -Infinity for max, Infinity for min
+    var layers = this._currentImage.getPane().children;
+    var edgeZIndex = -compare(-Infinity, Infinity); // -Infinity for max, Infinity for min
+    for (var i = 0, len = layers.length, zIndex; i < len; i++) {
+      zIndex = layers[i].style.zIndex;
+      if (layers[i] !== this._currentImage._image && zIndex) {
+        edgeZIndex = compare(edgeZIndex, +zIndex);
+      }
+    }
 
-		for (var i = 0, len = layers.length, zIndex; i < len; i++) {
-
-			zIndex = layers[i].style.zIndex;
-
-			if (layers[i] !== this._currentImage._image && zIndex) {
-				edgeZIndex = compare(edgeZIndex, +zIndex);
-			}
-		}
-
-		if (isFinite(edgeZIndex)) {
-			this.options.zIndex = edgeZIndex + compare(-1, 1);
-			this.setZIndex(this.options.zIndex);
-		}
-	},
+    if (isFinite(edgeZIndex)) {
+      this.options.zIndex = edgeZIndex + compare(-1, 1);
+      this.setZIndex(this.options.zIndex);
+    }
+  },
 
   getAttribution: function () {
     return this.options.attribution;


### PR DESCRIPTION
增加了手动设置和自动设置图层 zIndex 值的方法。
在初始化设置了 position 参数时，自动设置图层 zIndex 值（遍历所在 pane 里的所有图层，设置最大（front）或最小（back）值）。
在初始化设置了 zIndex 参数时，position 参数的默认值失效，直接使用该值作为图层zIndex值。
如果之后手动调用 bringToFront 或 bringToBack 方法，之前手动设置的zIndex失效，自动分配图层 zIndex 值。
-----------------------------渣翻译分割线--------------------------
if set position option, it will auto set the image dom zIndex. (go through all other layers of the same pane, set zIndex to max + 1 (front) or min - 1 (back))
if set zIndex option, it will use the value as the image dom zIndex.
if call bringToFront / bringToBack function, though set zIndex option in initialize, it will auto set the image dom zIndex.