### PR TITLE
attribution - move "powered by esri" out of the "prefix"

### DIFF
--- a/spec/Layers/BasemapLayerSpec.js
+++ b/spec/Layers/BasemapLayerSpec.js
@@ -110,6 +110,20 @@ describe('L.esri.BasemapLayer', function () {
     expect(L.esri.basemapLayer('Topographic')).to.be.instanceof(L.esri.BasemapLayer);
   });
 
+  it('should not affect the attribution control prefix', function () {
+    map.attributionControl.setPrefix('aaa');
+    const layer = L.esri.basemapLayer('Topographic');
+    layer.addTo(map);
+    expect(map.attributionControl.options.prefix).to.equal('aaa');
+  });
+
+  it('should handle empty attribution prefix similar to tile layer', function () {
+    map.attributionControl.setPrefix('');
+    const layer = L.esri.basemapLayer('Topographic');
+    layer.addTo(map);
+    expect(map.attributionControl.options.prefix).to.equal('');
+  });
+
   // /*
   // need to figure out how to wire up the mockAttributions to
   // test display when map is panned beyond the dateline

--- a/src/Util.js
+++ b/src/Util.js
@@ -8,7 +8,6 @@ import {
   arcgisToGeoJSON as a2g
 } from '@terraformer/arcgis';
 
-var BASE_LEAFLET_ATTRIBUTION_STRING = '<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a>';
 var POWERED_BY_ESRI_ATTRIBUTION_STRING = 'Powered by <a href="https://www.esri.com">Esri</a>';
 
 export function geojsonToArcGIS (geojson, idAttr) {
@@ -217,7 +216,6 @@ export function setEsriAttribution (map) {
       map.attributionControl._esriAttributionAddedOnce = true;
     }
 
-    map.attributionControl.setPrefix(BASE_LEAFLET_ATTRIBUTION_STRING + ' | ' + POWERED_BY_ESRI_ATTRIBUTION_STRING);
     DomUtil.addClass(map.attributionControl._container, 'esri-truncated-attribution:hover');
     DomUtil.addClass(map.attributionControl._container, 'esri-truncated-attribution');
   }
@@ -233,7 +231,6 @@ export function removeEsriAttribution (map) {
 
   // Only remove the attribution if we're about to remove the LAST esri-leaflet layer (_esriAttributionLayerCount)
   if (map.attributionControl._esriAttributionLayerCount && map.attributionControl._esriAttributionLayerCount === 1) {
-    map.attributionControl.setPrefix(BASE_LEAFLET_ATTRIBUTION_STRING);
     DomUtil.removeClass(map.attributionControl._container, 'esri-truncated-attribution:hover');
     DomUtil.removeClass(map.attributionControl._container, 'esri-truncated-attribution');
   }
@@ -356,7 +353,7 @@ export function _updateMapAttribution (evt) {
       }
     }
 
-    newAttributions = newAttributions.substr(2);
+    newAttributions = POWERED_BY_ESRI_ATTRIBUTION_STRING + ' | ' + newAttributions.substr(2);
     attributionElement.innerHTML = newAttributions;
     attributionElement.style.maxWidth = calcAttributionWidth(map);
 


### PR DESCRIPTION
As an alternative to #1360, this instead moves the "Powered by Esri" text out of the "prefix" and into the "dynamic" text. This simplifies everything and resolves #1361.

@markconnellypro can you please review this alternative and see if it solves #1361 for you?