### PR TITLE
Add removeEsriAttribution to EsriUtil export

### DIFF
--- a/src/Util.js
+++ b/src/Util.js
@@ -379,6 +379,7 @@ export var EsriUtil = {
   extentToBounds: extentToBounds,
   calcAttributionWidth: calcAttributionWidth,
   setEsriAttribution: setEsriAttribution,
+  removeEsriAttribution: removeEsriAttribution,
   _setGeometry: _setGeometry,
   _getAttributionData: _getAttributionData,
   _updateMapAttribution: _updateMapAttribution,


### PR DESCRIPTION
This function is needed by esri-leaflet-vector. 

See details there: [esri-leaflet-vector PR#208](https://github.com/Esri/esri-leaflet-vector/pull/208)