### PR TITLE
use @terraformer/arcgis to generate GeoJSON from older ArcGIS services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@esri/arcgis-to-geojson-utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-to-geojson-utils/-/arcgis-to-geojson-utils-1.3.0.tgz",
-      "integrity": "sha512-8yPorlHeU63U6aT7RJbgSfXGKTZtnQz7Os8Qw96PW2lXJ+g1CRe5L/G8h5qtYHqt5VM4yCUGIhzHHYxdGzanLQ=="
-    },
     "@sinonjs/commons": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
@@ -43,6 +38,19 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.2.tgz",
       "integrity": "sha512-ZwTHAlC9akprWDinwEPD4kOuwaYZlyMwVJIANsKNC3QVp0AHB04m7RnB4eqeWfgmxw8MGTzS9uMaw93Z3QcZbw==",
       "dev": true
+    },
+    "@terraformer/arcgis": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@terraformer/arcgis/-/arcgis-2.0.1.tgz",
+      "integrity": "sha512-6w/dtLdB8jJrDJ5Yog4gMA0z0oY4R7tGv/EZrAmatApLWdA6/ZrPvu4TzHP9a4h9tvcFAJSKg12fo5z2eawoOw==",
+      "requires": {
+        "@terraformer/common": "^2.0.0"
+      }
+    },
+    "@terraformer/common": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@terraformer/common/-/common-2.0.0.tgz",
+      "integrity": "sha512-17ZsM314vSvLblAXI8aZ+fDXVGorbU3+BVbSWdvMpwmTIX2QTKm1Gnp6zo23F5nPbZetOm0C9ksi8yCMZQ5Yjw=="
     },
     "abbrev": {
       "version": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "John Gravois <jgravois@esri.com> (http://johngravois.com)"
   ],
   "dependencies": {
-    "@esri/arcgis-to-geojson-utils": "^1.3.0",
+    "@terraformer/arcgis": "^2.0.1",
     "leaflet-virtual-grid": "^1.0.7",
     "tiny-binary-search": "^1.0.3"
   },

--- a/src/Util.js
+++ b/src/Util.js
@@ -6,7 +6,7 @@ import { Support } from './Support';
 import {
   geojsonToArcGIS as g2a,
   arcgisToGeoJSON as a2g
-} from '@esri/arcgis-to-geojson-utils';
+} from '@terraformer/arcgis';
 
 export function geojsonToArcGIS (geojson, idAttr) {
   return g2a(geojson, idAttr);


### PR DESCRIPTION
over the years we've refactored the code that turns ArcGIS Geometries into GeoJSON _more than once_ in this library.

1. originally we inlined a subset of the code from Terraformer
2. later @patrickarlt created a new standalone package https://www.npmjs.com/package/@esri/arcgis-to-geojson-utils
3. by that point, @Esri had _quite a few_ packages and repos that served a similar purpose. and people started getting confused about when they should use what. 

ref: 
* https://github.com/Esri/terraformer-arcgis-parser/issues/44
* https://github.com/Esri/geojson-utils/issues/16

it always irked me that we were maintaining (and sometimes failing to maintain) so much nearly identical code. so i came up with the brilliant idea to publish **even more**. 😝 

see: https://xkcd.com/927

to make a long story long, `@terraformer/arcgis` is pretty much a glorified renaming of `@esri/arcgis-to-geojson-utils`.
to make a long story longer, it comes paired with another package for converting between WKT and GeoJSON and another package for using spatial predicates on GeoJSON. Esri Leaflet doesn't have any use for these, but they're [big in Japan](https://www.youtube.com/watch?v=DdWZKb659K0).

https://www.npmjs.com/package/@terraformer/wkt
https://www.npmjs.com/package/@terraformer/spatial

why rewrite them? mostly to make the functionality in the second two [tree shakable](https://en.wikipedia.org/wiki/Tree_shaking) and to put everything back under the familiar 'Terraformer' umbrella.

my hope is that this will help us archive all our old [Esri/Terraformer](https://github.com/Esri?q=terraformer&type=&language=) code and all the other alternative GeoJSON parsing code we wrote along the way.

only time will tell though.