### PR TITLE
load the tile in cases where this.options.crs exists

### DIFF
--- a/src/Layers/TiledMapLayer.js
+++ b/src/Layers/TiledMapLayer.js
@@ -113,9 +113,12 @@ export const TiledMapLayer = TileLayer.extend({
     */
     tile.alt = "";
 
-    // if there is no lod map or an lod map with a proper zoom load the tile
+    // if this is a map with a custom CRS or an lod map with a proper zoom load the tile
     // otherwise wait for the lod map to become available
-    if (this._lodMap && this._lodMap[this._getZoomForUrl()] !== undefined) {
+    if (
+      this._lodMap === "crs" ||
+      (this._lodMap && this._lodMap[this._getZoomForUrl()] !== undefined)
+    ) {
       tile.src = this.getTileUrl(coords);
     } else {
       this.once(
@@ -185,6 +188,8 @@ export const TiledMapLayer = TileLayer.extend({
             map.options.crs.code.indexOf(sr) > -1
           ) {
             // if the projection is WGS84, or the developer is using Proj4 to define a custom CRS, no action is required
+            this._lodMap = "crs";
+            this.fire("lodmap");
           } else {
             // if the service was cached in a custom projection and an appropriate LOD hasn't been defined in the map, guide the developer to our Proj4 sample
             warn(


### PR DESCRIPTION
Attempt to fix #1384 .

In #1400 we changed this line so that it would work for cases for custom LODs. But that broke this for cases of Non-mercator projections. So this PR attempts to solve both cases by creating a separate case for non-mercator projections (`this._lodMap = "crs"`) ... but it does feel a bit hacky so I'm wondering if maybe we need to just go back to #1400 and see if that was an incorrect fix. I probably need to discuss this with @patrickarlt.