### PR TITLE
Fix performance issue with refreshing features

### DIFF
--- a/src/Layers/FeatureLayer/FeatureLayer.js
+++ b/src/Layers/FeatureLayer/FeatureLayer.js
@@ -407,7 +407,7 @@ export var FeatureLayer = FeatureManager.extend({
 
     // looks like a path (polygon/polyline)
     if (layer && layer.setStyle && this.options.style) {
-      this.resetStyle(geojson.id);
+      this.resetFeatureStyle(geojson.id);
     }
   }
 });


### PR DESCRIPTION
This should resolve #1340 which is a result of an error I made in #1304.

1. In #1304 I added a call to `redraw`.
2. Internally this eventually called [`resetStyle`](https://github.com/Esri/esri-leaflet/blob/master/src/Layers/FeatureLayer/FeatureLayer.js#L410)
3. `resetStyle` calls `resetFeatureStyle` on every feature in the layer. This ends up causing a huge amount of extra calls since it calls since the happens `N * N` times.

This PR simply changes this to call `resetFeatureStyle` directly for the specific feature.