### PR TITLE
fix: Use default export from package instead of named export version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+### Fixed
+
+- Do not use named exports from JSON ([info](https://webpack.js.org/migrate/5/#cleanup-the-code)) (🙏destus90🙏 [#1273](https://github.com/Esri/esri-leaflet/pull/1273))
+
 ## [3.0.1] - 2021-02-23
 
 ### Fixed

--- a/src/EsriLeaflet.js
+++ b/src/EsriLeaflet.js
@@ -1,7 +1,7 @@
 // export version
 import packageInfo from '../package.json';
 var version = packageInfo.version;
-export {version as VERSION};
+export { version as VERSION };
 
 // import base
 export { Support } from './Support';

--- a/src/EsriLeaflet.js
+++ b/src/EsriLeaflet.js
@@ -1,5 +1,7 @@
 // export version
-export {version as VERSION} from '../package.json';
+import packageInfo from '../package.json';
+var version = packageInfo.version;
+export {version as VERSION};
 
 // import base
 export { Support } from './Support';


### PR DESCRIPTION
https://webpack.js.org/migrate/5/#cleanup-the-code

> Using named exports from JSON modules: this is not supported by the new specification and you will get a warning. Instead of import { version } from './package.json' use import package from './package.json'; const { version } = package;

With this fix allow to use Webpack 5 with no warning emitted.

Fixes https://github.com/Esri/esri-leaflet/issues/1249