### PR TITLE
Fix use of timeout property for synchronous XMLHttpRequests

### DIFF
--- a/src/Request.js
+++ b/src/Request.js
@@ -123,9 +123,9 @@ export function request (url, params, callback, context) {
 
   // ie10/11 require the request be opened before a timeout is applied
   if (requestLength <= 2000 && Support.cors) {
-    httpRequest.open('GET', url + '?' + paramString);
+    httpRequest.open('GET', url + '?' + paramString, true);
   } else if (requestLength > 2000 && Support.cors) {
-    httpRequest.open('POST', url);
+    httpRequest.open('POST', url, true);
     httpRequest.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
   }
 


### PR DESCRIPTION
Convert XMLHttpRequests to be asynchronous to allow for the use of the timeout property. The timeout property can't be used for synchronous requests in a document environment (window/iframe) or an `InvalidAccessError` is thrown. (Please see the [documentation](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/timeout))

This issue only appeared after updating my Salesforce org to the Summer '24 Release. I am deploying the Esri Leaflet map in Salesforce with LWC.

All `npm test` tests pass with the new changes.

**Browser:** Chrome
**Browser version:** 124.0.6367.207
**Esri Leaflet version:** 3.0.12
**Leaflet version:** 1.9.4
**Bundling tool:** Salesforce