### PR TITLE
added siteinfo step to release

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -9,7 +9,7 @@ npm test || exit 1
 
 # Integrity string and save to siteData.json
 JS_INTEGRITY=$(cat dist/esri-leaflet.js | openssl dgst -sha512 -binary | openssl base64 -A)
-echo "{\"name\": \"esri-leaflet\",\"version\": \"$VERSION\",\"lib\": {\"path\": \"dist/esri-leaflet.js\",\"integrity\": \"sha512-$JS_INTEGRITY\"}}" > siteData.json
+echo "{\"name\": \"esri-leaflet\",\"version\": \"$VERSION\",\"lib\": {\"path\": \"dist/esri-leaflet.js\",\"integrity\": \"sha512-$JS_INTEGRITY\"}}" > dist/siteData.json
 
 # checkout temp branch for release
 git checkout -b gh-release

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,6 +7,10 @@ NAME=$(node --eval "console.log(require('./package.json').name);")
 # build and test
 npm test || exit 1
 
+# Integrity string and save to siteData.json
+JS_INTEGRITY=$(cat dist/esri-leaflet.js | openssl dgst -sha512 -binary | openssl base64 -A)
+echo "{\"name\": \"esri-leaflet\",\"version\": \"$VERSION\",\"lib\": {\"path\": \"dist/esri-leaflet.js\",\"integrity\": \"sha512-$JS_INTEGRITY\"}}" > siteData.json
+
 # checkout temp branch for release
 git checkout -b gh-release
 

--- a/siteData.json
+++ b/siteData.json
@@ -1,1 +1,0 @@
-{"name": "esri-leaflet","version": "3.0.4","lib": {"path": "dist/esri-leaflet.js","integrity": "sha512-oUArlxr7VpoY7f/dd3ZdUL7FGOvS79nXVVQhxlg6ij4Fhdc4QID43LUFRs7abwHNJ0EYWijiN5LP2ZRR2PY4hQ=="}}

--- a/siteData.json
+++ b/siteData.json
@@ -1,0 +1,1 @@
+{"name": "esri-leaflet","version": "3.0.4","lib": {"path": "dist/esri-leaflet.js","integrity": "sha512-oUArlxr7VpoY7f/dd3ZdUL7FGOvS79nXVVQhxlg6ij4Fhdc4QID43LUFRs7abwHNJ0EYWijiN5LP2ZRR2PY4hQ=="}}


### PR DESCRIPTION
Adds an additional step to the release bash script that generates the ssri integrity string and saves it (and the lib version number) into a JSON file in the root of the repository (`siteData.json`). This is generating the integrity string based on the built file on disk (as opposed to reading it from NPM) for the security/integrity of the process.

We will do a similar thing in all the related repositories (`esri-leaflet-geocoder`, `esri-leaflet-vector`, etc) so that it will replace the functionality that https://github.com/Esri/esri-leaflet-doc/blob/master/data/integrity.js is currently providing. 

I got the command from [MDN: Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity#tools_for_generating_sri_hashes). It does require OpenSSL to be installed on the build machine but I think that's fairly common/standard. 