### PR TITLE
Fire loading event before export request

### DIFF
--- a/src/Layers/RasterLayer.js
+++ b/src/Layers/RasterLayer.js
@@ -296,7 +296,7 @@ export var RasterLayer = Layer.extend({
 
     if (params) {
       this._requestExport(params, bounds);
-      
+
       this.fire('loading', {
         bounds: bounds
       });

--- a/src/Layers/RasterLayer.js
+++ b/src/Layers/RasterLayer.js
@@ -264,10 +264,6 @@ export var RasterLayer = Layer.extend({
 
       // once the image loads
       image.once('load', onOverlayLoad, this);
-
-      this.fire('loading', {
-        bounds: bounds
-      });
     }
   },
 
@@ -300,6 +296,10 @@ export var RasterLayer = Layer.extend({
 
     if (params) {
       this._requestExport(params, bounds);
+      
+      this.fire('loading', {
+        bounds: bounds
+      });
     } else if (this._currentImage) {
       this._currentImage._map.removeLayer(this._currentImage);
       this._currentImage = null;


### PR DESCRIPTION
Applies both to DynamicMapLayer and ImageMapLayer.
Fixes #1146