### PR TITLE
1256-onRemove-prototype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- Ensure that `TileMapLayer` will complete its `onRemove` prototype logic after removing its attribution. ([#1256](https://github.com/Esri/esri-leaflet/issues/1256))
+
 ## [3.0.0] - 2021-01-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Ensure that `TileMapLayer` will complete its `onRemove` prototype logic after removing its attribution. ([#1256](https://github.com/Esri/esri-leaflet/issues/1256))
+- Ensure that `TiledMapLayer` will complete its `onRemove` prototype logic after removing its attribution. ([#1256](https://github.com/Esri/esri-leaflet/issues/1256))
 
 ## [3.0.0] - 2021-01-25
 

--- a/src/Layers/TiledMapLayer.js
+++ b/src/Layers/TiledMapLayer.js
@@ -155,6 +155,8 @@ export var TiledMapLayer = TileLayer.extend({
 
   onRemove: function (map) {
     removeEsriAttribution(map);
+
+    TileLayer.prototype.onRemove.call(this, map);
   },
 
   metadata: function (callback, context) {


### PR DESCRIPTION
Fixes #1256. The `TiledMapLayer` needed to call its `onRemove` prototype logic to complete being removed from the map.

Borrowing from the jsfiddle repro code in the original issue, below is a sample debug page to test this out.

I added a `DynamicMapLayer` instance to make sure that the underlying `RasterLayer.js` was removing itself correctly, which it is.

<details><summary>sample code</summary>

```html
<!DOCTYPE html>
<html>

<head>
  <meta charset="utf-8" />
  <title>Esri Leaflet Debugging Sample</title>
  <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />

  <!-- Load Leaflet -->
  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css" integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ==" crossorigin="" />

  <!-- Make sure you put this AFTER Leaflet's CSS -->
  <script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js" integrity="sha512-gZwIG9x3wUXg2hdXF6+rVkLF/0Vi9U8D2Ntg4Ga5I5BZpVkVxlJWbSQtXPSiUTtC0TjtGOmxa1AJPuV0CPthew==" crossorigin=""></script>

  <!-- Load Esri Leaflet from source-->
  <script src="../dist/esri-leaflet-debug.js"></script>

  <style>
  </style>
</head>

<body>
  <div id="map" style="width: 300px; height: 300px;">

  </div>
  <button type="button" onClick="javascript:removeTiledMapLayer()">
    Remove tiled map layer (to test `TiledMapLayer.js`)
  </button>
  <button type="button" onClick="javascript:removeDynamicLayer()">
    Remove dynamic map layer (to test `RasterLayer.js`)
  </button>
  <button type="button" onClick="javascript:removeAllLayers()">
    Remove all layers
  </button>
  <button type="button" onClick="javascript:printLayers()">
    Print layers
  </button>

  <script>
    const map = L.map('map').setView([40, -90], 3);

    L.esri.basemapLayer('Physical').addTo(map);

    const tiledMapLayer = L.esri.tiledMapLayer({
      url: 'https://services.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer',
      opacity: 0.7
    });
    tiledMapLayer.addTo(map);

    const dynamicMapLayer = L.esri.dynamicMapLayer({
      url: 'https://services.arcgisonline.com/arcgis/rest/services/Specialty/Soil_Survey_Map/MapServer',
      opacity: 0.7
    });
    dynamicMapLayer.addTo(map);

    function removeTiledMapLayer() {
      map.removeLayer(tiledMapLayer);
    }

    function removeDynamicLayer() {
      map.removeLayer(dynamicMapLayer);
    }

    function removeAllLayers() {
      map.eachLayer(l => map.removeLayer(l));
    }

    function printLayers() {
      let content = "";
      map.eachLayer(l => content = content + l._url + '\n');
      console.log(content);
    }
  </script>
</body>

</html>
```

</details>