### PR TITLE
move inline sourcemaps in debug build to an external file

### DIFF
--- a/profiles/base.js
+++ b/profiles/base.js
@@ -27,6 +27,7 @@ export default {
     globals: {
       'leaflet': 'L',
       'esri-leaflet': 'L.esri'
-    }
+    },
+    sourcemap: true
   }
 };

--- a/profiles/debug.js
+++ b/profiles/debug.js
@@ -1,6 +1,5 @@
 import config from './base.js';
 
 config.output.file = 'dist/esri-leaflet-debug.js';
-config.output.sourcemap = 'inline';
 
 export default config;

--- a/profiles/production.js
+++ b/profiles/production.js
@@ -2,7 +2,6 @@ import uglify from 'rollup-plugin-uglify';
 import config from './base.js';
 
 config.output.file = 'dist/esri-leaflet.js';
-config.output.sourcemap = 'dist/esri-leaflet.js.map';
 
 // use a Regex to preserve copyright text
 config.plugins.push(uglify({ output: {comments: /Institute, Inc/} }));


### PR DESCRIPTION
[this stack overflow thread](https://stackoverflow.com/questions/27671390/why-inline-source-maps) has me convinced that inline sourcemaps are overkill for our purposes.

given that https://unpkg.com/esri-leaflet serves up `esri-leaflet-debug` lets try moving the sourcemap into an external file.