### PR TITLE
fix warning in Leaflet 1.8.0

### DIFF
--- a/src/Layers/RasterLayer.js
+++ b/src/Layers/RasterLayer.js
@@ -216,7 +216,7 @@ export var RasterLayer = Layer.extend({
       };
 
       var onOverlayLoad = function (e) {
-        image.off('error', onOverlayLoad, this);
+        image.off('error', onOverlayError, this);
         if (this._map) {
           var newImage = e.target;
           var oldImage = this._currentImage;


### PR DESCRIPTION
When an overlay loads we should remove the error handler not the already removed load handler.