### PR TITLE
Fix FeatureLayer.refresh for moved point layers

### DIFF
--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -133,7 +133,6 @@ export var FeatureLayer = FeatureManager.extend({
       // update geometry if the layer already existed.
       if (layer && (layer.setLatLngs || layer.setLatLng)) {
         this._updateLayer(layer, geojson);
-        this.redraw(geojson.id);
       }
 
       if (!layer) {

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -127,12 +127,8 @@ export var FeatureLayer = FeatureManager.extend({
         );
       }
 
-      // update geometry if necessary
-      if (
-        layer &&
-        this.options.simplifyFactor > 0 &&
-        (layer.setLatLngs || layer.setLatLng)
-      ) {
+      // update geometry if the layer already existed.
+      if (layer && (layer.setLatLngs || layer.setLatLng)) {
         this._updateLayer(layer, geojson);
       }
 

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -133,6 +133,7 @@ export var FeatureLayer = FeatureManager.extend({
       // update geometry if the layer already existed.
       if (layer && (layer.setLatLngs || layer.setLatLng)) {
         this._updateLayer(layer, geojson);
+        this.redraw(geojson.id);
       }
 
       if (!layer) {

--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -98,6 +98,9 @@ export var FeatureLayer = FeatureManager.extend({
         layer.setLatLngs(latlngs);
         break;
     }
+
+    // update symbol/style
+    this.redraw(layer.feature.id);
   },
 
   /**


### PR DESCRIPTION
This fixes `FeatureLayer.refresh()` for layers where `simplifyFactor` is not set. Originally this was intended to update the geometry when a higher resolution geometry came in from the service but it also means that layers with edited geometries were missed by `FeatureLayer.refresh()`

Can be reproudced with the following HTML in the `debug` folder (originally from @gavinr):

```html
<!-- https://esri.github.io/esri-leaflet/examples/simple-editing.html -->
<!-- Forked from https://codepen.io/jwasilgeo/pen/KKXVjvy?editors=1000 -->
<!DOCTYPE html>
<html>

<head>
  <meta charset="utf-8" />
  <title>Editing feature layers</title>
  <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />

  <!-- Load Leaflet from CDN -->
  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
  <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>

  <!-- Load Esri Leaflet from source-->
  <script src="../dist/esri-leaflet-debug.js"></script>

  <style>
    body {
      margin: 0;
      padding: 0;
    }

    #map {
      position: absolute;
      top: 150px;
      bottom: 0;
      right: 0;
      left: 0;
    }
  </style>
</head>

<body>

  <!-- Leaflet Draw -->
  <style>
    #info-pane {
      z-index: 400;
      padding: 1em;
      background: white;
      text-align: right;
    }

    #form {
      display: none;
    }
  </style>

  <div id="map"></div>
  <div id="info-pane" class="leaflet-bar" style="font-size: 10px">
    These do not use the Leaflet or Esri Leaflet add/edit funcitonality. They call the REST endpoints using FETCH
    directly:<br />
    <button id="addFeatureButton">ADD a feature within the current extent</button><br />
    <button id="moveFeatureButton">MOVE one of the features within the current extent</button>
    <br /><br />
    This DOES call the leaflet layer.refresh() function:<br />
    <button id="refreshLayerButton">Refresh the layer</button>
  </div>

  <script>
    // create the map
    var map = L.map('map').setView([38.631, -90.199], 8);
    // basemap
    var OpenStreetMap_Mapnik = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
      maxZoom: 19,
      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
    });
    OpenStreetMap_Mapnik.addTo(map);
    // add our feature layer to the map
    const militaryOps = L.esri.featureLayer({
      url: 'https://sampleserver6.arcgisonline.com/arcgis/rest/services/Military/FeatureServer/3'
    }).addTo(map);

    const addFeatureButton = document.querySelector("#addFeatureButton");
    const moveFeatureButton = document.querySelector("#moveFeatureButton");
    const refreshLayerButton = document.querySelector("#refreshLayerButton");
    addFeatureButton.addEventListener("click", () => {
      const latlng = getRandomPointWithinCurrentExtent(map);
      const feat = L.marker(latlng).toGeoJSON();
      // set the attribute value that controls the feature service symbology
      feat.properties.symbolname = "Decision Point";
      fetch(`${militaryOps.options.url}/addFeatures`, {
        "headers": {
          "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
        },
        "body": `features=${JSON.stringify([L.esri.Util.geojsonToArcGIS(feat)])}&f=json`,
        "method": "POST",
        "mode": "cors"
      })
        .then(res => res.json())
        .then(res => {
          console.log(res);
          // militaryOps.refresh();
        });
    });

    moveFeatureButton.addEventListener("click", () => {
      console.log('move', map.getPanes()[militaryOps.options.pane]);
      const latlng = getRandomPointWithinCurrentExtent(map);
      console.log("latlng", latlng);

      let feat = {};
      militaryOps.eachActiveFeature((feature) => {
        feat.attributes = {};
        feat.attributes.OBJECTID = feature.feature.id
        feat.geometry = { "spatialReference": { "wkid": 4326 } };

        feat.geometry.x = latlng.lng;
        feat.geometry.y = latlng.lat;
      });

      console.log('sending:', feat);
      // const latlng = getRandomPointWithinCurrentExtent(map);
      // const feat = L.marker(latlng).toGeoJSON();
      // // set the attribute value that controls the feature service symbology
      // feat.properties.symbolname = "Decision Point";
      fetch(`${militaryOps.options.url}/updateFeatures`, {
        "headers": {
          "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
        },
        "body": `features=${JSON.stringify([feat])}&f=json`,
        "method": "POST",
        "mode": "cors"
      })
        .then(res => res.json())
        .then(res => {
          console.log(res);
          // militaryOps.refresh();
        });
    });

    refreshLayerButton.addEventListener("click", () => {
      militaryOps.refresh();
    });

    function randomIntFromInterval(min, max) { // min and max included 
      return Math.random() * (max - min) + min;
    }
    const getRandomPointWithinCurrentExtent = (map) => {
      const bounds = map.getBounds();
      var lng = randomIntFromInterval(bounds.getEast(), bounds.getWest()).toFixed(5);
      var lat = randomIntFromInterval(bounds.getSouth(), bounds.getNorth()).toFixed(5);
      return L.latLng(lat, lng);
    }

    // when a marker is clicked, remove the feature from the service, using its id
    militaryOps.on('click', function (e) {
      // militaryOps.deleteFeature(e.layer.feature.id, function(err, response) {
      //   if (err) {
      //     return;
      //   }
      //   console.log(response);
      // });
      fetch(`${militaryOps.options.url}/deleteFeatures`, {
        "headers": {
          "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
        },
        "body": `objectIds=${e.layer.feature.id}&f=json`,
        "method": "POST",
        "mode": "cors"
      })
        .then(res => res.json())
        .then(res => {
          console.log(res);
          militaryOps.refresh();
        });
      // make sure map click event isn't fired.
      L.DomEvent.stopPropagation(e);
    });
  </script>

</body>

</html>
```