### PR TITLE
do not clear _currentSnapshot when hiding the layer

### DIFF
--- a/src/Layers/FeatureLayer/FeatureGrid.js
+++ b/src/Layers/FeatureLayer/FeatureGrid.js
@@ -388,7 +388,9 @@ export var FeatureGrid = Layer.extend({
       }
 
       for (i = 0; i < queue.length; i++) {
-        if (this._activeCells[this._cellCoordsToKey(queue[i])]) {
+        var _key = this._cellCoordsToKey(queue[i]);
+        var _coords = this._keyToCellCoords(_key);
+        if (this._activeCells[_coords]) {
           this._reuseCell(queue[i]);
         } else {
           this._createCell(queue[i]);

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -502,7 +502,6 @@ export var FeatureManager = FeatureGrid.extend({
   _handleZoomChange: function () {
     if (!this._visibleZoom()) {
       this.removeLayers(this._currentSnapshot);
-      this._currentSnapshot = [];
     } else {
       /*
       for every cell in this._cells

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -307,7 +307,7 @@ export var FeatureManager = FeatureGrid.extend({
       pendingRequests++;
       var coords = this._keyToCellCoords(key);
       var bounds = this._cellCoordsToBounds(coords);
-      this._requestFeatures(bounds, key, requestCallback);
+      this._requestFeatures(bounds, coords, requestCallback);
     }
 
     return this;
@@ -353,7 +353,7 @@ export var FeatureManager = FeatureGrid.extend({
         pendingRequests++;
         var coords = this._keyToCellCoords(key);
         var bounds = this._cellCoordsToBounds(coords);
-        this._requestFeatures(bounds, key, requestCallback);
+        this._requestFeatures(bounds, coords, requestCallback);
       }
     }
 
@@ -364,7 +364,7 @@ export var FeatureManager = FeatureGrid.extend({
     for (var key in this._cells) {
       var coords = this._keyToCellCoords(key);
       var bounds = this._cellCoordsToBounds(coords);
-      this._requestFeatures(bounds, key);
+      this._requestFeatures(bounds, coords);
     }
 
     if (this.redraw) {


### PR DESCRIPTION
The behavior in #1207 is happening because the first time the layer is hidden due to the maxZoom, [`this._currentSnapshot` is emptied](https://github.com/Esri/esri-leaflet/blob/0e89c5e12e4387a22510a4bee628126298482413/src/Layers/FeatureLayer/FeatureManager.js#L505), so the [next time it tries to hide the layers](https://github.com/Esri/esri-leaflet/blob/0e89c5e12e4387a22510a4bee628126298482413/src/Layers/FeatureLayer/FeatureManager.js#L504), `this._currentSnapshot` is empty so it does not remove anything.

The bug is fixed if you remove that line (this PR), but I'm not quite convinced this is the correct fix because I'm guessing there's some side-effect that requires that line, and I'm just not understanding it - @patrickarlt @jgravois please let me know if you have any insights into why this line (`this._currentSnapshot = [];`) was [originally included](https://github.com/Esri/esri-leaflet/commit/4bffb46e44fe1e809645361299a40f16a4d483ec#diff-b59294fc1c59924a39c0eb1607d4cc9cR74).

![bug fixed](https://user-images.githubusercontent.com/209355/87082631-d9f6f480-c21a-11ea-8a55-7ceab3c8f85f.gif)

