### PR TITLE
src/Util.js - custom Leaflet prefix support

### DIFF
--- a/spec/Layers/BasemapLayerSpec.js
+++ b/spec/Layers/BasemapLayerSpec.js
@@ -110,6 +110,29 @@ describe('L.esri.BasemapLayer', function () {
     expect(L.esri.basemapLayer('Topographic')).to.be.instanceof(L.esri.BasemapLayer);
   });
 
+  it('should have correct attribution when attribution is set BEFORE adding the layer to the map', function () {
+    map.attributionControl.setPrefix("ccc");
+    const layer = L.esri.basemapLayer("Topographic");
+    layer.addTo(map);
+      expect(map.attributionControl.options.prefix).to.equal('ccc | Powered by <a href="https://www.esri.com">Esri</a>');
+  });
+
+  it('should have correct attribution when attribution is set AFTER adding the layer to the map', function () {
+    const layer = L.esri.basemapLayer("Topographic");
+    layer.addTo(map);
+      map.attributionControl.setPrefix("ddd");
+      expect(map.attributionControl.options.prefix).to.equal('ddd | Powered by <a href="https://www.esri.com">Esri</a>');
+  });
+
+  it('should remove the attribution when the layer is removed from the map', function () {
+    map.attributionControl.setPrefix("aaa");
+    const layer = L.esri.basemapLayer("Topographic");
+    layer.addTo(map);
+    expect(map.attributionControl.options.prefix).to.equal('aaa | Powered by <a href="https://www.esri.com">Esri</a>');
+    map.removeLayer(layer);
+    expect(map.attributionControl.options.prefix).to.equal('aaa');
+  });
+
   // /*
   // need to figure out how to wire up the mockAttributions to
   // test display when map is panned beyond the dateline

--- a/spec/Layers/BasemapLayerSpec.js
+++ b/spec/Layers/BasemapLayerSpec.js
@@ -1,4 +1,6 @@
 /* eslint-env mocha */
+var POWERED_BY_ESRI_ATTRIBUTION_STRING = 'Powered by <a href="https://www.esri.com">Esri</a>';
+
 describe('L.esri.BasemapLayer', function () {
   function createMap () {
     // create container
@@ -114,21 +116,21 @@ describe('L.esri.BasemapLayer', function () {
     map.attributionControl.setPrefix('aaa');
     const layer = L.esri.basemapLayer('Topographic');
     layer.addTo(map);
-    expect(map.attributionControl.options.prefix).to.equal('aaa | Powered by <a href="https://www.esri.com">Esri</a>');
+    expect(map.attributionControl.options.prefix).to.equal('aaa | ' + POWERED_BY_ESRI_ATTRIBUTION_STRING);
   });
 
   it('should have correct attribution when attribution is set AFTER adding the layer to the map', function () {
     const layer = L.esri.basemapLayer('Topographic');
     layer.addTo(map);
     map.attributionControl.setPrefix('bbb');
-    expect(map.attributionControl.options.prefix).to.equal('bbb | Powered by <a href="https://www.esri.com">Esri</a>');
+    expect(map.attributionControl.options.prefix).to.equal('bbb | ' + POWERED_BY_ESRI_ATTRIBUTION_STRING);
   });
 
   it('should remove the attribution when the layer is removed from the map', function () {
     map.attributionControl.setPrefix('ccc');
     const layer = L.esri.basemapLayer('Topographic');
     layer.addTo(map);
-    expect(map.attributionControl.options.prefix).to.equal('ccc | Powered by <a href="https://www.esri.com">Esri</a>');
+    expect(map.attributionControl.options.prefix).to.equal('ccc | ' + POWERED_BY_ESRI_ATTRIBUTION_STRING);
     map.removeLayer(layer);
     expect(map.attributionControl.options.prefix).to.equal('ccc');
   });
@@ -137,7 +139,7 @@ describe('L.esri.BasemapLayer', function () {
     const layer = L.esri.basemapLayer('Topographic');
     layer.addTo(map);
     map.attributionControl.setPrefix('ddd');
-    expect(map.attributionControl.options.prefix).to.equal('ddd | Powered by <a href="https://www.esri.com">Esri</a>');
+    expect(map.attributionControl.options.prefix).to.equal('ddd | ' + POWERED_BY_ESRI_ATTRIBUTION_STRING);
     map.removeLayer(layer);
     expect(map.attributionControl.options.prefix).to.equal('ddd');
   });
@@ -146,7 +148,7 @@ describe('L.esri.BasemapLayer', function () {
     map.attributionControl.setPrefix('');
     const layer = L.esri.basemapLayer('Topographic');
     layer.addTo(map);
-    expect(map.attributionControl.options.prefix).to.equal('Powered by <a href="https://www.esri.com">Esri</a>');
+    expect(map.attributionControl.options.prefix).to.equal(POWERED_BY_ESRI_ATTRIBUTION_STRING);
     map.removeLayer(layer);
     expect(map.attributionControl.options.prefix).to.equal('');
   });

--- a/spec/Layers/BasemapLayerSpec.js
+++ b/spec/Layers/BasemapLayerSpec.js
@@ -111,26 +111,35 @@ describe('L.esri.BasemapLayer', function () {
   });
 
   it('should have correct attribution when attribution is set BEFORE adding the layer to the map', function () {
-    map.attributionControl.setPrefix('ccc');
+    map.attributionControl.setPrefix('aaa');
     const layer = L.esri.basemapLayer('Topographic');
     layer.addTo(map);
-    expect(map.attributionControl.options.prefix).to.equal('ccc | Powered by <a href="https://www.esri.com">Esri</a>');
+    expect(map.attributionControl.options.prefix).to.equal('aaa | Powered by <a href="https://www.esri.com">Esri</a>');
   });
 
   it('should have correct attribution when attribution is set AFTER adding the layer to the map', function () {
     const layer = L.esri.basemapLayer('Topographic');
     layer.addTo(map);
-    map.attributionControl.setPrefix('ddd');
-    expect(map.attributionControl.options.prefix).to.equal('ddd | Powered by <a href="https://www.esri.com">Esri</a>');
+    map.attributionControl.setPrefix('bbb');
+    expect(map.attributionControl.options.prefix).to.equal('bbb | Powered by <a href="https://www.esri.com">Esri</a>');
   });
 
   it('should remove the attribution when the layer is removed from the map', function () {
-    map.attributionControl.setPrefix('aaa');
+    map.attributionControl.setPrefix('ccc');
     const layer = L.esri.basemapLayer('Topographic');
     layer.addTo(map);
-    expect(map.attributionControl.options.prefix).to.equal('aaa | Powered by <a href="https://www.esri.com">Esri</a>');
+    expect(map.attributionControl.options.prefix).to.equal('ccc | Powered by <a href="https://www.esri.com">Esri</a>');
     map.removeLayer(layer);
-    expect(map.attributionControl.options.prefix).to.equal('aaa');
+    expect(map.attributionControl.options.prefix).to.equal('ccc');
+  });
+
+  it('should remove the attribution when the layer is removed from the map (But attribution added after the layer)', function () {
+    const layer = L.esri.basemapLayer('Topographic');
+    layer.addTo(map);
+    map.attributionControl.setPrefix('ddd');
+    expect(map.attributionControl.options.prefix).to.equal('ddd | Powered by <a href="https://www.esri.com">Esri</a>');
+    map.removeLayer(layer);
+    expect(map.attributionControl.options.prefix).to.equal('ddd');
   });
 
   // /*

--- a/spec/Layers/BasemapLayerSpec.js
+++ b/spec/Layers/BasemapLayerSpec.js
@@ -142,6 +142,15 @@ describe('L.esri.BasemapLayer', function () {
     expect(map.attributionControl.options.prefix).to.equal('ddd');
   });
 
+  it('should handle empty attribution prefix similar to tile layer', function () {
+    map.attributionControl.setPrefix('');
+    const layer = L.esri.basemapLayer('Topographic');
+    layer.addTo(map);
+    expect(map.attributionControl.options.prefix).to.equal('Powered by <a href="https://www.esri.com">Esri</a>');
+    map.removeLayer(layer);
+    expect(map.attributionControl.options.prefix).to.equal('');
+  });
+
   // /*
   // need to figure out how to wire up the mockAttributions to
   // test display when map is panned beyond the dateline

--- a/spec/Layers/BasemapLayerSpec.js
+++ b/spec/Layers/BasemapLayerSpec.js
@@ -111,22 +111,22 @@ describe('L.esri.BasemapLayer', function () {
   });
 
   it('should have correct attribution when attribution is set BEFORE adding the layer to the map', function () {
-    map.attributionControl.setPrefix("ccc");
-    const layer = L.esri.basemapLayer("Topographic");
+    map.attributionControl.setPrefix('ccc');
+    const layer = L.esri.basemapLayer('Topographic');
     layer.addTo(map);
-      expect(map.attributionControl.options.prefix).to.equal('ccc | Powered by <a href="https://www.esri.com">Esri</a>');
+    expect(map.attributionControl.options.prefix).to.equal('ccc | Powered by <a href="https://www.esri.com">Esri</a>');
   });
 
   it('should have correct attribution when attribution is set AFTER adding the layer to the map', function () {
-    const layer = L.esri.basemapLayer("Topographic");
+    const layer = L.esri.basemapLayer('Topographic');
     layer.addTo(map);
-      map.attributionControl.setPrefix("ddd");
-      expect(map.attributionControl.options.prefix).to.equal('ddd | Powered by <a href="https://www.esri.com">Esri</a>');
+    map.attributionControl.setPrefix('ddd');
+    expect(map.attributionControl.options.prefix).to.equal('ddd | Powered by <a href="https://www.esri.com">Esri</a>');
   });
 
   it('should remove the attribution when the layer is removed from the map', function () {
-    map.attributionControl.setPrefix("aaa");
-    const layer = L.esri.basemapLayer("Topographic");
+    map.attributionControl.setPrefix('aaa');
+    const layer = L.esri.basemapLayer('Topographic');
     layer.addTo(map);
     expect(map.attributionControl.options.prefix).to.equal('aaa | Powered by <a href="https://www.esri.com">Esri</a>');
     map.removeLayer(layer);

--- a/src/Util.js
+++ b/src/Util.js
@@ -173,6 +173,26 @@ export function calcAttributionWidth (map) {
   return (map.getSize().x - options.attributionWidthOffset) + 'px';
 }
 
+export function _getLeafletAttribution (map) {
+  if (!map.attributionControl.options._originalPrefix) {
+    _setLeafletAttribution(map);
+  }
+
+  return map.attributionControl.options._originalPrefix;
+}
+
+export function _setLeafletAttribution (map) {
+  if (!map.attributionControl.options.prefix) {
+    if (!Object.getPrototypeOf(map.attributionControl).options.prefix) {
+      map.attributionControl.options._originalPrefix = BASE_LEAFLET_ATTRIBUTION_STRING;
+    } else {
+      map.attributionControl.options._originalPrefix = Object.getPrototypeOf(map.attributionControl).options.prefix;
+    }
+  } else {
+    map.attributionControl.options._originalPrefix = map.attributionControl.options.prefix;
+  }
+}
+
 export function setEsriAttribution (map) {
   if (!map.attributionControl) {
     return;
@@ -217,7 +237,7 @@ export function setEsriAttribution (map) {
       map.attributionControl._esriAttributionAddedOnce = true;
     }
 
-    map.attributionControl.setPrefix(BASE_LEAFLET_ATTRIBUTION_STRING + ' | ' + POWERED_BY_ESRI_ATTRIBUTION_STRING);
+    map.attributionControl.setPrefix(_getLeafletAttribution(map) + ' | ' + POWERED_BY_ESRI_ATTRIBUTION_STRING);
     DomUtil.addClass(map.attributionControl._container, 'esri-truncated-attribution:hover');
     DomUtil.addClass(map.attributionControl._container, 'esri-truncated-attribution');
   }
@@ -233,7 +253,8 @@ export function removeEsriAttribution (map) {
 
   // Only remove the attribution if we're about to remove the LAST esri-leaflet layer (_esriAttributionLayerCount)
   if (map.attributionControl._esriAttributionLayerCount && map.attributionControl._esriAttributionLayerCount === 1) {
-    map.attributionControl.setPrefix(BASE_LEAFLET_ATTRIBUTION_STRING);
+    map.attributionControl.setPrefix(_getLeafletAttribution(map));
+    map.attributionControl.options._originalPrefix = undefined;
     DomUtil.removeClass(map.attributionControl._container, 'esri-truncated-attribution:hover');
     DomUtil.removeClass(map.attributionControl._container, 'esri-truncated-attribution');
   }
@@ -386,7 +407,9 @@ export var EsriUtil = {
   _getAttributionData: _getAttributionData,
   _updateMapAttribution: _updateMapAttribution,
   _findIdAttributeFromFeature: _findIdAttributeFromFeature,
-  _findIdAttributeFromResponse: _findIdAttributeFromResponse
+  _findIdAttributeFromResponse: _findIdAttributeFromResponse,
+  _getLeafletAttribution: _getLeafletAttribution,
+  _setLeafletAttribution: _setLeafletAttribution
 };
 
 export default EsriUtil;

--- a/src/Util.js
+++ b/src/Util.js
@@ -174,16 +174,20 @@ export function calcAttributionWidth (map) {
   return (map.getSize().x - options.attributionWidthOffset) + 'px';
 }
 
-export function _getLeafletAttribution (map) {
-  if (!map.attributionControl.options[ORIGINAL_PREFIX_CUSTOM_ATTRIBUTE]) {
+export function _getLeafletAttribution (map, suffix = '') {
+  if (typeof map.attributionControl.options[ORIGINAL_PREFIX_CUSTOM_ATTRIBUTE] === 'undefined') {
     _setLeafletAttribution(map);
   }
 
-  return map.attributionControl.options[ORIGINAL_PREFIX_CUSTOM_ATTRIBUTE];
+  var attributionText = map.attributionControl.options[ORIGINAL_PREFIX_CUSTOM_ATTRIBUTE];
+  if (attributionText.length) {
+    attributionText += suffix;
+  }
+  return attributionText;
 }
 
 export function _setLeafletAttribution (map) {
-  if (!map.attributionControl.options.prefix) {
+  if (typeof map.attributionControl.options.prefix === 'undefined') {
     if (!Object.getPrototypeOf(map.attributionControl).options.prefix) {
       map.attributionControl.options[ORIGINAL_PREFIX_CUSTOM_ATTRIBUTE] = BASE_LEAFLET_ATTRIBUTION_STRING;
     } else {
@@ -238,7 +242,7 @@ export function setEsriAttribution (map) {
       map.attributionControl._esriAttributionAddedOnce = true;
     }
 
-    map.attributionControl.setPrefix(_getLeafletAttribution(map) + ' | ' + POWERED_BY_ESRI_ATTRIBUTION_STRING);
+    map.attributionControl.setPrefix(_getLeafletAttribution(map, ' | ') + POWERED_BY_ESRI_ATTRIBUTION_STRING);
     DomUtil.addClass(map.attributionControl._container, 'esri-truncated-attribution:hover');
     DomUtil.addClass(map.attributionControl._container, 'esri-truncated-attribution');
   }

--- a/src/Util.js
+++ b/src/Util.js
@@ -10,6 +10,7 @@ import {
 
 var BASE_LEAFLET_ATTRIBUTION_STRING = '<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a>';
 var POWERED_BY_ESRI_ATTRIBUTION_STRING = 'Powered by <a href="https://www.esri.com">Esri</a>';
+var ORIGINAL_PREFIX_CUSTOM_ATTRIBUTE = '_esriLeafletOriginalPrefix';
 
 export function geojsonToArcGIS (geojson, idAttr) {
   return g2a(geojson, idAttr);
@@ -174,22 +175,22 @@ export function calcAttributionWidth (map) {
 }
 
 export function _getLeafletAttribution (map) {
-  if (!map.attributionControl.options._originalPrefix) {
+  if (!map.attributionControl.options[ORIGINAL_PREFIX_CUSTOM_ATTRIBUTE]) {
     _setLeafletAttribution(map);
   }
 
-  return map.attributionControl.options._originalPrefix;
+  return map.attributionControl.options[ORIGINAL_PREFIX_CUSTOM_ATTRIBUTE];
 }
 
 export function _setLeafletAttribution (map) {
   if (!map.attributionControl.options.prefix) {
     if (!Object.getPrototypeOf(map.attributionControl).options.prefix) {
-      map.attributionControl.options._originalPrefix = BASE_LEAFLET_ATTRIBUTION_STRING;
+      map.attributionControl.options[ORIGINAL_PREFIX_CUSTOM_ATTRIBUTE] = BASE_LEAFLET_ATTRIBUTION_STRING;
     } else {
-      map.attributionControl.options._originalPrefix = Object.getPrototypeOf(map.attributionControl).options.prefix;
+      map.attributionControl.options[ORIGINAL_PREFIX_CUSTOM_ATTRIBUTE] = Object.getPrototypeOf(map.attributionControl).options.prefix;
     }
   } else {
-    map.attributionControl.options._originalPrefix = map.attributionControl.options.prefix;
+    map.attributionControl.options[ORIGINAL_PREFIX_CUSTOM_ATTRIBUTE] = map.attributionControl.options.prefix;
   }
 }
 
@@ -254,7 +255,7 @@ export function removeEsriAttribution (map) {
   // Only remove the attribution if we're about to remove the LAST esri-leaflet layer (_esriAttributionLayerCount)
   if (map.attributionControl._esriAttributionLayerCount && map.attributionControl._esriAttributionLayerCount === 1) {
     map.attributionControl.setPrefix(_getLeafletAttribution(map));
-    map.attributionControl.options._originalPrefix = undefined;
+    map.attributionControl.options[ORIGINAL_PREFIX_CUSTOM_ATTRIBUTE] = undefined;
     DomUtil.removeClass(map.attributionControl._container, 'esri-truncated-attribution:hover');
     DomUtil.removeClass(map.attributionControl._container, 'esri-truncated-attribution');
   }


### PR DESCRIPTION
When Esri Leaflet adds _Powered by [Esri](http://www.esri.com/)_ to the attribution, it overwrites the preexisting attribution prefix. This pull request changes this process to retrieve the existing attribution prefix first, so that it can be used in lieu of the constant when overwriting and so that it can be restored in the event that all Esri layers are moved from the map display.