### PR TITLE
Update husky pre-commit hook in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "lint": "semistandard | snazzy",
     "prebuild": "mkdirp dist",
     "pretest": "npm run build",
-    "precommit": "npm run lint",
     "fix": "semistandard --fix",
     "release": "./scripts/release.sh",
     "start-watch": "chokidar src -c \"npm run build\"",
@@ -103,5 +102,10 @@
       "proj4"
     ]
   },
-  "unpkg": "dist/esri-leaflet-debug.js"
+  "unpkg": "dist/esri-leaflet-debug.js",
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm run lint"
+    }
+  }
 }


### PR DESCRIPTION
#1369 

Updates how we set our pre-commit in package.json.

Moved from `scripts` to `husky.hooks`.

<img width="622" alt="image" src="https://github.com/Esri/esri-leaflet/assets/25443796/2649cee0-ec78-47a1-a8c7-442157a96808">
