### PR TITLE
Url encode apostrophes in request params

### DIFF
--- a/spec/Layers/FeatureLayer/FeatureManagerSpec.js
+++ b/spec/Layers/FeatureLayer/FeatureManagerSpec.js
@@ -652,7 +652,7 @@ describe('L.esri.FeatureManager', function () {
   it('should filter features with a where parameter', function () {
     server.respondWith(
       'GET',
-      /Type%3D'Active'/g,
+      /Type%3D%27Active%27/g,
       JSON.stringify({
         fields: fields,
         features: [feature1],
@@ -662,7 +662,7 @@ describe('L.esri.FeatureManager', function () {
 
     server.respondWith(
       'GET',
-      /Type%3D'Inactive'/g,
+      /Type%3D%27Inactive%27/g,
       JSON.stringify({
         fields: fields,
         features: [feature2],

--- a/spec/RequestSpec.js
+++ b/spec/RequestSpec.js
@@ -214,5 +214,19 @@ describe('L.esri request helpers', function () {
   it('should setup an alias for L.esri.post', function () {
     expect(L.esri.post).to.be.a('function');
   });
+
+  it('should encode params for a request with params with apostrophes', function (done) {
+    const quotedString = "'id123'";
+
+    L.esri.request('http://services.arcgisonline.com/ArcGIS/rest/info',
+      { id: quotedString }, function (error, response) {
+        expect(response).to.deep.equal(sampleResponse);
+        done();
+      });
+
+    const quotedStringEncoded = quotedString.replaceAll("'", '%27');
+    expect(requests[0].url).to.contain(quotedStringEncoded);
+    requests[0].respond(200, { 'Content-Type': 'text/plain; charset=utf-8' }, JSON.stringify(sampleResponse));
+  });
 });
 /* eslint-enable handle-callback-err */

--- a/spec/Tasks/QuerySpec.js
+++ b/spec/Tasks/QuerySpec.js
@@ -571,7 +571,7 @@ describe('L.esri.Query', function () {
   });
 
   it('should query features with a where option', function (done) {
-    server.respondWith('GET', featureLayerUrl + 'query?returnGeometry=true&where=NAME%3D\'Site\'&outSR=4326&outFields=*&f=json', JSON.stringify(sampleQueryResponse));
+    server.respondWith('GET', featureLayerUrl + 'query?returnGeometry=true&where=NAME%3D%27Site%27&outSR=4326&outFields=*&f=json', JSON.stringify(sampleQueryResponse));
 
     task.where('NAME=\'Site\'').run(function (error, featureCollection, raw) {
       expect(featureCollection).to.deep.equal(sampleFeatureCollection);

--- a/src/Request.js
+++ b/src/Request.js
@@ -32,7 +32,8 @@ function serialize (params) {
     }
   }
 
-  return data;
+  const APOSTROPHE_URL_ENCODE = '%27';
+  return data.replaceAll("'", APOSTROPHE_URL_ENCODE);
 }
 
 function createRequest (callback, context) {


### PR DESCRIPTION
Fix #1246

Replace the apostrophe sign ' with %27