### PR TITLE
abort when JSON export response is missing an image entirely

### DIFF
--- a/src/Layers/RasterLayer.js
+++ b/src/Layers/RasterLayer.js
@@ -158,6 +158,10 @@ export var RasterLayer = Layer.extend({
       if (contentType) {
         url = 'data:' + contentType + ';base64,' + url;
       }
+
+      // if server returns an inappropriate response, abort.
+      if (!url) return;
+
       // create a new image overlay and add it to the map
       // to start loading the image
       // opacity is 0 while the image is loading


### PR DESCRIPTION
resolves #1107 

this is actually a situation where `f:"json"` allows us to handle ArcGIS Server errors that `f:"image"` doesn't give us the opportunity to catch.

this is because the CORS error happens _before_ [`L.ImageOverlay.on('error')`](https://leafletjs.com/reference-1.3.0.html#imageoverlay-error) fires.