### PR TITLE
Only load featurelayer tiles after metadata has been loaded

### DIFF
--- a/src/Layers/FeatureLayer/FeatureGrid.js
+++ b/src/Layers/FeatureLayer/FeatureGrid.js
@@ -48,7 +48,6 @@ export var FeatureGrid = Layer.extend({
     this._cells = {};
     this._activeCells = {};
     this._resetView();
-    this._update();
   },
 
   onRemove: function (map) {

--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -111,6 +111,8 @@ export var FeatureManager = FeatureGrid.extend({
           map.attributionControl.addAttribution(this.getAttribution());
         }
       }
+      // Only request cells once we know whether we have geoJSON support or not:
+      this._update();
     }, this);
 
     map.on('zoomend', this._handleZoomChange, this);


### PR DESCRIPTION
This can have a significant impact on performance for larger layers, where the initial detailed tiles are requested concurrently with the metadata request and thus loaded in arcgis format -- assuming isModern hasn't been manually set -- and need to be converted to geojson (which can choke a browser).

This is only a partial fix, as _setView can also trigger  _update.

A potential fix for this is an instance variable to check whether metadata has loaded yet (tricky as metadata is requested in a subclass), or some proxy for this -- I have been using "_cells is empty or not", but there may be a better way, and I'm possibly missing cases as well.