### PR TITLE
trap exception when map has no attributionControl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+## [2.2.1] - 2018-07-11
+
+### Fixed
+
+* resolved issue that caused _some_ raw ES6 files to not be bundled on npm.
+
 ## [2.2.0] - 2018-07-08
 
 ### Added
@@ -624,7 +630,8 @@ None
 * Add DarkGray and DarkGrayLabels to BasemapLayer. #190
 * An attributionControl on maps is now required when using BasemapLayer. #159
 
-[unreleased]: https://github.com/esri/esri-leaflet/compare/v2.2.0...HEAD
+[unreleased]: https://github.com/esri/esri-leaflet/compare/v2.2.1...HEAD
+[2.2.1]: https://github.com/esri/esri-leaflet/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/esri/esri-leaflet/compare/v2.1.4...v2.2.0
 [2.1.4]: https://github.com/esri/esri-leaflet/compare/v2.1.3...v2.1.4
 [2.1.3]: https://github.com/esri/esri-leaflet/compare/v2.1.2...v2.1.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "esri-leaflet",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esri-leaflet",
   "description": "Leaflet plugins for consuming ArcGIS Online and ArcGIS Server services.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": "Patrick Arlt <parlt@esri.com> (http://patrickarlt.com)",
   "browser": "dist/esri-leaflet-debug.js",
   "bugs": {

--- a/src/Util.js
+++ b/src/Util.js
@@ -317,9 +317,12 @@ export function _getAttributionData (url, map) {
 export function _updateMapAttribution (evt) {
   var map = evt.target;
   var oldAttributions = map._esriAttributions;
+
+  if (!map || !map.attributionControl) return;
+
   var attributionElement = map.attributionControl._container.querySelector('.esri-dynamic-attribution');
 
-  if (map && map.attributionControl && attributionElement && oldAttributions) {
+  if (attributionElement && oldAttributions) {
     var newAttributions = '';
     var bounds = map.getBounds();
     var wrappedBounds = latLngBounds(


### PR DESCRIPTION
fixes logic error in #1078 to handle _both_ the scenarios below.

![cannot read property '_container' of undefined](https://user-images.githubusercontent.com/3011734/42712158-5e4a687a-869f-11e8-9ffd-845671f59ecc.png)


```js
var map = L.map('map', { attributionControl: false });
L.esri.basemapLayer('Topographic').addTo(map);
```

```js
var map = L.map('map');
L.esri.basemapLayer('Topographic', { attribution: null }).addTo(map);
```