### PR TITLE
update npm release process

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "build": "rollup -c profiles/debug.js & rollup -c profiles/production.js",
     "lint": "semistandard | snazzy",
     "prebuild": "mkdirp dist",
-    "prepare": "npm run build",
     "pretest": "npm run build",
     "precommit": "npm run lint",
     "fix": "semistandard --fix",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -29,10 +29,10 @@ zip -r $NAME-v$VERSION.zip dist
 # run gh-release to create the tag and push release to github
 gh-release --assets $NAME-v$VERSION.zip
 
+# publish release on NPM
+npm publish
+
 # checkout master and delete release branch locally and on GitHub
 git checkout master
 git branch -D gh-release
 git push https://github.com/Esri/esri-leaflet :gh-release
-
-# publish release on NPM
-npm publish


### PR DESCRIPTION
In today's builds, `siteData.json` is still [not getting published to npm](https://unpkg.com/browse/esri-leaflet@3.0.6/dist/). 

This is because we have an issue with our release process: right now, `release.sh` generates the dist files [on line 8](https://github.com/Esri/esri-leaflet/blob/6a8b7db704e3086b8b25dbd2d46bcd4d8f6b35a4/scripts/release.sh#L8) when `npm test` runs. Then later when [`npm publish` runs](https://github.com/Esri/esri-leaflet/blob/6a8b7db704e3086b8b25dbd2d46bcd4d8f6b35a4/scripts/release.sh#L38), [`npm prepare` runs as part of that](https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts), which [runs `npm run build`](https://github.com/Esri/esri-leaflet/blob/6a8b7db704e3086b8b25dbd2d46bcd4d8f6b35a4/package.json#L85), _re-building the dist files_. I think this is unnecessary and causing `siteData.json` to not be included in the npm release.

So, this PR changes it so that when publishing, do not use "prepare" script to re-build the dist files, just use the files that are there from earlier in `release.sh` when it ran `npm test`.