### PR TITLE
remove attribution logic

### DIFF
--- a/src/Layers/BasemapLayer.js
+++ b/src/Layers/BasemapLayer.js
@@ -2,6 +2,7 @@ import { TileLayer, Util } from 'leaflet';
 import { pointerEvents } from '../Support';
 import {
   setEsriAttribution,
+  removeEsriAttribution,
   _getAttributionData,
   _updateMapAttribution
 } from '../Util';
@@ -251,6 +252,8 @@ export var BasemapLayer = TileLayer.extend({
   },
 
   onRemove: function (map) {
+    removeEsriAttribution(map);
+
     map.off('moveend', _updateMapAttribution);
 
     TileLayer.prototype.onRemove.call(this, map);

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -1,6 +1,6 @@
 import { Util } from 'leaflet';
 import featureLayerService from '../../Services/FeatureLayerService';
-import { getUrlParams, warn, setEsriAttribution } from '../../Util';
+import { getUrlParams, warn, setEsriAttribution, removeEsriAttribution } from '../../Util';
 import { FeatureGrid } from './FeatureGrid';
 import BinarySearchIndex from 'tiny-binary-search';
 
@@ -111,6 +111,7 @@ export var FeatureManager = FeatureGrid.extend({
   },
 
   onRemove: function (map) {
+    removeEsriAttribution(map);
     map.off('zoomend', this._handleZoomChange, this);
 
     return FeatureGrid.prototype.onRemove.call(this, map);

--- a/src/Layers/RasterLayer.js
+++ b/src/Layers/RasterLayer.js
@@ -1,6 +1,6 @@
 import { ImageOverlay, CRS, DomUtil, Util, Layer, popup, latLng, bounds } from 'leaflet';
 import { cors } from '../Support';
-import { setEsriAttribution } from '../Util';
+import { setEsriAttribution, removeEsriAttribution } from '../Util';
 
 var Overlay = ImageOverlay.extend({
   onAdd: function (map) {
@@ -65,6 +65,8 @@ export var RasterLayer = Layer.extend({
   },
 
   onRemove: function (map) {
+    removeEsriAttribution(map);
+
     if (this._currentImage) {
       this._map.removeLayer(this._currentImage);
     }

--- a/src/Layers/TiledMapLayer.js
+++ b/src/Layers/TiledMapLayer.js
@@ -1,5 +1,5 @@
 import { CRS, DomEvent, TileLayer, Util } from 'leaflet';
-import { warn, getUrlParams, setEsriAttribution } from '../Util';
+import { warn, getUrlParams, setEsriAttribution, removeEsriAttribution } from '../Util';
 import mapService from '../Services/MapService';
 
 export var TiledMapLayer = TileLayer.extend({
@@ -151,6 +151,10 @@ export var TiledMapLayer = TileLayer.extend({
     }
 
     TileLayer.prototype.onAdd.call(this, map);
+  },
+
+  onRemove: function (map) {
+    removeEsriAttribution(map);
   },
 
   metadata: function (callback, context) {


### PR DESCRIPTION
This is a follow-up to #841 where we added the logic to _add_ the attribution, but did not add the logic to _remove_ the attribution string:
- Track how many esri-leaflet layers are on the map (stored as in integer in `attributionControl._esriAttributionLayerCount`)
- using the count from `attributionControl._esriAttributionLayerCount`, remove the "Powered by Esri" attribution when all the esri-leaflet layers have been removed from the map

#1239 