### PR TITLE
Fix toLatLngBounds was not found in 'leaflet'

### DIFF
--- a/src/Layers/FeatureLayer/FeatureGrid.js
+++ b/src/Layers/FeatureLayer/FeatureGrid.js
@@ -1,6 +1,6 @@
 import {
   LatLngBounds,
-  toLatLngBounds as latLngBounds,
+  latLngBounds,
   Layer,
   Browser,
   Util,


### PR DESCRIPTION
export 'toLatLngBounds' (imported as 'latLngBounds') was not found in 'leaflet'