### PR TITLE
refactor circular dependency in util/request

### DIFF
--- a/spec/UtilSpec.js
+++ b/spec/UtilSpec.js
@@ -135,4 +135,10 @@ describe('L.esri.Util', function () {
       });
     }
   });
+
+  describe('warn', function () {
+    it('should setup an alias for L.esri.Util.warn', function () {
+      expect(L.esri.Util.warn).to.be.a('function');
+    });
+  });
 });

--- a/src/Request.js
+++ b/src/Request.js
@@ -1,6 +1,5 @@
 import { Util, DomUtil } from 'leaflet';
 import { Support } from './Support';
-import { warn } from './Util';
 
 var callbacks = 0;
 
@@ -220,6 +219,12 @@ export function jsonp (url, params, callback, context) {
 var get = ((Support.cors) ? xmlHttpGet : jsonp);
 get.CORS = xmlHttpGet;
 get.JSONP = jsonp;
+
+export function warn () {
+  if (console && console.warn) {
+    console.warn.apply(console, arguments);
+  }
+}
 
 // choose the correct AJAX handler depending on CORS support
 export { get };

--- a/src/Util.js
+++ b/src/Util.js
@@ -1,5 +1,5 @@
 import { latLng, latLngBounds, LatLng, LatLngBounds, Util, DomUtil, GeoJSON } from 'leaflet';
-import { request } from './Request';
+import { request, warn } from './Request';
 import { options } from './Options';
 import { Support } from './Support';
 
@@ -163,12 +163,6 @@ export function geojsonTypeToArcGIS (geoJsonType) {
   }
 
   return arcgisGeometryType;
-}
-
-export function warn () {
-  if (console && console.warn) {
-    console.warn.apply(console, arguments);
-  }
 }
 
 export function calcAttributionWidth (map) {
@@ -342,6 +336,9 @@ export function _updateMapAttribution (evt) {
     });
   }
 }
+
+// for backwards compatibility
+export { warn };
 
 export var EsriUtil = {
   warn: warn,


### PR DESCRIPTION
resolves the rollup nag:
> (!) Circular dependency: src/Util.js -> src/Request.js -> src/Util.js

technically `warn` is just an internal helper method (its not documented in the API reference for [`L.esri.Util`](https://esri.github.io/esri-leaflet/api-reference/util.html)), but I reexported it there for backwards compatibility anyway.
![Screen Shot 2020-01-25 at 12 10 22 PM](https://user-images.githubusercontent.com/3011734/73126861-c4dc2100-3f6c-11ea-86a3-a80cd6bda6e2.png)

