### PR TITLE
Add case to _featureWithinTimeRange(feature)

### DIFF
--- a/spec/Layers/FeatureLayer/FeatureManagerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureManagerSpec.js
@@ -661,6 +661,22 @@ describe('L.esri.FeatureManager', function () {
       },
       'id': 2
     })).to.equal(false);
+    
+    expect(layer._featureWithinTimeRange({
+      'type': 'Feature',
+      'geometry': {
+        'type': 'Point',
+        'coordinates': [-122.673345, 45.537188]
+      },
+      'properties': {
+        'OBJECTID': 3,
+        'Name': 'Site 3',
+        'Type': 'Active',
+        'StartTime': new Date('November 29 2013 GMT-0800').valueOf(),
+        'EndTime': new Date('January 15 2014 GMT-0800').valueOf()
+      },
+      'id': 3
+    })).to.equal(true);
   });
 
   it('should return false when no time range is set', function () {

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -424,7 +424,7 @@ export var FeatureManager = VirtualGrid.extend({
     if (this.options.timeField.start && this.options.timeField.end) {
       var startDate = +feature.properties[this.options.timeField.start];
       var endDate = +feature.properties[this.options.timeField.end];
-      return ((startDate >= from) && (startDate <= to)) || ((endDate >= from) && (endDate <= to));
+      return ((startDate >= from) && (startDate <= to)) || ((endDate >= from) && (endDate <= to)) || ((startDate <= from) && (endDate >= to));
     }
   },
 


### PR DESCRIPTION
Add a case for when the feature's time range contains the time range given in the to and from options for the layer. This way, a feature will always show up during its specified time range.

#1173