### PR TITLE
Documentation issue type

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,23 @@
+name: "Documentation"
+description: Suggest an idea or report an issue with the documentation site, https://developers.arcgis.com/esri-leaflet
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to submit your feedback!
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Please provide a clear and concise description the idea or issue. The more information you can provide here, the better.
+      placeholder: I'd like to add a sample that does ...
+    validations:
+      required: true
+  - type: input
+    id: link
+    attributes:
+      label: Link to page
+      description: Please provide the URL to the associated documentation page, if applicable.
+      placeholder: e.g. https://developers.arcgis.com/esri-leaflet/samples/visualize-points-as-a-heatmap/
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,5 +1,6 @@
 name: "Documentation"
 description: Suggest an idea or report an issue with the documentation site, https://developers.arcgis.com/esri-leaflet
+labels: [Documentation]
 body:
   - type: markdown
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,9 +20,9 @@ If you think you're encountering a new bug, please feel free to log an [issue](h
 
 There is a lot of room for contributions to Esri Leaflet. Make sure you check out the [development instructions](https://github.com/Esri/esri-leaflet#development-instructions) in the readme to help you get started.
 
-##### More examples
+##### More samples
 
-The Esri Leaflet website is written using [Assemble](https://assemble.io/) and can be found at [esri-leaflet-doc](https://github.com/Esri/esri-leaflet-doc/tree/master/src). You can use the existing examples as a reference.
+If you'd like to add an additional sample to the Esri Leaflet documentation, [let us know by creating an issue in this repository](https://github.com/Esri/esri-leaflet/issues/new?assignees=&labels=Documentation&template=documentation.yml).
 
 ##### More tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Esri welcomes contributions from anyone and everyone. Please see our [guidelines
 
 Please take a look at [previous issues](https://github.com/Esri/esri-leaflet/issues?labels=FAQ&milestone=&page=1&state=closed) that resolve common problems.
 
-If you're just looking for help, you'll probably attract the most eyes if you post in [GIS Stackexchange](http://gis.stackexchange.com/questions/ask?tags=esri-leaflet,leaflet) or the [Esri Leaflet place](https://geonet.esri.com/discussion/create.jspa?sr=pmenu&containerID=1841&containerType=700&tags=esri-leaflet,leaflet) on GeoNet.
+If you're just looking for help, you'll probably attract the most eyes if you post in [GIS Stackexchange](http://gis.stackexchange.com/questions/ask?tags=esri-leaflet,leaflet) or the [Esri Leaflet Community](https://community.esri.com/t5/esri-leaflet/ct-p/esri-leaflet) on GeoNet.
 
 If you think you're encountering a new bug, please feel free to log an [issue](https://github.com/Esri/esri-leaflet/issues/new) and include the steps to reproduce the problem (and preferably a running sample).
 
@@ -26,7 +26,7 @@ The Esri Leaflet website is written using [Assemble](https://assemble.io/) and c
 
 ##### More tests
 
-Esri Leaflet has a fairly comprehensive test suite built with [Mocha](http://mochajs.org/), [Chai](http://chaijs.com/), [Sinon](http://sinonjs.org), and [Karma](http://karma-runner.github.io/0.12/index.html). The tests can be found in the [`master/spec` folder](https://github.com/Esri/esri-leaflet/tree/master/spec).
+Esri Leaflet has a fairly comprehensive test suite built with [Mocha](https://mochajs.org/), [Chai](https://www.chaijs.com/), [Sinon](https://sinonjs.org/), and [Karma](https://karma-runner.github.io/). The tests can be found in the [`spec` folder](https://github.com/Esri/esri-leaflet/tree/master/spec).
 
 You can run the tests with `npm test`.
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ Support for [Geocoding](https://github.com/Esri/esri-leaflet-geocoder) services 
 ## Table of Contents
 
 - [Getting Started](#getting-started)
-  - [Demos](#demos)
   - [Quick Start](#quick-start)
-  - [API Reference](#api-reference)
+  - [Samples, Tutorials, and API Reference](#samples-tutorials-and-api-reference)
   - [Additional Plugins](#additional-plugins)
   - [Frequently Asked Questions](#frequently-asked-questions)
   - [Issues](#issues)
@@ -40,20 +39,17 @@ Support for [Geocoding](https://github.com/Esri/esri-leaflet-geocoder) services 
 - [Credit](#credit)
 - [License](#license)
 
-## Demos
-We've shared lots of sample code showing off many of the features of Esri Leaflet.
-
-https://developers.arcgis.com/esri-leaflet/samples/
-
 ## Quick Start
 The easiest way to get started is to load Esri Leaflet via [CDN](https://unpkg.com/esri-leaflet). Here is an example you can copy/paste into your own `.html` file: [Esri Leaflet Quick Start](https://developers.arcgis.com/esri-leaflet/get-started/)
 
 [![App](https://raw.github.com/Esri/esri-leaflet/master/example.png)](https://developers.arcgis.com/esri-leaflet/samples/)
 
 
-## [API Reference](https://developers.arcgis.com/esri-leaflet/api-reference/)
+## [Samples, Tutorials, and API Reference](https://developers.arcgis.com/esri-leaflet/)
 
-The source code for our documentation site can be found [here](https://github.com/Esri/esri-leaflet-doc). If you notice a typo or other problem, _please_ [let us know](https://github.com/Esri/esri-leaflet-doc/issues)!
+[Samples](https://developers.arcgis.com/esri-leaflet/samples/), [tutorials](https://developers.arcgis.com/esri-leaflet/tutorials/), and the [API reference](https://developers.arcgis.com/esri-leaflet/api-reference/) can be found at [developers.arcgis.com/esri-leaflet](https://developers.arcgis.com/esri-leaflet/).
+
+If you notice any issues or would like to propose a change to the documentation, _please_ [let us know by creating an issue in this repository](https://github.com/Esri/esri-leaflet/issues/new?assignees=&labels=Documentation&template=documentation.yml).
 
 ## Additional Plugins
 


### PR DESCRIPTION
Adding a documentation issue type. This will add a new entry when someone clicks the "New Issue" button in this GitHub repository:

![image](https://user-images.githubusercontent.com/209355/163587194-4d4f716b-b228-4ef4-9109-68df819e63a9.png)

Also:

- Updated the `README.md` and `CONTRIBUTING.md` to point to this issue type for documentation issues.
- Consolidated the "demos" and "API Reference" section of the README into a single, documentation-focused section.

Resolves https://github.com/Esri/esri-leaflet-doc/issues/325