### PR TITLE
Fix bugs with feature layer setWhere

### DIFF
--- a/src/Layers/FeatureLayer/FeatureGrid.js
+++ b/src/Layers/FeatureLayer/FeatureGrid.js
@@ -44,7 +44,7 @@ export var FeatureGrid = Layer.extend({
     Util.setOptions(this, options);
   },
 
-  onAdd: function () {
+  onAdd: function (map) {
     this._cells = {};
     this._activeCells = {};
     this._resetView();

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -133,7 +133,7 @@ export var FeatureManager = FeatureGrid.extend({
   _requestFeatures: function (bounds, coords, callback) {
     this._activeRequests++;
 
-    const originalWhere = this.options.where;
+    var originalWhere = this.options.where;
 
     // our first active request fires loading
     if (this._activeRequests === 1) {

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -133,6 +133,8 @@ export var FeatureManager = FeatureGrid.extend({
   _requestFeatures: function (bounds, coords, callback) {
     this._activeRequests++;
 
+    const originalWhere = this.options.where;
+
     // our first active request fires loading
     if (this._activeRequests === 1) {
       this.fire(
@@ -151,6 +153,11 @@ export var FeatureManager = FeatureGrid.extend({
     ) {
       if (response && response.exceededTransferLimit) {
         this.fire('drawlimitexceeded');
+      }
+
+      // the where changed while this request was being run so don't it.
+      if (this.options.where !== originalWhere) {
+        return;
       }
 
       // no error, features
@@ -271,7 +278,11 @@ export var FeatureManager = FeatureGrid.extend({
 
       pendingRequests--;
 
-      if (pendingRequests <= 0 && this._visibleZoom()) {
+      if (
+        pendingRequests <= 0 &&
+        this._visibleZoom() &&
+        where === this.options.where // the where is still the same so use this one
+      ) {
         this._currentSnapshot = newSnapshot;
         // schedule adding features for the next animation frame
         Util.requestAnimFrame(
@@ -289,6 +300,9 @@ export var FeatureManager = FeatureGrid.extend({
     for (var i = this._currentSnapshot.length - 1; i >= 0; i--) {
       oldSnapshot.push(this._currentSnapshot[i]);
     }
+
+    this._cache = {};
+
     for (var key in this._cells) {
       pendingRequests++;
       var coords = this._keyToCellCoords(key);


### PR DESCRIPTION
This PR fixes the following issues with `FeatureLayer.setWhere()`

* Fix #875
* Fix #1196

#1196 is happening because the internal layer cache was not cleared when `setWhere()` was called.  #875 was caused by race conditions in calling `setWhere` in quick succession. Given that we cannot cancel requests we now simply ignore then if the `where` in the request doesn't match the current `where` of the layer.

This means that callback to `setWhere` won't be run if they get interrupted by another `setWhere()` which I think is better behavior.

Adding @gavinr and @jwasilgeo for review.