### PR TITLE
swap in 'esri-oss' as the recommended stack overflow tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ http://esri.github.io/esri-leaflet/plugins/
 
 If something isn't working the way you expected, please take a look at [previously logged issues](https://github.com/Esri/esri-leaflet/issues?labels=FAQ&milestone=&page=1&state=closed) that resolve common problems first.  Have you found a new bug?  Want to request a new feature?  We'd love to hear from you.  Please let us know by submitting an [issue](https://github.com/Esri/esri-leaflet/issues).
 
-If you're looking for help you can also find answers on [GIS StackExchange](https://gis.stackexchange.com/questions/tagged/esri-leaflet) and [GeoNet](https://community.esri.com/groups/esri-leaflet/activity).
+If you're looking for help you can also find answers on [Stack Overflow](https://stackoverflow.com/questions/tagged/esri-oss) and [GeoNet](https://community.esri.com/groups/esri-leaflet/activity).
 
 ## Going Deeper
 


### PR DESCRIPTION
When we started working on [ArcGIS REST JS](https://github.com/Esri/arcgis-rest-js), I seeded a generic <kbd>esri-oss</kbd> Stack Overflow / GIS Stack Exchange tag to make it easier for maintainers to keep an eye on questions from folks asking for help using our different open source projects on GitHub.

Given the relatively modest volume of questions posted and tagged with <kbd>esri-leaflet</kbd>, I'd recommend just combining the two.