### PR TITLE
Disregard stale DynamicMapLayer updates

### DIFF
--- a/src/Layers/DynamicMapLayer.js
+++ b/src/Layers/DynamicMapLayer.js
@@ -173,6 +173,8 @@ export var DynamicMapLayer = RasterLayer.extend({
   _requestExport: function (params, bounds) {
     if (this.options.f === 'json') {
       this.service.request('export', params, function (error, response) {
+        if(this.latestRequestParams !== params) { return; }
+
         if (error) { return; } // we really can't do anything here but authenticate or requesterror will fire
 
         if (this.options.token && response.href) {

--- a/src/Layers/RasterLayer.js
+++ b/src/Layers/RasterLayer.js
@@ -295,7 +295,7 @@ export var RasterLayer = Layer.extend({
 
     var params = this._buildExportParams();
     Util.extend(params, this.options.requestParams);
-
+    this.latestRequestParams = params
     if (params) {
       this._requestExport(params, bounds);
 


### PR DESCRIPTION
Alleviates #749  by not updating layer with image for a set of params which have changed while request was in flight.

This isn't the most elegant solution; I'm very open to feedback 😁 