### PR TITLE
Remove usage of toLatLngBounds

### DIFF
--- a/src/Layers/FeatureLayer/FeatureGrid.js
+++ b/src/Layers/FeatureLayer/FeatureGrid.js
@@ -1,6 +1,6 @@
 import {
   LatLngBounds,
-  toLatLngBounds as latLngBounds,
+  latLngBounds,
   Layer,
   Browser,
   Util,


### PR DESCRIPTION
Resolves #1386 (also possibly related to #1200 ?)

After this change, ESM CDNs can be used. I published this change to https://www.npmjs.com/package/el-esm-test to be able to test it using https://esm.sh/el-esm-test@3.0.14 ... see here for an example of using that:
https://jsbin.com/xoxopus/1/edit?html,output

Note that using **esm.run** (JSDelivr's ESM CDN): https://esm.run/el-esm-test@3.0.14
... does **not** work. We think this is a bug with esm.run and will possibly follow up with a bug report to that project. For now our recommendation will be to **use esm.sh if you want to use an ESM CDN with esri-leaflet**. 