### PR TITLE
Fix #1228 safari partially rendering

### DIFF
--- a/src/Layers/RasterLayer.js
+++ b/src/Layers/RasterLayer.js
@@ -209,6 +209,11 @@ export var RasterLayer = Layer.extend({
         interactive: this.options.interactive
       }).addTo(this._map);
 
+      // See issue 1228 (https://github.com/Esri/esri-leaflet/issues/1228)
+      // Safari sometimes only partially renders imgs with decoding = sync (safari default)
+      // To enforce full rendering of img use decoding = async
+      image._image.decoding = 'async';
+
       var onOverlayError = function () {
         this._map.removeLayer(image);
         this.fire('error');


### PR DESCRIPTION
### Problem
See issue 1228 (https://github.com/Esri/esri-leaflet/issues/1228)
Safari sometimes only partially renders the image layer. 

### Solution
The bug is related to the leaflet library. 
Safari seems to have problems decoding too many images in main thread. 
I would suggest leaflet maintainers to switch from img to canvas to avoid such decoding problems.

In the meantime setting the img.decoding attribute to "async" will fix the bug and ensures full rendering of the layer image.

Stackblitz with bugfix: https://stackblitz.com/edit/web-platform-dmw9yg?file=esri-leaflet-debug.js