### PR TITLE
test for proxy with ImageMapLayer

### DIFF
--- a/spec/Layers/DynamicMapLayerSpec.js
+++ b/spec/Layers/DynamicMapLayerSpec.js
@@ -389,7 +389,7 @@ describe('L.esri.DynamicMapLayer', function () {
     expect(spy.getCall(0).args[0]).to.match(new RegExp(/http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockMapService\/MapServer\/export\?bbox=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&size=500%2C500&dpi=96&format=png32&transparent=true&bboxSR=3857&imageSR=3857&token=foo&f=image/));
   });
 
-  it('should be able to request an image using a proxy', function () {
+  it('should be able to request json using a proxy', function () {
     var imageUrl = 'http://services.arcgis.com/mock/arcgis/rest/directories/arcgisoutput/Census_MapServer/_ags_mapec70f175eca3415a97c0db6779ad9976.png';
     server.respondWith('GET', new RegExp(/\.\/proxy.ashx\?http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockMapService\/MapServer\/export\?bbox=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&size=500%2C500&dpi=96&format=png32&transparent=true&bboxSR=3857&imageSR=3857&proxy=\.%2Fproxy.ashx&f=json/), JSON.stringify({
       href: imageUrl,

--- a/spec/Layers/FeatureLayer/FeatureManagerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureManagerSpec.js
@@ -429,7 +429,7 @@ describe('L.esri.FeatureManager', function () {
     layer.addTo(map);
 
     server.respond();
-    console.log(1, server.lastRequest.url);
+    // console.log(1, server.lastRequest.url);
 
     expect(layer.createLayers).to.have.been.calledWith([
       {
@@ -464,7 +464,7 @@ describe('L.esri.FeatureManager', function () {
     );
 
     server.respond();
-    console.log(2, server.lastRequest.url);
+    // console.log(2, server.lastRequest.url);
     expect(layer.removeLayers).to.have.been.calledWith([1]);
 
     expect(layer.createLayers).to.have.been.calledWith([

--- a/spec/Layers/ImageMapLayerSpec.js
+++ b/spec/Layers/ImageMapLayerSpec.js
@@ -493,5 +493,23 @@ describe('L.esri.ImageMapLayer', function () {
     layer.addTo(map);
     server.respond();
   });
+
+  it('should be able to request json using a proxy', function () {
+    var imageUrl = 'http://services.arcgis.com/mock/arcgis/rest/directories/arcgisoutput/Census_MapServer/_ags_mapec70f175eca3415a97c0db6779ad9976.png';
+    server.respondWith('GET', new RegExp(/\.\/proxy.ashx\?http:\/\/services.arcgis.com\/mock\/arcgis\/rest\/services\/MockImageService\/ImageServer\/exportImage\?bbox=-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+%2C-?\d+\.\d+&size=500%2C500&format=jpgpng&transparent=true&bboxSR=3857&imageSR=3857&f=json/), JSON.stringify({
+      href: imageUrl
+    }));
+
+    layer = L.esri.imageMapLayer({
+      url: url,
+      f: 'json',
+      proxy: './proxy.ashx'
+    });
+    var spy = sinon.spy(layer, '_renderImage');
+
+    layer.addTo(map);
+    server.respond();
+    expect(spy.getCall(0).args[0]).to.equal('./proxy.ashx?' + imageUrl);
+  });
 });
 /* eslint-enable handle-callback-err */


### PR DESCRIPTION
completes the `ImageMapLayer > proxy support > f: 'json' and proxy has unit test` checkbox of #1184 