### PR TITLE
Fixed: Request GeoJSON by default for feature services 1376

### DIFF
--- a/src/Layers/FeatureLayer/FeatureManager.js
+++ b/src/Layers/FeatureLayer/FeatureManager.js
@@ -80,26 +80,29 @@ export var FeatureManager = FeatureGrid.extend({
         var supportedFormats = metadata.supportedQueryFormats;
 
         // Check if someone has requested that we don't use geoJSON, even if it's available
+       // Check if someone has requested that we don't use geoJSON, even if it's available
         var forceJsonFormat = false;
         if (
-          this.service.options.isModern === false ||
+          this.service.options.isModern === false || // Explicitly disabled
           this.options.fetchAllFeatures
         ) {
           forceJsonFormat = true;
+        } else if (this.service.options.isModern === undefined) {
+          this.service.options.isModern = true; // Default to modern
         }
 
-        // Unless we've been told otherwise, check to see whether service can emit GeoJSON natively
+
+       // Unless we've been told otherwise, check to see whether service can emit GeoJSON natively
         if (
           !forceJsonFormat &&
           supportedFormats &&
           supportedFormats.indexOf('geoJSON') !== -1
         ) {
-          this.service.options.isModern = true;
+          this.service.options.isModern = true; // Confirm GeoJSON support
+        } else if (this.service.options.isModern === undefined) {
+          this.service.options.isModern = true; // Default assumption
         }
 
-        if (metadata.objectIdField) {
-          this.service.options.idAttribute = metadata.objectIdField;
-        }
 
         // add copyright text listed in service metadata
         if (

--- a/src/Tasks/Query.js
+++ b/src/Tasks/Query.js
@@ -126,14 +126,18 @@ export var Query = Task.extend({
     this._cleanParams();
 
     // services hosted on ArcGIS Online and ArcGIS Server 10.3.1+ support requesting geojson directly
-    if (this.options.isModern || (isArcgisOnline(this.options.url) && this.options.isModern === undefined)) {
+    if (this.options.isModern === undefined) {
+      this.options.isModern = true; // Default to modern
+    }
+
+    if (this.options.isModern || isArcgisOnline(this.options.url)) {
       this.params.f = 'geojson';
 
       return this.request(function (error, response) {
         this._trapSQLerrors(error);
         callback.call(context, error, response, response);
       }, this);
-
+    
       // otherwise convert it in the callback then pass it on
     } else {
       return this.request(function (error, response) {


### PR DESCRIPTION
The following changes were made:

Updated the logic to default isModern to true for feature services.

Modified instances where isModern is used to ensure GeoJSON is requested by default.
