### PR TITLE
added deprecation notice (warning) to BasemapLayer

### DIFF
--- a/src/Layers/BasemapLayer.js
+++ b/src/Layers/BasemapLayer.js
@@ -223,6 +223,11 @@ export var BasemapLayer = TileLayer.extend({
 
     Util.setOptions(this, tileOptions);
 
+    // Deprecation notice:
+    if(!this.options.ignoreDeprecationWarning) {
+      console.warn('WARNING: L.esri.BasemapLayer uses data services that are in mature support and are not being updated. Please use L.esri.Vector.vectorBasemapLayer instead. More info: https://esriurl.com/TODO');
+    }
+
     if (this.options.token && config.urlTemplate.indexOf('token=') === -1) {
       config.urlTemplate += ('?token=' + this.options.token);
     }

--- a/src/Layers/BasemapLayer.js
+++ b/src/Layers/BasemapLayer.js
@@ -225,7 +225,7 @@ export var BasemapLayer = TileLayer.extend({
 
     // Deprecation notice:
     if(!this.options.ignoreDeprecationWarning) {
-      console.warn('WARNING: L.esri.BasemapLayer uses data services that are in mature support and are not being updated. Please use L.esri.Vector.vectorBasemapLayer instead. More info: https://esriurl.com/TODO');
+      console.warn('WARNING: L.esri.BasemapLayer uses data services that are in mature support and are not being updated. Please use L.esri.Vector.vectorBasemapLayer instead. More info: https://esriurl.com/esri-leaflet-basemap');
     }
 
     if (this.options.token && config.urlTemplate.indexOf('token=') === -1) {


### PR DESCRIPTION
Adds a warning when using BasemapLayer:

![image](https://user-images.githubusercontent.com/209355/134355562-c77ccca9-d5a8-42ba-bd43-781e91e0f366.png)

This warning can be supressed/disabled by setting a new option property,  `ignoreDeprecationWarning`, to true:

```
L.esri.basemapLayer("Topographic", {
  ignoreDeprecationWarning: true
}).addTo(map);
```